### PR TITLE
fix build errors in controller and apis generation

### DIFF
--- a/cmd/ack-generate/command/apis.go
+++ b/cmd/ack-generate/command/apis.go
@@ -89,7 +89,7 @@ func generateAPIs(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	typeDefs, err := sh.GetTypeDefs()
+	typeDefs, typeImports, err := sh.GetTypeDefs()
 	if err != nil {
 		return err
 	}
@@ -110,7 +110,7 @@ func generateAPIs(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err = writeTypesGo(typeDefs); err != nil {
+	if err = writeTypesGo(typeImports, typeDefs); err != nil {
 		return err
 	}
 
@@ -196,11 +196,13 @@ func writeEnumsGo(
 }
 
 func writeTypesGo(
+	typeImports map[string]string,
 	typeDefs []*model.TypeDef,
 ) error {
 	vars := &template.TypesTemplateVars{
 		APIVersion: optGenVersion,
 		TypeDefs:   typeDefs,
+		Imports:    typeImports,
 	}
 	var b bytes.Buffer
 	tpl, err := template.NewTypesTemplate(optTemplatesDir)

--- a/cmd/ack-generate/command/controller.go
+++ b/cmd/ack-generate/command/controller.go
@@ -101,7 +101,7 @@ func writeControllerMainGo(sh *model.Helper) error {
 	var b bytes.Buffer
 	vars := &cmdtemplate.ControllerMainTemplateVars{
 		APIVersion:   latestAPIVersion,
-		ServiceAlias: sh.GetServiceAlias(),
+		ServiceAlias: strings.ToLower(sh.GetServiceAlias()),
 	}
 	tpl, err := cmdtemplate.NewControllerMainTemplate(optTemplatesDir)
 	if err != nil {

--- a/pkg/template/apis/types.go
+++ b/pkg/template/apis/types.go
@@ -25,7 +25,7 @@ import (
 type TypesTemplateVars struct {
 	APIVersion string
 	TypeDefs   []*model.TypeDef
-	EnumDefs   []*model.EnumDef
+	Imports    map[string]string
 }
 
 func NewTypesTemplate(tplDir string) (*ttpl.Template, error) {

--- a/templates/apis/crd.go.tpl
+++ b/templates/apis/crd.go.tpl
@@ -11,7 +11,7 @@ import (
 // {{ .CRD.Kind }}Spec defines the desired state of {{ .CRD.Kind }}
 type {{ .CRD.Kind }}Spec struct {
 	{{- range $fieldName, $field := .CRD.SpecFields }}
-	{{ $field.Names.Camel }} {{ $field.GoType }} `json:"{{ $field.Names.CamelLower }},omitempty"
+	{{ $field.Names.Camel }} {{ $field.GoType }} `json:"{{ $field.Names.CamelLower }},omitempty"`
 {{- end }}
 }
 
@@ -27,7 +27,7 @@ type {{ .CRD.Kind }}Status struct {
 	// resource
 	Conditions []*ackv1alpha1.Condition `json:"conditions"`
 	{{- range $fieldName, $field := .CRD.StatusFields }}
-	{{ $field.Names.Camel }} {{ $field.GoType }} `json:"{{ $field.Names.CamelLower }},omitempty"
+	{{ $field.Names.Camel }} {{ $field.GoType }} `json:"{{ $field.Names.CamelLower }},omitempty"`
 {{- end }}
 }
 

--- a/templates/apis/crd.go.tpl
+++ b/templates/apis/crd.go.tpl
@@ -4,6 +4,12 @@
 package {{ .APIVersion }}
 
 import (
+{{- range $packagePath, $alias := .CRD.TypeImports }}
+    {{ if $alias -}}{{ $alias }} {{ end -}}"{{ $packagePath }}"
+{{ end -}}
+{{- if .CRD.TypeImports }}
+
+{{- end -}}
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/templates/apis/enums.go.tpl
+++ b/templates/apis/enums.go.tpl
@@ -1,10 +1,6 @@
 {{ template "boilerplate" }}
 
 package {{ .APIVersion }}
-
-import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
 {{- range $enumDef := .EnumDefs }}
 
 {{ template "enum_def" $enumDef }}

--- a/templates/apis/type_def.go.tpl
+++ b/templates/apis/type_def.go.tpl
@@ -1,7 +1,7 @@
 {{- define "type_def" -}}
 type {{ .Names.Camel }} struct {
 {{- range $attrName, $attr := .Attrs }}
-	{{ $attr.Names.Camel }} {{ $attr.GoType }} `json:"{{ $attr.Names.CamelLower }},omitempty" aws:"{{ $attr.Names.Original }}"`
+	{{ $attr.Names.Camel }} {{ $attr.GoType }} `json:"{{ $attr.Names.CamelLower }},omitempty"`
 {{- end }}
 }
 {{- end -}}

--- a/templates/apis/types.go.tpl
+++ b/templates/apis/types.go.tpl
@@ -1,10 +1,15 @@
 {{ template "boilerplate" }}
 
 package {{ .APIVersion }}
-
+{{- if .Imports }}
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+{{- end -}}
+{{- range $packagePath, $alias := .Imports }}
+    {{ if $alias -}}{{ $alias }} {{ end -}}"{{ $packagePath }}"
+{{ end -}}
+{{- if .Imports }}
 )
+{{- end -}}
 {{- range $typeDef := .TypeDefs }}
 
 {{ template "type_def" $typeDef }}

--- a/templates/pkg/crd_resource.go.tpl
+++ b/templates/pkg/crd_resource.go.tpl
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8srt "k8s.io/apimachinery/pkg/runtime"
 
-	svcapitypes "github.com/aws/aws-controllers-k8s/service/{{ .ServiceAlias }}/apis/{{ .APIVersion}}
+	svcapitypes "github.com/aws/aws-controllers-k8s/services/{{ .ServiceAlias }}/apis/{{ .APIVersion}}"
 )
 
 // resource implements the `aws-service-operator-k8s/pkg/types.AWSResource`


### PR DESCRIPTION
This PR fixes two issues found while generating the ECR service controller
and building the service controller.

The first issue was that the template variables used to generate the
`cmd/controller/main.go` file were not lowercasing the service alias, so an
improper import path of:

```
    svcapitypes "github.com/aws/aws-controllers-k8s/services/ECR/apis/v1alpha1"
```

was being generated. There was also a typo of "service" instead of "services" in another
template's import paths.

The second issue I found was due to certain type definitions or fields in CRD `Status`
or `Spec` structs used types that were not builtins. For example, the `CreateTime`
field in the `Repository.Status` CRD struct is of type `*time.Time`. We were not importing
the `time` package in the `types.go` file or the CRD individual .go files and therefore
builds were failing.

I added a system for tracking imported packages for the collection of TypeDef
objects (which are those structs that are part of a CRD's definition) as well as
each CRD itself and changed the templates for `types.go` and the individual
CRD .go files to write out those imports appropriately.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
