### PR TITLE
Append _SDK to type_def when type name collides with CRD name.

### DIFF
--- a/pkg/model/type_def.go
+++ b/pkg/model/type_def.go
@@ -69,7 +69,7 @@ func (h *Helper) GetTypeDefs() ([]*TypeDef, map[string]string, error) {
 		tdefNames := names.New(shapeName)
 		// Handle name conflicts with top-level CRD.Spec or CRD.Status
 		// types
-		if inStrings(tdefNames.Camel, crdSpecNames) || inStrings(tdefNames.Camel, crdStatusNames) {
+		if inStrings(tdefNames.Camel, crdNames) || inStrings(tdefNames.Camel, crdSpecNames) || inStrings(tdefNames.Camel, crdStatusNames) {
 			tdefNames.Camel = tdefNames.Camel + "_SDK"
 		}
 


### PR DESCRIPTION
Issue #94 , if available:

Description of changes:
Append _SDK to type_def when type name collides with CRD name.

```
vijat@186590cff3cf aws-controllers-k8s % ./scripts/build-controller.sh apigatewayv2
Building Kubernetes API objects for apigatewayv2
Generating deepcopy code for apigatewayv2
Building service controller for apigatewayv2
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
