### PR TITLE
include TypeDef names same as CRDs

### DIFF
--- a/pkg/model/type_def.go
+++ b/pkg/model/type_def.go
@@ -51,10 +51,6 @@ func (h *Helper) GetTypeDefs() ([]*TypeDef, map[string]string, error) {
 	}
 
 	for shapeName, shape := range h.sdkAPI.Shapes {
-		if inStrings(shapeName, crdNames) {
-			// CRDs are already top-level structs
-			continue
-		}
 		if inStrings(shapeName, payloads) {
 			// Payloads are not type defs
 			continue
@@ -67,7 +63,7 @@ func (h *Helper) GetTypeDefs() ([]*TypeDef, map[string]string, error) {
 			continue
 		}
 		tdefNames := names.New(shapeName)
-		// Handle name conflicts with top-level CRD.Spec or CRD.Status
+		// Handle name conflicts with top-level CRD, CRD.Spec or CRD.Status
 		// types
 		if inStrings(tdefNames.Camel, crdNames) || inStrings(tdefNames.Camel, crdSpecNames) || inStrings(tdefNames.Camel, crdStatusNames) {
 			tdefNames.Camel = tdefNames.Camel + "_SDK"


### PR DESCRIPTION
We were excluding type definition generation for Shapes that had the
same name as a CRD, however this was incorrect. Instead, we need to
rename the type definition to ensure it doesn't conflict with the CRD
struct name. We still need to use these type definitions when
constructing SDK linkage.

Specifically, when generating the service controller for APIGatewayV2, a
number of type definitions that represent the returned object
representation from ReadMany operations (List) were not being written to
the types.go file. Examples of this include Deployment, Stage, Route,
Model, etc.

These type definitions are now included:

```
jaypipes@thelio:~/go/src/github.com/aws/aws-controllers-k8s$ tree services/apigatewayv2/apis/v1alpha1/
services/apigatewayv2/apis/v1alpha1/
├── api.go
├── api_mapping.go
├── authorizer.go
├── deployment.go
├── doc.go
├── domain_name.go
├── enums.go
├── groupversion_info.go
├── integration.go
├── integration_response.go
├── model.go
├── route.go
├── route_response.go
├── stage.go
├── types.go
├── vpc_link.go
└── zz_generated.deepcopy.go

0 directories, 17 files
jaypipes@thelio:~/go/src/github.com/aws/aws-controllers-k8s$ ack '_SDK' services/apigatewayv2/apis/v1alpha1/types.go
type APIMapping_SDK struct {
type API_SDK struct {
type Authorizer_SDK struct {
type Deployment_SDK struct {
type DomainName_SDK struct {
type IntegrationResponse_SDK struct {
type Integration_SDK struct {
type Model_SDK struct {
type RouteResponse_SDK struct {
type Route_SDK struct {
type Stage_SDK struct {
type VPCLink_SDK struct {
```

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
