### PR TITLE
Support name cleaning for some special cases

### DIFF
--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -42,8 +42,9 @@ var (
 		// camel-cased "Ids" refers to a set of Identifiers, so the correct
 		// uppercase representation is "IDs"
 		{"Ids", "IDs", "ids", nil},
-		// Need to prevent "Identifier" from becoming "IDentifier"
-		{"Id", "ID", "id", regexp.MustCompile("Id(?!entifier)", regexp.None)},
+		// Need to prevent "Identifier" from becoming "IDentifier",
+		// and "Idle" from becoming "IDle"
+		{"Id", "ID", "id", regexp.MustCompile("Id(?!entifier|le)", regexp.None)},
 		// Need to prevent "DbInstance" from becoming "dbinstance" when lower
 		// prefix-converted (should be dbInstance). Amazingly, even within just
 		// the RDS API, there are fields named "DbiResourceId",
@@ -101,7 +102,8 @@ var (
 		{"Tde", "TDE", "tde", nil},
 		{"Tls", "TLS", "tls", nil},
 		{"Udp", "UDP", "udp", nil},
-		{"Uri", "URI", "uri", nil},
+		// Need to prevent "security" from becoming "SecURIty"
+		{"Uri", "URI", "uri", regexp.MustCompile("(?!sec)uri(?!ty)", regexp.None)},
 		{"Url", "URL", "url", nil},
 		{"Vpc", "VPC", "vpc", nil},
 		{"Vpn", "VPN", "vpn", nil},
@@ -139,6 +141,9 @@ func goName(original string, lowerFirst bool, snake bool) (result string) {
 	}
 	if lowerFirst {
 		result, err = normalizeInitialisms(strcase.ToLowerCamel(result), lowerFirst, snake)
+		if err != nil {
+			panic(err)
+		}
 	}
 	if snake {
 		result = strcase.ToSnake(result)

--- a/pkg/names/names_test.go
+++ b/pkg/names/names_test.go
@@ -43,6 +43,8 @@ func TestNames(t *testing.T) {
 		{"DBInstanceId", "DBInstanceID", "dbInstanceID", "db_instance_id"},
 		{"DBInstanceID", "DBInstanceID", "dbInstanceID", "db_instance_id"},
 		{"DBInstanceIdentifier", "DBInstanceIdentifier", "dbInstanceIdentifier", "db_instance_identifier"},
+		{"MaxIdleConnectionsPercent", "MaxIdleConnectionsPercent", "maxIdleConnectionsPercent", "max_idle_connections_percent"},
+		{"CacheSecurityGroup", "CacheSecurityGroup", "cacheSecurityGroup", "cache_security_group"},
 	}
 	for _, tc := range testCases {
 		n := names.New(tc.original)


### PR DESCRIPTION
Update the initialism table, to correctly clean names containing the following special words: `Security` and `Idle`

Fixes #90 and #97

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.