### PR TITLE
correct sdk.go code generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.9.1
-	github.com/spf13/cobra v0.0.7
+	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b // indirect
@@ -21,5 +21,5 @@ require (
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v0.18.2
 	sigs.k8s.io/controller-runtime v0.6.0
-	sigs.k8s.io/controller-tools v0.3.0 // indirect
+	sigs.k8s.io/controller-tools v0.3.1-0.20200716001835-4a903ddb7005 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -295,6 +295,8 @@ github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v0.0.7 h1:FfTH+vuMXOas8jmfb5/M7dzEYx7LpcLb7a0LPe34uOU=
 github.com/spf13/cobra v0.0.7/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
+github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
+github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -323,6 +325,7 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
@@ -344,6 +347,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190320223903-b7391e95e576/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190617133340-57b3e21c3d56/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 h1:/Tl7pH94bvbAAHBdZJT947M/+gp0+CqQXDtMRC0fseo=
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -351,6 +355,8 @@ golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/mod v0.2.0 h1:KU7oHjnv3XNWfa5COkzUifxZmxp1TyI7ImMXqFxLwvQ=
+golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -423,7 +429,11 @@ golang.org/x/tools v0.0.0-20190614205625-5aca471b1d59/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190617190820-da514acc4774/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72 h1:bw9doJza/SFBEweII/rHQh338oozWyiFsBRHtrflcws=
 golang.org/x/tools v0.0.0-20190920225731-5eefd052ad72/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20200616195046-dc31b401abb5 h1:UaoXseXAWUJUcuJ2E2oczJdLxAJXL0lOmVaBl7kuk+I=
+golang.org/x/tools v0.0.0-20200616195046-dc31b401abb5/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1 h1:xyiBuvkD2g5n7cYzx6u2sxQvsAy4QJsZFCzGVdzOXZ0=
@@ -499,6 +509,8 @@ sigs.k8s.io/controller-runtime v0.6.0 h1:Fzna3DY7c4BIP6KwfSlrfnj20DJ+SeMBK8HSFvO
 sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2cftPHndTroo=
 sigs.k8s.io/controller-tools v0.3.0 h1:y3YD99XOyWaXkiF1kd41uRvfp/64teWcrEZFuHxPhJ4=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
+sigs.k8s.io/controller-tools v0.3.1-0.20200716001835-4a903ddb7005 h1:AJmBTL2CXoOuQxdyfV/I3z52CE8TKPGmqLGn7eEIOr8=
+sigs.k8s.io/controller-tools v0.3.1-0.20200716001835-4a903ddb7005/go.mod h1:G9rHdZMVlBDocIxGkK3jHLWqcTMNvveypYJwrvYKjWU=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0 h1:dOmIZBMfhcHS09XZkMyUgkq5trg3/jRyJYFZUiaOp8E=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=

--- a/pkg/model/crd_test.go
+++ b/pkg/model/crd_test.go
@@ -81,16 +81,16 @@ func TestSNSTopic(t *testing.T) {
 	expCreateInput := `
 	res.SetAttributes(r.ko.Spec.Attributes)
 	res.SetName(*r.ko.Spec.Name)
-	tmp0 := []*svcsdk.Tag{}
-	for _, elem0 := range res.Tags {
-		tmpElem0 := &svcsdk.Tag{}
-		tmpElem0.SetKey(*elem0.Key)
-		tmpElem0.SetValue(*elem0.Value)
-		tmp0 = append(tmp0, tmpElem0)
+	f2 := []*svcsdk.Tag{}
+	for _, f2iter := range r.ko.Spec.Tags {
+		f2elem := &svcsdk.Tag{}
+		f2elem.SetKey(*f2iter.Key)
+		f2elem.SetValue(*f2iter.Value)
+		f2 = append(f2, f2elem)
 	}
-	res.Tags = tmp0
+	res.SetTags(f2)
 `
-	assert.Equal(expCreateInput, crd.GoCodeSetInput(model.OpTypeCreate, "res", "r.ko.Spec", 1))
+	assert.Equal(expCreateInput, crd.GoCodeSetInput(model.OpTypeCreate, "r.ko.Spec", "res", 1))
 
 	// None of the fields in the Topic resource's CreateTopicInput shape are
 	// returned in the CreateTopicOutput shape, so none of them return any Go
@@ -175,188 +175,188 @@ func TestEC2LaunchTemplate(t *testing.T) {
 	expCreateInput := `
 	res.SetClientToken(*r.ko.Spec.ClientToken)
 	res.SetDryRun(*r.ko.Spec.DryRun)
-	tmp0 := &svcsdk.RequestLaunchTemplateData{}
-	tmp0f1 := []*svcsdk.LaunchTemplateBlockDeviceMappingRequest{}
-	for _, elem1 := range r.ko.Spec.LaunchTemplateData.BlockDeviceMappings {
-		tmpElem1 := &svcsdk.LaunchTemplateBlockDeviceMappingRequest{}
-		tmpElem1.SetDeviceName(*elem1.DeviceName)
-		tmpElem1f0 := &svcsdk.LaunchTemplateEbsBlockDeviceRequest{}
-		tmpElem1f0.SetDeleteOnTermination(*elem1.DeleteOnTermination)
-		tmpElem1f0.SetEncrypted(*elem1.Encrypted)
-		tmpElem1f0.SetIops(*elem1.IOPS)
-		tmpElem1f0.SetKmsKeyId(*elem1.KMSKeyID)
-		tmpElem1f0.SetSnapshotId(*elem1.SnapshotID)
-		tmpElem1f0.SetVolumeSize(*elem1.VolumeSize)
-		tmpElem1f0.SetVolumeType(*elem1.VolumeType)
-		tmpElem1.Ebs = tmpElem1f0
-		tmpElem1.SetNoDevice(*elem1.NoDevice)
-		tmpElem1.SetVirtualName(*elem1.VirtualName)
-		tmp0f1 = append(tmp0f1, tmpElem1)
+	f2 := &svcsdk.RequestLaunchTemplateData{}
+	f2f0 := []*svcsdk.LaunchTemplateBlockDeviceMappingRequest{}
+	for _, f2f0iter := range r.ko.Spec.LaunchTemplateData.BlockDeviceMappings {
+		f2f0elem := &svcsdk.LaunchTemplateBlockDeviceMappingRequest{}
+		f2f0elem.SetDeviceName(*f2f0iter.DeviceName)
+		f2f0elemf1 := &svcsdk.LaunchTemplateEbsBlockDeviceRequest{}
+		f2f0elemf1.SetDeleteOnTermination(*f2f0iter.EBS.DeleteOnTermination)
+		f2f0elemf1.SetEncrypted(*f2f0iter.EBS.Encrypted)
+		f2f0elemf1.SetIops(*f2f0iter.EBS.IOPS)
+		f2f0elemf1.SetKmsKeyId(*f2f0iter.EBS.KMSKeyID)
+		f2f0elemf1.SetSnapshotId(*f2f0iter.EBS.SnapshotID)
+		f2f0elemf1.SetVolumeSize(*f2f0iter.EBS.VolumeSize)
+		f2f0elemf1.SetVolumeType(*f2f0iter.EBS.VolumeType)
+		f2f0elem.SetEbs(f2f0elemf1)
+		f2f0elem.SetNoDevice(*f2f0iter.NoDevice)
+		f2f0elem.SetVirtualName(*f2f0iter.VirtualName)
+		f2f0 = append(f2f0, f2f0elem)
 	}
-	tmp0.BlockDeviceMappings = tmp0f1
-	tmp0f0 := &svcsdk.LaunchTemplateCapacityReservationSpecificationRequest{}
-	tmp0f0.SetCapacityReservationPreference(*r.ko.Spec.LaunchTemplateData.CapacityReservationPreference)
-	tmp0f0f0 := &svcsdk.CapacityReservationTarget{}
-	tmp0f0f0.SetCapacityReservationId(*r.ko.Spec.LaunchTemplateData.CapacityReservationID)
-	tmp0f0.CapacityReservationTarget = tmp0f0f0
-	tmp0.CapacityReservationSpecification = tmp0f0
-	tmp0f0 := &svcsdk.LaunchTemplateCpuOptionsRequest{}
-	tmp0f0.SetCoreCount(*r.ko.Spec.LaunchTemplateData.CoreCount)
-	tmp0f0.SetThreadsPerCore(*r.ko.Spec.LaunchTemplateData.ThreadsPerCore)
-	tmp0.CpuOptions = tmp0f0
-	tmp0f0 := &svcsdk.CreditSpecificationRequest{}
-	tmp0f0.SetCpuCredits(*r.ko.Spec.LaunchTemplateData.CPUCredits)
-	tmp0.CreditSpecification = tmp0f0
-	tmp0.SetDisableApiTermination(*r.ko.Spec.LaunchTemplateData.DisableAPITermination)
-	tmp0.SetEbsOptimized(*r.ko.Spec.LaunchTemplateData.EBSOptimized)
-	tmp0f2 := []*svcsdk.ElasticGpuSpecification{}
-	for _, elem2 := range r.ko.Spec.LaunchTemplateData.ElasticGPUSpecifications {
-		tmpElem2 := &svcsdk.ElasticGpuSpecification{}
-		tmpElem2.SetType(*elem2.Type)
-		tmp0f2 = append(tmp0f2, tmpElem2)
+	f2.SetBlockDeviceMappings(f2f0)
+	f2f1 := &svcsdk.LaunchTemplateCapacityReservationSpecificationRequest{}
+	f2f1.SetCapacityReservationPreference(*r.ko.Spec.LaunchTemplateData.CapacityReservationSpecification.CapacityReservationPreference)
+	f2f1f1 := &svcsdk.CapacityReservationTarget{}
+	f2f1f1.SetCapacityReservationId(*r.ko.Spec.LaunchTemplateData.CapacityReservationSpecification.CapacityReservationTarget.CapacityReservationID)
+	f2f1.SetCapacityReservationTarget(f2f1f1)
+	f2.SetCapacityReservationSpecification(f2f1)
+	f2f2 := &svcsdk.LaunchTemplateCpuOptionsRequest{}
+	f2f2.SetCoreCount(*r.ko.Spec.LaunchTemplateData.CPUOptions.CoreCount)
+	f2f2.SetThreadsPerCore(*r.ko.Spec.LaunchTemplateData.CPUOptions.ThreadsPerCore)
+	f2.SetCpuOptions(f2f2)
+	f2f3 := &svcsdk.CreditSpecificationRequest{}
+	f2f3.SetCpuCredits(*r.ko.Spec.LaunchTemplateData.CreditSpecification.CPUCredits)
+	f2.SetCreditSpecification(f2f3)
+	f2.SetDisableApiTermination(*r.ko.Spec.LaunchTemplateData.DisableAPITermination)
+	f2.SetEbsOptimized(*r.ko.Spec.LaunchTemplateData.EBSOptimized)
+	f2f6 := []*svcsdk.ElasticGpuSpecification{}
+	for _, f2f6iter := range r.ko.Spec.LaunchTemplateData.ElasticGPUSpecifications {
+		f2f6elem := &svcsdk.ElasticGpuSpecification{}
+		f2f6elem.SetType(*f2f6iter.Type)
+		f2f6 = append(f2f6, f2f6elem)
 	}
-	tmp0.ElasticGpuSpecifications = tmp0f2
-	tmp0f3 := []*svcsdk.LaunchTemplateElasticInferenceAccelerator{}
-	for _, elem3 := range r.ko.Spec.LaunchTemplateData.ElasticInferenceAccelerators {
-		tmpElem3 := &svcsdk.LaunchTemplateElasticInferenceAccelerator{}
-		tmpElem3.SetCount(*elem3.Count)
-		tmpElem3.SetType(*elem3.Type)
-		tmp0f3 = append(tmp0f3, tmpElem3)
+	f2.SetElasticGpuSpecifications(f2f6)
+	f2f7 := []*svcsdk.LaunchTemplateElasticInferenceAccelerator{}
+	for _, f2f7iter := range r.ko.Spec.LaunchTemplateData.ElasticInferenceAccelerators {
+		f2f7elem := &svcsdk.LaunchTemplateElasticInferenceAccelerator{}
+		f2f7elem.SetCount(*f2f7iter.Count)
+		f2f7elem.SetType(*f2f7iter.Type)
+		f2f7 = append(f2f7, f2f7elem)
 	}
-	tmp0.ElasticInferenceAccelerators = tmp0f3
-	tmp0f0 := &svcsdk.LaunchTemplateHibernationOptionsRequest{}
-	tmp0f0.SetConfigured(*r.ko.Spec.LaunchTemplateData.Configured)
-	tmp0.HibernationOptions = tmp0f0
-	tmp0f0 := &svcsdk.LaunchTemplateIamInstanceProfileSpecificationRequest{}
-	tmp0f0.SetArn(*r.ko.Spec.LaunchTemplateData.ARN)
-	tmp0f0.SetName(*r.ko.Spec.LaunchTemplateData.Name)
-	tmp0.IamInstanceProfile = tmp0f0
-	tmp0.SetImageId(*r.ko.Spec.LaunchTemplateData.ImageID)
-	tmp0.SetInstanceInitiatedShutdownBehavior(*r.ko.Spec.LaunchTemplateData.InstanceInitiatedShutdownBehavior)
-	tmp0f0 := &svcsdk.LaunchTemplateInstanceMarketOptionsRequest{}
-	tmp0f0.SetMarketType(*r.ko.Spec.LaunchTemplateData.MarketType)
-	tmp0f0f0 := &svcsdk.LaunchTemplateSpotMarketOptionsRequest{}
-	tmp0f0f0.SetBlockDurationMinutes(*r.ko.Spec.LaunchTemplateData.BlockDurationMinutes)
-	tmp0f0f0.SetInstanceInterruptionBehavior(*r.ko.Spec.LaunchTemplateData.InstanceInterruptionBehavior)
-	tmp0f0f0.SetMaxPrice(*r.ko.Spec.LaunchTemplateData.MaxPrice)
-	tmp0f0f0.SetSpotInstanceType(*r.ko.Spec.LaunchTemplateData.SpotInstanceType)
-	tmp0f0f0.SetValidUntil(*r.ko.Spec.LaunchTemplateData.ValidUntil.Time)
-	tmp0f0.SpotOptions = tmp0f0f0
-	tmp0.InstanceMarketOptions = tmp0f0
-	tmp0.SetInstanceType(*r.ko.Spec.LaunchTemplateData.InstanceType)
-	tmp0.SetKernelId(*r.ko.Spec.LaunchTemplateData.KernelID)
-	tmp0.SetKeyName(*r.ko.Spec.LaunchTemplateData.KeyName)
-	tmp0f4 := []*svcsdk.LaunchTemplateLicenseConfigurationRequest{}
-	for _, elem4 := range r.ko.Spec.LaunchTemplateData.LicenseSpecifications {
-		tmpElem4 := &svcsdk.LaunchTemplateLicenseConfigurationRequest{}
-		tmpElem4.SetLicenseConfigurationArn(*elem4.LicenseConfigurationARN)
-		tmp0f4 = append(tmp0f4, tmpElem4)
+	f2.SetElasticInferenceAccelerators(f2f7)
+	f2f8 := &svcsdk.LaunchTemplateHibernationOptionsRequest{}
+	f2f8.SetConfigured(*r.ko.Spec.LaunchTemplateData.HibernationOptions.Configured)
+	f2.SetHibernationOptions(f2f8)
+	f2f9 := &svcsdk.LaunchTemplateIamInstanceProfileSpecificationRequest{}
+	f2f9.SetArn(*r.ko.Spec.LaunchTemplateData.IAMInstanceProfile.ARN)
+	f2f9.SetName(*r.ko.Spec.LaunchTemplateData.IAMInstanceProfile.Name)
+	f2.SetIamInstanceProfile(f2f9)
+	f2.SetImageId(*r.ko.Spec.LaunchTemplateData.ImageID)
+	f2.SetInstanceInitiatedShutdownBehavior(*r.ko.Spec.LaunchTemplateData.InstanceInitiatedShutdownBehavior)
+	f2f12 := &svcsdk.LaunchTemplateInstanceMarketOptionsRequest{}
+	f2f12.SetMarketType(*r.ko.Spec.LaunchTemplateData.InstanceMarketOptions.MarketType)
+	f2f12f1 := &svcsdk.LaunchTemplateSpotMarketOptionsRequest{}
+	f2f12f1.SetBlockDurationMinutes(*r.ko.Spec.LaunchTemplateData.InstanceMarketOptions.SpotOptions.BlockDurationMinutes)
+	f2f12f1.SetInstanceInterruptionBehavior(*r.ko.Spec.LaunchTemplateData.InstanceMarketOptions.SpotOptions.InstanceInterruptionBehavior)
+	f2f12f1.SetMaxPrice(*r.ko.Spec.LaunchTemplateData.InstanceMarketOptions.SpotOptions.MaxPrice)
+	f2f12f1.SetSpotInstanceType(*r.ko.Spec.LaunchTemplateData.InstanceMarketOptions.SpotOptions.SpotInstanceType)
+	f2f12f1.SetValidUntil(*r.ko.Spec.LaunchTemplateData.InstanceMarketOptions.SpotOptions.ValidUntil.Time)
+	f2f12.SetSpotOptions(f2f12f1)
+	f2.SetInstanceMarketOptions(f2f12)
+	f2.SetInstanceType(*r.ko.Spec.LaunchTemplateData.InstanceType)
+	f2.SetKernelId(*r.ko.Spec.LaunchTemplateData.KernelID)
+	f2.SetKeyName(*r.ko.Spec.LaunchTemplateData.KeyName)
+	f2f16 := []*svcsdk.LaunchTemplateLicenseConfigurationRequest{}
+	for _, f2f16iter := range r.ko.Spec.LaunchTemplateData.LicenseSpecifications {
+		f2f16elem := &svcsdk.LaunchTemplateLicenseConfigurationRequest{}
+		f2f16elem.SetLicenseConfigurationArn(*f2f16iter.LicenseConfigurationARN)
+		f2f16 = append(f2f16, f2f16elem)
 	}
-	tmp0.LicenseSpecifications = tmp0f4
-	tmp0f0 := &svcsdk.LaunchTemplateInstanceMetadataOptionsRequest{}
-	tmp0f0.SetHttpEndpoint(*r.ko.Spec.LaunchTemplateData.HTTPEndpoint)
-	tmp0f0.SetHttpPutResponseHopLimit(*r.ko.Spec.LaunchTemplateData.HTTPPutResponseHopLimit)
-	tmp0f0.SetHttpTokens(*r.ko.Spec.LaunchTemplateData.HTTPTokens)
-	tmp0.MetadataOptions = tmp0f0
-	tmp0f0 := &svcsdk.LaunchTemplatesMonitoringRequest{}
-	tmp0f0.SetEnabled(*r.ko.Spec.LaunchTemplateData.Enabled)
-	tmp0.Monitoring = tmp0f0
-	tmp0f5 := []*svcsdk.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest{}
-	for _, elem5 := range r.ko.Spec.LaunchTemplateData.NetworkInterfaces {
-		tmpElem5 := &svcsdk.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest{}
-		tmpElem5.SetAssociatePublicIpAddress(*elem5.AssociatePublicIPAddress)
-		tmpElem5.SetDeleteOnTermination(*elem5.DeleteOnTermination)
-		tmpElem5.SetDescription(*elem5.Description)
-		tmpElem5.SetDeviceIndex(*elem5.DeviceIndex)
-		tmpElem5f0 := []*string{}
-		for _, elem0 := range elem5.Groups {
-			tmpElem0.SetSecurityGroupIdStringList(*elem0.Groups.SecurityGroupIDStringList)
-			tmpElem5f0 = append(tmpElem5f0, tmpElem0)
+	f2.SetLicenseSpecifications(f2f16)
+	f2f17 := &svcsdk.LaunchTemplateInstanceMetadataOptionsRequest{}
+	f2f17.SetHttpEndpoint(*r.ko.Spec.LaunchTemplateData.MetadataOptions.HTTPEndpoint)
+	f2f17.SetHttpPutResponseHopLimit(*r.ko.Spec.LaunchTemplateData.MetadataOptions.HTTPPutResponseHopLimit)
+	f2f17.SetHttpTokens(*r.ko.Spec.LaunchTemplateData.MetadataOptions.HTTPTokens)
+	f2.SetMetadataOptions(f2f17)
+	f2f18 := &svcsdk.LaunchTemplatesMonitoringRequest{}
+	f2f18.SetEnabled(*r.ko.Spec.LaunchTemplateData.Monitoring.Enabled)
+	f2.SetMonitoring(f2f18)
+	f2f19 := []*svcsdk.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest{}
+	for _, f2f19iter := range r.ko.Spec.LaunchTemplateData.NetworkInterfaces {
+		f2f19elem := &svcsdk.LaunchTemplateInstanceNetworkInterfaceSpecificationRequest{}
+		f2f19elem.SetAssociatePublicIpAddress(*f2f19iter.AssociatePublicIPAddress)
+		f2f19elem.SetDeleteOnTermination(*f2f19iter.DeleteOnTermination)
+		f2f19elem.SetDescription(*f2f19iter.Description)
+		f2f19elem.SetDeviceIndex(*f2f19iter.DeviceIndex)
+		f2f19elemf4 := []*string{}
+		for _, f2f19elemf4iter := range f2f19iter.Groups {
+			f2f19elemf4elem.SetGroups(*f2f19elemf4iter)
+			f2f19elemf4 = append(f2f19elemf4, f2f19elemf4elem)
 		}
-		tmpElem5.Groups = tmpElem5f0
-		tmpElem5.SetInterfaceType(*elem5.InterfaceType)
-		tmpElem5.SetIpv6AddressCount(*elem5.IPv6AddressCount)
-		tmpElem5f1 := []*svcsdk.InstanceIpv6AddressRequest{}
-		for _, elem1 := range elem5.IPv6Addresses {
-			tmpElem1 := &svcsdk.InstanceIpv6AddressRequest{}
-			tmpElem1.SetIpv6Address(*elem1.IPv6Address)
-			tmpElem5f1 = append(tmpElem5f1, tmpElem1)
+		f2f19elem.SetGroups(f2f19elemf4)
+		f2f19elem.SetInterfaceType(*f2f19iter.InterfaceType)
+		f2f19elem.SetIpv6AddressCount(*f2f19iter.IPv6AddressCount)
+		f2f19elemf7 := []*svcsdk.InstanceIpv6AddressRequest{}
+		for _, f2f19elemf7iter := range f2f19iter.IPv6Addresses {
+			f2f19elemf7elem := &svcsdk.InstanceIpv6AddressRequest{}
+			f2f19elemf7elem.SetIpv6Address(*f2f19elemf7iter.IPv6Address)
+			f2f19elemf7 = append(f2f19elemf7, f2f19elemf7elem)
 		}
-		tmpElem5.Ipv6Addresses = tmpElem5f1
-		tmpElem5.SetNetworkInterfaceId(*elem5.NetworkInterfaceID)
-		tmpElem5.SetPrivateIpAddress(*elem5.PrivateIPAddress)
-		tmpElem5f2 := []*svcsdk.PrivateIpAddressSpecification{}
-		for _, elem2 := range elem5.PrivateIPAddresses {
-			tmpElem2 := &svcsdk.PrivateIpAddressSpecification{}
-			tmpElem2.SetPrimary(*elem2.Primary)
-			tmpElem2.SetPrivateIpAddress(*elem2.PrivateIPAddress)
-			tmpElem5f2 = append(tmpElem5f2, tmpElem2)
+		f2f19elem.SetIpv6Addresses(f2f19elemf7)
+		f2f19elem.SetNetworkInterfaceId(*f2f19iter.NetworkInterfaceID)
+		f2f19elem.SetPrivateIpAddress(*f2f19iter.PrivateIPAddress)
+		f2f19elemf10 := []*svcsdk.PrivateIpAddressSpecification{}
+		for _, f2f19elemf10iter := range f2f19iter.PrivateIPAddresses {
+			f2f19elemf10elem := &svcsdk.PrivateIpAddressSpecification{}
+			f2f19elemf10elem.SetPrimary(*f2f19elemf10iter.Primary)
+			f2f19elemf10elem.SetPrivateIpAddress(*f2f19elemf10iter.PrivateIPAddress)
+			f2f19elemf10 = append(f2f19elemf10, f2f19elemf10elem)
 		}
-		tmpElem5.PrivateIpAddresses = tmpElem5f2
-		tmpElem5.SetSecondaryPrivateIpAddressCount(*elem5.SecondaryPrivateIPAddressCount)
-		tmpElem5.SetSubnetId(*elem5.SubnetID)
-		tmp0f5 = append(tmp0f5, tmpElem5)
+		f2f19elem.SetPrivateIpAddresses(f2f19elemf10)
+		f2f19elem.SetSecondaryPrivateIpAddressCount(*f2f19iter.SecondaryPrivateIPAddressCount)
+		f2f19elem.SetSubnetId(*f2f19iter.SubnetID)
+		f2f19 = append(f2f19, f2f19elem)
 	}
-	tmp0.NetworkInterfaces = tmp0f5
-	tmp0f0 := &svcsdk.LaunchTemplatePlacementRequest{}
-	tmp0f0.SetAffinity(*r.ko.Spec.LaunchTemplateData.Affinity)
-	tmp0f0.SetAvailabilityZone(*r.ko.Spec.LaunchTemplateData.AvailabilityZone)
-	tmp0f0.SetGroupName(*r.ko.Spec.LaunchTemplateData.GroupName)
-	tmp0f0.SetHostId(*r.ko.Spec.LaunchTemplateData.HostID)
-	tmp0f0.SetHostResourceGroupArn(*r.ko.Spec.LaunchTemplateData.HostResourceGroupARN)
-	tmp0f0.SetPartitionNumber(*r.ko.Spec.LaunchTemplateData.PartitionNumber)
-	tmp0f0.SetSpreadDomain(*r.ko.Spec.LaunchTemplateData.SpreadDomain)
-	tmp0f0.SetTenancy(*r.ko.Spec.LaunchTemplateData.Tenancy)
-	tmp0.Placement = tmp0f0
-	tmp0.SetRamDiskId(*r.ko.Spec.LaunchTemplateData.RamDiskID)
-	tmp0f6 := []*string{}
-	for _, elem6 := range r.ko.Spec.LaunchTemplateData.SecurityGroupIDs {
-		tmpElem6.SetSecurityGroupIdStringList(*elem6.SecurityGroupIDs.SecurityGroupIDStringList)
-		tmp0f6 = append(tmp0f6, tmpElem6)
+	f2.SetNetworkInterfaces(f2f19)
+	f2f20 := &svcsdk.LaunchTemplatePlacementRequest{}
+	f2f20.SetAffinity(*r.ko.Spec.LaunchTemplateData.Placement.Affinity)
+	f2f20.SetAvailabilityZone(*r.ko.Spec.LaunchTemplateData.Placement.AvailabilityZone)
+	f2f20.SetGroupName(*r.ko.Spec.LaunchTemplateData.Placement.GroupName)
+	f2f20.SetHostId(*r.ko.Spec.LaunchTemplateData.Placement.HostID)
+	f2f20.SetHostResourceGroupArn(*r.ko.Spec.LaunchTemplateData.Placement.HostResourceGroupARN)
+	f2f20.SetPartitionNumber(*r.ko.Spec.LaunchTemplateData.Placement.PartitionNumber)
+	f2f20.SetSpreadDomain(*r.ko.Spec.LaunchTemplateData.Placement.SpreadDomain)
+	f2f20.SetTenancy(*r.ko.Spec.LaunchTemplateData.Placement.Tenancy)
+	f2.SetPlacement(f2f20)
+	f2.SetRamDiskId(*r.ko.Spec.LaunchTemplateData.RamDiskID)
+	f2f22 := []*string{}
+	for _, f2f22iter := range r.ko.Spec.LaunchTemplateData.SecurityGroupIDs {
+		f2f22elem.SetSecurityGroupIds(*f2f22iter)
+		f2f22 = append(f2f22, f2f22elem)
 	}
-	tmp0.SecurityGroupIds = tmp0f6
-	tmp0f7 := []*string{}
-	for _, elem7 := range r.ko.Spec.LaunchTemplateData.SecurityGroups {
-		tmpElem7.SetSecurityGroupStringList(*elem7.SecurityGroups.SecurityGroupStringList)
-		tmp0f7 = append(tmp0f7, tmpElem7)
+	f2.SetSecurityGroupIds(f2f22)
+	f2f23 := []*string{}
+	for _, f2f23iter := range r.ko.Spec.LaunchTemplateData.SecurityGroups {
+		f2f23elem.SetSecurityGroups(*f2f23iter)
+		f2f23 = append(f2f23, f2f23elem)
 	}
-	tmp0.SecurityGroups = tmp0f7
-	tmp0f8 := []*svcsdk.LaunchTemplateTagSpecificationRequest{}
-	for _, elem8 := range r.ko.Spec.LaunchTemplateData.TagSpecifications {
-		tmpElem8 := &svcsdk.LaunchTemplateTagSpecificationRequest{}
-		tmpElem8.SetResourceType(*elem8.ResourceType)
-		tmpElem8f0 := []*svcsdk.Tag{}
-		for _, elem0 := range elem8.Tags {
-			tmpElem0 := &svcsdk.Tag{}
-			tmpElem0.SetKey(*elem0.Key)
-			tmpElem0.SetValue(*elem0.Value)
-			tmpElem8f0 = append(tmpElem8f0, tmpElem0)
+	f2.SetSecurityGroups(f2f23)
+	f2f24 := []*svcsdk.LaunchTemplateTagSpecificationRequest{}
+	for _, f2f24iter := range r.ko.Spec.LaunchTemplateData.TagSpecifications {
+		f2f24elem := &svcsdk.LaunchTemplateTagSpecificationRequest{}
+		f2f24elem.SetResourceType(*f2f24iter.ResourceType)
+		f2f24elemf1 := []*svcsdk.Tag{}
+		for _, f2f24elemf1iter := range f2f24iter.Tags {
+			f2f24elemf1elem := &svcsdk.Tag{}
+			f2f24elemf1elem.SetKey(*f2f24elemf1iter.Key)
+			f2f24elemf1elem.SetValue(*f2f24elemf1iter.Value)
+			f2f24elemf1 = append(f2f24elemf1, f2f24elemf1elem)
 		}
-		tmpElem8.Tags = tmpElem8f0
-		tmp0f8 = append(tmp0f8, tmpElem8)
+		f2f24elem.SetTags(f2f24elemf1)
+		f2f24 = append(f2f24, f2f24elem)
 	}
-	tmp0.TagSpecifications = tmp0f8
-	tmp0.SetUserData(*r.ko.Spec.LaunchTemplateData.UserData)
-	res.LaunchTemplateData = tmp0
+	f2.SetTagSpecifications(f2f24)
+	f2.SetUserData(*r.ko.Spec.LaunchTemplateData.UserData)
+	res.SetLaunchTemplateData(f2)
 	res.SetLaunchTemplateName(*r.ko.Spec.LaunchTemplateName)
-	tmp9 := []*svcsdk.TagSpecification{}
-	for _, elem9 := range res.TagSpecifications {
-		tmpElem9 := &svcsdk.TagSpecification{}
-		tmpElem9.SetResourceType(*elem9.ResourceType)
-		tmpElem9f0 := []*svcsdk.Tag{}
-		for _, elem0 := range elem9.Tags {
-			tmpElem0 := &svcsdk.Tag{}
-			tmpElem0.SetKey(*elem0.Key)
-			tmpElem0.SetValue(*elem0.Value)
-			tmpElem9f0 = append(tmpElem9f0, tmpElem0)
+	f4 := []*svcsdk.TagSpecification{}
+	for _, f4iter := range r.ko.Spec.TagSpecifications {
+		f4elem := &svcsdk.TagSpecification{}
+		f4elem.SetResourceType(*f4iter.ResourceType)
+		f4elemf1 := []*svcsdk.Tag{}
+		for _, f4elemf1iter := range f4iter.Tags {
+			f4elemf1elem := &svcsdk.Tag{}
+			f4elemf1elem.SetKey(*f4elemf1iter.Key)
+			f4elemf1elem.SetValue(*f4elemf1iter.Value)
+			f4elemf1 = append(f4elemf1, f4elemf1elem)
 		}
-		tmpElem9.Tags = tmpElem9f0
-		tmp9 = append(tmp9, tmpElem9)
+		f4elem.SetTags(f4elemf1)
+		f4 = append(f4, f4elem)
 	}
-	res.TagSpecifications = tmp9
+	res.SetTagSpecifications(f4)
 	res.SetVersionDescription(*r.ko.Spec.VersionDescription)
 `
-	assert.Equal(expCreateInput, crd.GoCodeSetInput(model.OpTypeCreate, "res", "r.ko.Spec", 1))
+	assert.Equal(expCreateInput, crd.GoCodeSetInput(model.OpTypeCreate, "r.ko.Spec", "res", 1))
 
 	// Check that we properly determined how to find the CreatedBy attribute
 	// within the CreateLaunchTemplateResult shape, which has a single field called
@@ -367,14 +367,14 @@ func TestEC2LaunchTemplate(t *testing.T) {
 	ko.Status.DefaultVersionNumber = resp.LaunchTemplate.DefaultVersionNumber
 	ko.Status.LatestVersionNumber = resp.LaunchTemplate.LatestVersionNumber
 	ko.Status.LaunchTemplateID = resp.LaunchTemplate.LaunchTemplateId
-	tmp0 := []*svcapitypes.Tag{}
-	for _, elem0 := range ko.Status.Tags {
-		tmpElem0 := &svcapitypes.Tag{}
-		tmpElem0.Key = elem0
-		tmpElem0.Value = elem0
-		tmp0 = append(tmp0, tmpElem0)
+	f6 := []*svcapitypes.Tag{}
+	for _, f6iter := range resp.LaunchTemplate.Tags {
+		f6elem := &svcapitypes.Tag{}
+		f6elem.Key = f6iter.Key
+		f6elem.Value = f6iter.Value
+		f6 = append(f6, f6elem)
 	}
-	ko.Status.Tags = tmp0
+	ko.Status.Tags = f6
 `
 	assert.Equal(expCreateOutput, crd.GoCodeSetOutput(model.OpTypeCreate, "resp", "ko.Status", 1))
 
@@ -441,21 +441,21 @@ func TestECRRepository(t *testing.T) {
 	// CreateRepositoryOutput shape, so it should produce Go code to set the
 	// appropriate input shape member.
 	expCreateInput := `
-	tmp0 := &svcsdk.ImageScanningConfiguration{}
-	tmp0.SetScanOnPush(*r.ko.Spec.ImageScanningConfiguration.ScanOnPush)
-	res.ImageScanningConfiguration = tmp0
+	f0 := &svcsdk.ImageScanningConfiguration{}
+	f0.SetScanOnPush(*r.ko.Spec.ImageScanningConfiguration.ScanOnPush)
+	res.SetImageScanningConfiguration(f0)
 	res.SetImageTagMutability(*r.ko.Spec.ImageTagMutability)
 	res.SetRepositoryName(*r.ko.Spec.RepositoryName)
-	tmp1 := []*svcsdk.Tag{}
-	for _, elem1 := range res.Tags {
-		tmpElem1 := &svcsdk.Tag{}
-		tmpElem1.SetKey(*elem1.Key)
-		tmpElem1.SetValue(*elem1.Value)
-		tmp1 = append(tmp1, tmpElem1)
+	f3 := []*svcsdk.Tag{}
+	for _, f3iter := range r.ko.Spec.Tags {
+		f3elem := &svcsdk.Tag{}
+		f3elem.SetKey(*f3iter.Key)
+		f3elem.SetValue(*f3iter.Value)
+		f3 = append(f3, f3elem)
 	}
-	res.Tags = tmp1
+	res.SetTags(f3)
 `
-	assert.Equal(expCreateInput, crd.GoCodeSetInput(model.OpTypeCreate, "res", "r.ko.Spec", 1))
+	assert.Equal(expCreateInput, crd.GoCodeSetInput(model.OpTypeCreate, "r.ko.Spec", "res", 1))
 
 	expStatusFieldCamel := []string{
 		"CreatedAt",
@@ -608,7 +608,7 @@ func TestSQSQueue(t *testing.T) {
 	res.SetQueueName(*r.ko.Spec.QueueName)
 	res.SetTags(r.ko.Spec.Tags)
 `
-	assert.Equal(expCreateInput, crd.GoCodeSetInput(model.OpTypeCreate, "res", "r.ko.Spec", 1))
+	assert.Equal(expCreateInput, crd.GoCodeSetInput(model.OpTypeCreate, "r.ko.Spec", "res", 1))
 
 	// There are no fields other than QueueID in the returned CreateQueueResult
 	// shape

--- a/pkg/model/crd_test.go
+++ b/pkg/model/crd_test.go
@@ -240,7 +240,7 @@ func TestEC2LaunchTemplate(t *testing.T) {
 	tmp0f0f0.SetInstanceInterruptionBehavior(*r.ko.Spec.LaunchTemplateData.InstanceInterruptionBehavior)
 	tmp0f0f0.SetMaxPrice(*r.ko.Spec.LaunchTemplateData.MaxPrice)
 	tmp0f0f0.SetSpotInstanceType(*r.ko.Spec.LaunchTemplateData.SpotInstanceType)
-	tmp0f0f0.SetValidUntil(*r.ko.Spec.LaunchTemplateData.ValidUntil)
+	tmp0f0f0.SetValidUntil(*r.ko.Spec.LaunchTemplateData.ValidUntil.Time)
 	tmp0f0.SpotOptions = tmp0f0f0
 	tmp0.InstanceMarketOptions = tmp0f0
 	tmp0.SetInstanceType(*r.ko.Spec.LaunchTemplateData.InstanceType)
@@ -362,7 +362,7 @@ func TestEC2LaunchTemplate(t *testing.T) {
 	// within the CreateLaunchTemplateResult shape, which has a single field called
 	// "LaunchTemplate" that contains the CreatedBy field.
 	expCreateOutput := `
-	ko.Status.CreateTime = resp.LaunchTemplate.CreateTime
+	ko.Status.CreateTime = &metav1.Time{*resp.LaunchTemplate.CreateTime}
 	ko.Status.CreatedBy = resp.LaunchTemplate.CreatedBy
 	ko.Status.DefaultVersionNumber = resp.LaunchTemplate.DefaultVersionNumber
 	ko.Status.LatestVersionNumber = resp.LaunchTemplate.LatestVersionNumber
@@ -477,7 +477,7 @@ func TestECRRepository(t *testing.T) {
 	// within the CreateRepositoryOutput shape, which has a single field called
 	// "Repository" that contains the RegistryId field.
 	expCreateOutput := `
-	ko.Status.CreatedAt = resp.Repository.CreatedAt
+	ko.Status.CreatedAt = &metav1.Time{*resp.Repository.CreatedAt}
 	ko.Status.RegistryID = resp.Repository.RegistryId
 	ko.Status.RepositoryURI = resp.Repository.RepositoryUri
 `

--- a/pkg/model/helper.go
+++ b/pkg/model/helper.go
@@ -21,8 +21,10 @@ import (
 )
 
 type Helper struct {
-	sdkAPI *awssdkmodel.API
-	crds   []*CRD
+	sdkAPI      *awssdkmodel.API
+	crds        []*CRD
+	typeDefs    []*TypeDef
+	typeImports map[string]string
 	// A map of operation type and resource name to
 	// aws-sdk-go/private/model/api.Operation structs
 	opMap *OperationMap
@@ -56,7 +58,7 @@ func NewHelper(sdkAPI *awssdkmodel.API) *Helper {
 	// unexported map variable...
 	_ = sdkAPI.ServicePackageDoc()
 
-	return &Helper{sdkAPI, nil, nil}
+	return &Helper{sdkAPI, nil, nil, nil, nil}
 }
 
 // GetSDKAPIInterfaceTypeName returns the name of the aws-sdk-go primary API

--- a/pkg/model/helper.go
+++ b/pkg/model/helper.go
@@ -25,6 +25,7 @@ type Helper struct {
 	crds        []*CRD
 	typeDefs    []*TypeDef
 	typeImports map[string]string
+	typeRenames map[string]string
 	// A map of operation type and resource name to
 	// aws-sdk-go/private/model/api.Operation structs
 	opMap *OperationMap
@@ -49,6 +50,12 @@ func (h *Helper) GetAPIGroup() string {
 	return fmt.Sprintf("%s.services.k8s.aws", serviceAlias)
 }
 
+// GetTypeRenames returns a map of original type name to renamed name (some
+// type definition names conflict with generated names)
+func (h *Helper) GetTypeRenames() map[string]string {
+	return h.typeRenames
+}
+
 func NewHelper(sdkAPI *awssdkmodel.API) *Helper {
 	// If we don't do this, we can end up with panic()'s like this:
 	// panic: assignment to entry in nil map
@@ -58,7 +65,7 @@ func NewHelper(sdkAPI *awssdkmodel.API) *Helper {
 	// unexported map variable...
 	_ = sdkAPI.ServicePackageDoc()
 
-	return &Helper{sdkAPI, nil, nil, nil, nil}
+	return &Helper{sdkAPI, nil, nil, nil, nil, nil}
 }
 
 // GetSDKAPIInterfaceTypeName returns the name of the aws-sdk-go primary API

--- a/pkg/model/testdata/models/apis/apigatewayv2/0000-00-00/api-2.json
+++ b/pkg/model/testdata/models/apis/apigatewayv2/0000-00-00/api-2.json
@@ -1,0 +1,6981 @@
+{
+  "metadata" : {
+    "apiVersion" : "2018-11-29",
+    "endpointPrefix" : "apigateway",
+    "signingName" : "apigateway",
+    "serviceFullName" : "AmazonApiGatewayV2",
+    "serviceId" : "ApiGatewayV2",
+    "protocol" : "rest-json",
+    "jsonVersion" : "1.1",
+    "uid" : "apigatewayv2-2018-11-29",
+    "signatureVersion" : "v4"
+  },
+  "operations" : {
+    "CreateApi" : {
+      "name" : "CreateApi",
+      "http" : {
+        "method" : "POST",
+        "requestUri" : "/v2/apis",
+        "responseCode" : 201
+      },
+      "input" : {
+        "shape" : "CreateApiRequest"
+      },
+      "output" : {
+        "shape" : "CreateApiResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "CreateApiMapping" : {
+      "name" : "CreateApiMapping",
+      "http" : {
+        "method" : "POST",
+        "requestUri" : "/v2/domainnames/{domainName}/apimappings",
+        "responseCode" : 201
+      },
+      "input" : {
+        "shape" : "CreateApiMappingRequest"
+      },
+      "output" : {
+        "shape" : "CreateApiMappingResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "CreateAuthorizer" : {
+      "name" : "CreateAuthorizer",
+      "http" : {
+        "method" : "POST",
+        "requestUri" : "/v2/apis/{apiId}/authorizers",
+        "responseCode" : 201
+      },
+      "input" : {
+        "shape" : "CreateAuthorizerRequest"
+      },
+      "output" : {
+        "shape" : "CreateAuthorizerResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "CreateDeployment" : {
+      "name" : "CreateDeployment",
+      "http" : {
+        "method" : "POST",
+        "requestUri" : "/v2/apis/{apiId}/deployments",
+        "responseCode" : 201
+      },
+      "input" : {
+        "shape" : "CreateDeploymentRequest"
+      },
+      "output" : {
+        "shape" : "CreateDeploymentResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "CreateDomainName" : {
+      "name" : "CreateDomainName",
+      "http" : {
+        "method" : "POST",
+        "requestUri" : "/v2/domainnames",
+        "responseCode" : 201
+      },
+      "input" : {
+        "shape" : "CreateDomainNameRequest"
+      },
+      "output" : {
+        "shape" : "CreateDomainNameResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      }, {
+        "shape" : "AccessDeniedException"
+      } ]
+    },
+    "CreateIntegration" : {
+      "name" : "CreateIntegration",
+      "http" : {
+        "method" : "POST",
+        "requestUri" : "/v2/apis/{apiId}/integrations",
+        "responseCode" : 201
+      },
+      "input" : {
+        "shape" : "CreateIntegrationRequest"
+      },
+      "output" : {
+        "shape" : "CreateIntegrationResult"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "CreateIntegrationResponse" : {
+      "name" : "CreateIntegrationResponse",
+      "http" : {
+        "method" : "POST",
+        "requestUri" : "/v2/apis/{apiId}/integrations/{integrationId}/integrationresponses",
+        "responseCode" : 201
+      },
+      "input" : {
+        "shape" : "CreateIntegrationResponseRequest"
+      },
+      "output" : {
+        "shape" : "CreateIntegrationResponseResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "CreateModel" : {
+      "name" : "CreateModel",
+      "http" : {
+        "method" : "POST",
+        "requestUri" : "/v2/apis/{apiId}/models",
+        "responseCode" : 201
+      },
+      "input" : {
+        "shape" : "CreateModelRequest"
+      },
+      "output" : {
+        "shape" : "CreateModelResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "CreateRoute" : {
+      "name" : "CreateRoute",
+      "http" : {
+        "method" : "POST",
+        "requestUri" : "/v2/apis/{apiId}/routes",
+        "responseCode" : 201
+      },
+      "input" : {
+        "shape" : "CreateRouteRequest"
+      },
+      "output" : {
+        "shape" : "CreateRouteResult"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "CreateRouteResponse" : {
+      "name" : "CreateRouteResponse",
+      "http" : {
+        "method" : "POST",
+        "requestUri" : "/v2/apis/{apiId}/routes/{routeId}/routeresponses",
+        "responseCode" : 201
+      },
+      "input" : {
+        "shape" : "CreateRouteResponseRequest"
+      },
+      "output" : {
+        "shape" : "CreateRouteResponseResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "CreateStage" : {
+      "name" : "CreateStage",
+      "http" : {
+        "method" : "POST",
+        "requestUri" : "/v2/apis/{apiId}/stages",
+        "responseCode" : 201
+      },
+      "input" : {
+        "shape" : "CreateStageRequest"
+      },
+      "output" : {
+        "shape" : "CreateStageResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "CreateVpcLink" : {
+      "name" : "CreateVpcLink",
+      "http" : {
+        "method" : "POST",
+        "requestUri" : "/v2/vpclinks",
+        "responseCode" : 201
+      },
+      "input" : {
+        "shape" : "CreateVpcLinkRequest"
+      },
+      "output" : {
+        "shape" : "CreateVpcLinkResponse"
+      },
+      "errors" : [ {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "DeleteAccessLogSettings" : {
+      "name" : "DeleteAccessLogSettings",
+      "http" : {
+        "method" : "DELETE",
+        "requestUri" : "/v2/apis/{apiId}/stages/{stageName}/accesslogsettings",
+        "responseCode" : 204
+      },
+      "input" : {
+        "shape" : "DeleteAccessLogSettingsRequest"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "DeleteApi" : {
+      "name" : "DeleteApi",
+      "http" : {
+        "method" : "DELETE",
+        "requestUri" : "/v2/apis/{apiId}",
+        "responseCode" : 204
+      },
+      "input" : {
+        "shape" : "DeleteApiRequest"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "DeleteApiMapping" : {
+      "name" : "DeleteApiMapping",
+      "http" : {
+        "method" : "DELETE",
+        "requestUri" : "/v2/domainnames/{domainName}/apimappings/{apiMappingId}",
+        "responseCode" : 204
+      },
+      "input" : {
+        "shape" : "DeleteApiMappingRequest"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      } ]
+    },
+    "DeleteAuthorizer" : {
+      "name" : "DeleteAuthorizer",
+      "http" : {
+        "method" : "DELETE",
+        "requestUri" : "/v2/apis/{apiId}/authorizers/{authorizerId}",
+        "responseCode" : 204
+      },
+      "input" : {
+        "shape" : "DeleteAuthorizerRequest"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "DeleteCorsConfiguration" : {
+      "name" : "DeleteCorsConfiguration",
+      "http" : {
+        "method" : "DELETE",
+        "requestUri" : "/v2/apis/{apiId}/cors",
+        "responseCode" : 204
+      },
+      "input" : {
+        "shape" : "DeleteCorsConfigurationRequest"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "DeleteDeployment" : {
+      "name" : "DeleteDeployment",
+      "http" : {
+        "method" : "DELETE",
+        "requestUri" : "/v2/apis/{apiId}/deployments/{deploymentId}",
+        "responseCode" : 204
+      },
+      "input" : {
+        "shape" : "DeleteDeploymentRequest"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "DeleteDomainName" : {
+      "name" : "DeleteDomainName",
+      "http" : {
+        "method" : "DELETE",
+        "requestUri" : "/v2/domainnames/{domainName}",
+        "responseCode" : 204
+      },
+      "input" : {
+        "shape" : "DeleteDomainNameRequest"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "DeleteIntegration" : {
+      "name" : "DeleteIntegration",
+      "http" : {
+        "method" : "DELETE",
+        "requestUri" : "/v2/apis/{apiId}/integrations/{integrationId}",
+        "responseCode" : 204
+      },
+      "input" : {
+        "shape" : "DeleteIntegrationRequest"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "DeleteIntegrationResponse" : {
+      "name" : "DeleteIntegrationResponse",
+      "http" : {
+        "method" : "DELETE",
+        "requestUri" : "/v2/apis/{apiId}/integrations/{integrationId}/integrationresponses/{integrationResponseId}",
+        "responseCode" : 204
+      },
+      "input" : {
+        "shape" : "DeleteIntegrationResponseRequest"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "DeleteModel" : {
+      "name" : "DeleteModel",
+      "http" : {
+        "method" : "DELETE",
+        "requestUri" : "/v2/apis/{apiId}/models/{modelId}",
+        "responseCode" : 204
+      },
+      "input" : {
+        "shape" : "DeleteModelRequest"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "DeleteRoute" : {
+      "name" : "DeleteRoute",
+      "http" : {
+        "method" : "DELETE",
+        "requestUri" : "/v2/apis/{apiId}/routes/{routeId}",
+        "responseCode" : 204
+      },
+      "input" : {
+        "shape" : "DeleteRouteRequest"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "DeleteRouteRequestParameter" : {
+      "name" : "DeleteRouteRequestParameter",
+      "http" : {
+        "method" : "DELETE",
+        "requestUri" : "/v2/apis/{apiId}/routes/{routeId}/requestparameters/{requestParameterKey}",
+        "responseCode" : 204
+      },
+      "input" : {
+        "shape" : "DeleteRouteRequestParameterRequest"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "DeleteRouteResponse" : {
+      "name" : "DeleteRouteResponse",
+      "http" : {
+        "method" : "DELETE",
+        "requestUri" : "/v2/apis/{apiId}/routes/{routeId}/routeresponses/{routeResponseId}",
+        "responseCode" : 204
+      },
+      "input" : {
+        "shape" : "DeleteRouteResponseRequest"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "DeleteRouteSettings" : {
+      "name" : "DeleteRouteSettings",
+      "http" : {
+        "method" : "DELETE",
+        "requestUri" : "/v2/apis/{apiId}/stages/{stageName}/routesettings/{routeKey}",
+        "responseCode" : 204
+      },
+      "input" : {
+        "shape" : "DeleteRouteSettingsRequest"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "DeleteStage" : {
+      "name" : "DeleteStage",
+      "http" : {
+        "method" : "DELETE",
+        "requestUri" : "/v2/apis/{apiId}/stages/{stageName}",
+        "responseCode" : 204
+      },
+      "input" : {
+        "shape" : "DeleteStageRequest"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "DeleteVpcLink" : {
+      "name" : "DeleteVpcLink",
+      "http" : {
+        "method" : "DELETE",
+        "requestUri" : "/v2/vpclinks/{vpcLinkId}",
+        "responseCode" : 202
+      },
+      "input" : {
+        "shape" : "DeleteVpcLinkRequest"
+      },
+      "output" : {
+        "shape" : "DeleteVpcLinkResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "ExportApi" : {
+      "name" : "ExportApi",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/apis/{apiId}/exports/{specification}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "ExportApiRequest"
+      },
+      "output" : {
+        "shape" : "ExportApiResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      } ]
+    },
+    "GetApi" : {
+      "name" : "GetApi",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/apis/{apiId}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetApiRequest"
+      },
+      "output" : {
+        "shape" : "GetApiResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "GetApiMapping" : {
+      "name" : "GetApiMapping",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/domainnames/{domainName}/apimappings/{apiMappingId}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetApiMappingRequest"
+      },
+      "output" : {
+        "shape" : "GetApiMappingResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      } ]
+    },
+    "GetApiMappings" : {
+      "name" : "GetApiMappings",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/domainnames/{domainName}/apimappings",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetApiMappingsRequest"
+      },
+      "output" : {
+        "shape" : "GetApiMappingsResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      } ]
+    },
+    "GetApis" : {
+      "name" : "GetApis",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/apis",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetApisRequest"
+      },
+      "output" : {
+        "shape" : "GetApisResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      } ]
+    },
+    "GetAuthorizer" : {
+      "name" : "GetAuthorizer",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/apis/{apiId}/authorizers/{authorizerId}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetAuthorizerRequest"
+      },
+      "output" : {
+        "shape" : "GetAuthorizerResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "GetAuthorizers" : {
+      "name" : "GetAuthorizers",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/apis/{apiId}/authorizers",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetAuthorizersRequest"
+      },
+      "output" : {
+        "shape" : "GetAuthorizersResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      } ]
+    },
+    "GetDeployment" : {
+      "name" : "GetDeployment",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/apis/{apiId}/deployments/{deploymentId}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetDeploymentRequest"
+      },
+      "output" : {
+        "shape" : "GetDeploymentResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "GetDeployments" : {
+      "name" : "GetDeployments",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/apis/{apiId}/deployments",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetDeploymentsRequest"
+      },
+      "output" : {
+        "shape" : "GetDeploymentsResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      } ]
+    },
+    "GetDomainName" : {
+      "name" : "GetDomainName",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/domainnames/{domainName}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetDomainNameRequest"
+      },
+      "output" : {
+        "shape" : "GetDomainNameResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "GetDomainNames" : {
+      "name" : "GetDomainNames",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/domainnames",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetDomainNamesRequest"
+      },
+      "output" : {
+        "shape" : "GetDomainNamesResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      } ]
+    },
+    "GetIntegration" : {
+      "name" : "GetIntegration",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/apis/{apiId}/integrations/{integrationId}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetIntegrationRequest"
+      },
+      "output" : {
+        "shape" : "GetIntegrationResult"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "GetIntegrationResponse" : {
+      "name" : "GetIntegrationResponse",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/apis/{apiId}/integrations/{integrationId}/integrationresponses/{integrationResponseId}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetIntegrationResponseRequest"
+      },
+      "output" : {
+        "shape" : "GetIntegrationResponseResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "GetIntegrationResponses" : {
+      "name" : "GetIntegrationResponses",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/apis/{apiId}/integrations/{integrationId}/integrationresponses",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetIntegrationResponsesRequest"
+      },
+      "output" : {
+        "shape" : "GetIntegrationResponsesResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      } ]
+    },
+    "GetIntegrations" : {
+      "name" : "GetIntegrations",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/apis/{apiId}/integrations",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetIntegrationsRequest"
+      },
+      "output" : {
+        "shape" : "GetIntegrationsResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      } ]
+    },
+    "GetModel" : {
+      "name" : "GetModel",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/apis/{apiId}/models/{modelId}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetModelRequest"
+      },
+      "output" : {
+        "shape" : "GetModelResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "GetModelTemplate" : {
+      "name" : "GetModelTemplate",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/apis/{apiId}/models/{modelId}/template",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetModelTemplateRequest"
+      },
+      "output" : {
+        "shape" : "GetModelTemplateResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "GetModels" : {
+      "name" : "GetModels",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/apis/{apiId}/models",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetModelsRequest"
+      },
+      "output" : {
+        "shape" : "GetModelsResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      } ]
+    },
+    "GetRoute" : {
+      "name" : "GetRoute",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/apis/{apiId}/routes/{routeId}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetRouteRequest"
+      },
+      "output" : {
+        "shape" : "GetRouteResult"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "GetRouteResponse" : {
+      "name" : "GetRouteResponse",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/apis/{apiId}/routes/{routeId}/routeresponses/{routeResponseId}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetRouteResponseRequest"
+      },
+      "output" : {
+        "shape" : "GetRouteResponseResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "GetRouteResponses" : {
+      "name" : "GetRouteResponses",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/apis/{apiId}/routes/{routeId}/routeresponses",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetRouteResponsesRequest"
+      },
+      "output" : {
+        "shape" : "GetRouteResponsesResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      } ]
+    },
+    "GetRoutes" : {
+      "name" : "GetRoutes",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/apis/{apiId}/routes",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetRoutesRequest"
+      },
+      "output" : {
+        "shape" : "GetRoutesResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      } ]
+    },
+    "GetStage" : {
+      "name" : "GetStage",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/apis/{apiId}/stages/{stageName}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetStageRequest"
+      },
+      "output" : {
+        "shape" : "GetStageResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "GetStages" : {
+      "name" : "GetStages",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/apis/{apiId}/stages",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetStagesRequest"
+      },
+      "output" : {
+        "shape" : "GetStagesResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      } ]
+    },
+    "GetTags" : {
+      "name" : "GetTags",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/tags/{resource-arn}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetTagsRequest"
+      },
+      "output" : {
+        "shape" : "GetTagsResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "GetVpcLink" : {
+      "name" : "GetVpcLink",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/vpclinks/{vpcLinkId}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetVpcLinkRequest"
+      },
+      "output" : {
+        "shape" : "GetVpcLinkResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "GetVpcLinks" : {
+      "name" : "GetVpcLinks",
+      "http" : {
+        "method" : "GET",
+        "requestUri" : "/v2/vpclinks",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "GetVpcLinksRequest"
+      },
+      "output" : {
+        "shape" : "GetVpcLinksResponse"
+      },
+      "errors" : [ {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      } ]
+    },
+    "ImportApi" : {
+      "name" : "ImportApi",
+      "http" : {
+        "method" : "PUT",
+        "requestUri" : "/v2/apis",
+        "responseCode" : 201
+      },
+      "input" : {
+        "shape" : "ImportApiRequest"
+      },
+      "output" : {
+        "shape" : "ImportApiResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "ReimportApi" : {
+      "name" : "ReimportApi",
+      "http" : {
+        "method" : "PUT",
+        "requestUri" : "/v2/apis/{apiId}",
+        "responseCode" : 201
+      },
+      "input" : {
+        "shape" : "ReimportApiRequest"
+      },
+      "output" : {
+        "shape" : "ReimportApiResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "TagResource" : {
+      "name" : "TagResource",
+      "http" : {
+        "method" : "POST",
+        "requestUri" : "/v2/tags/{resource-arn}",
+        "responseCode" : 201
+      },
+      "input" : {
+        "shape" : "TagResourceRequest"
+      },
+      "output" : {
+        "shape" : "TagResourceResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "UntagResource" : {
+      "name" : "UntagResource",
+      "http" : {
+        "method" : "DELETE",
+        "requestUri" : "/v2/tags/{resource-arn}",
+        "responseCode" : 204
+      },
+      "input" : {
+        "shape" : "UntagResourceRequest"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "UpdateApi" : {
+      "name" : "UpdateApi",
+      "http" : {
+        "method" : "PATCH",
+        "requestUri" : "/v2/apis/{apiId}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "UpdateApiRequest"
+      },
+      "output" : {
+        "shape" : "UpdateApiResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "UpdateApiMapping" : {
+      "name" : "UpdateApiMapping",
+      "http" : {
+        "method" : "PATCH",
+        "requestUri" : "/v2/domainnames/{domainName}/apimappings/{apiMappingId}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "UpdateApiMappingRequest"
+      },
+      "output" : {
+        "shape" : "UpdateApiMappingResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "UpdateAuthorizer" : {
+      "name" : "UpdateAuthorizer",
+      "http" : {
+        "method" : "PATCH",
+        "requestUri" : "/v2/apis/{apiId}/authorizers/{authorizerId}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "UpdateAuthorizerRequest"
+      },
+      "output" : {
+        "shape" : "UpdateAuthorizerResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "UpdateDeployment" : {
+      "name" : "UpdateDeployment",
+      "http" : {
+        "method" : "PATCH",
+        "requestUri" : "/v2/apis/{apiId}/deployments/{deploymentId}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "UpdateDeploymentRequest"
+      },
+      "output" : {
+        "shape" : "UpdateDeploymentResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "UpdateDomainName" : {
+      "name" : "UpdateDomainName",
+      "http" : {
+        "method" : "PATCH",
+        "requestUri" : "/v2/domainnames/{domainName}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "UpdateDomainNameRequest"
+      },
+      "output" : {
+        "shape" : "UpdateDomainNameResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "UpdateIntegration" : {
+      "name" : "UpdateIntegration",
+      "http" : {
+        "method" : "PATCH",
+        "requestUri" : "/v2/apis/{apiId}/integrations/{integrationId}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "UpdateIntegrationRequest"
+      },
+      "output" : {
+        "shape" : "UpdateIntegrationResult"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "UpdateIntegrationResponse" : {
+      "name" : "UpdateIntegrationResponse",
+      "http" : {
+        "method" : "PATCH",
+        "requestUri" : "/v2/apis/{apiId}/integrations/{integrationId}/integrationresponses/{integrationResponseId}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "UpdateIntegrationResponseRequest"
+      },
+      "output" : {
+        "shape" : "UpdateIntegrationResponseResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "UpdateModel" : {
+      "name" : "UpdateModel",
+      "http" : {
+        "method" : "PATCH",
+        "requestUri" : "/v2/apis/{apiId}/models/{modelId}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "UpdateModelRequest"
+      },
+      "output" : {
+        "shape" : "UpdateModelResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "UpdateRoute" : {
+      "name" : "UpdateRoute",
+      "http" : {
+        "method" : "PATCH",
+        "requestUri" : "/v2/apis/{apiId}/routes/{routeId}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "UpdateRouteRequest"
+      },
+      "output" : {
+        "shape" : "UpdateRouteResult"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "UpdateRouteResponse" : {
+      "name" : "UpdateRouteResponse",
+      "http" : {
+        "method" : "PATCH",
+        "requestUri" : "/v2/apis/{apiId}/routes/{routeId}/routeresponses/{routeResponseId}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "UpdateRouteResponseRequest"
+      },
+      "output" : {
+        "shape" : "UpdateRouteResponseResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "UpdateStage" : {
+      "name" : "UpdateStage",
+      "http" : {
+        "method" : "PATCH",
+        "requestUri" : "/v2/apis/{apiId}/stages/{stageName}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "UpdateStageRequest"
+      },
+      "output" : {
+        "shape" : "UpdateStageResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      }, {
+        "shape" : "ConflictException"
+      } ]
+    },
+    "UpdateVpcLink" : {
+      "name" : "UpdateVpcLink",
+      "http" : {
+        "method" : "PATCH",
+        "requestUri" : "/v2/vpclinks/{vpcLinkId}",
+        "responseCode" : 200
+      },
+      "input" : {
+        "shape" : "UpdateVpcLinkRequest"
+      },
+      "output" : {
+        "shape" : "UpdateVpcLinkResponse"
+      },
+      "errors" : [ {
+        "shape" : "NotFoundException"
+      }, {
+        "shape" : "TooManyRequestsException"
+      }, {
+        "shape" : "BadRequestException"
+      } ]
+    }
+  },
+  "shapes" : {
+    "AccessDeniedException" : {
+      "type" : "structure",
+      "members" : {
+        "Message" : {
+          "shape" : "__string",
+          "locationName" : "message"
+        }
+      },
+      "exception" : true,
+      "error" : {
+        "httpStatusCode" : 403
+      }
+    },
+    "AccessLogSettings" : {
+      "type" : "structure",
+      "members" : {
+        "DestinationArn" : {
+          "shape" : "Arn",
+          "locationName" : "destinationArn"
+        },
+        "Format" : {
+          "shape" : "StringWithLengthBetween1And1024",
+          "locationName" : "format"
+        }
+      }
+    },
+    "Api" : {
+      "type" : "structure",
+      "members" : {
+        "ApiEndpoint" : {
+          "shape" : "__string",
+          "locationName" : "apiEndpoint"
+        },
+        "ApiId" : {
+          "shape" : "Id",
+          "locationName" : "apiId"
+        },
+        "ApiKeySelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "apiKeySelectionExpression"
+        },
+        "CorsConfiguration" : {
+          "shape" : "Cors",
+          "locationName" : "corsConfiguration"
+        },
+        "CreatedDate" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "createdDate"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "DisableSchemaValidation" : {
+          "shape" : "__boolean",
+          "locationName" : "disableSchemaValidation"
+        },
+        "ImportInfo" : {
+          "shape" : "__listOf__string",
+          "locationName" : "importInfo"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "ProtocolType" : {
+          "shape" : "ProtocolType",
+          "locationName" : "protocolType"
+        },
+        "RouteSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "routeSelectionExpression"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        },
+        "Version" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "version"
+        },
+        "Warnings" : {
+          "shape" : "__listOf__string",
+          "locationName" : "warnings"
+        }
+      },
+      "required" : [ "RouteSelectionExpression", "Name", "ProtocolType" ]
+    },
+    "ApiMapping" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "Id",
+          "locationName" : "apiId"
+        },
+        "ApiMappingId" : {
+          "shape" : "Id",
+          "locationName" : "apiMappingId"
+        },
+        "ApiMappingKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "apiMappingKey"
+        },
+        "Stage" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "stage"
+        }
+      },
+      "required" : [ "Stage", "ApiId" ]
+    },
+    "ApiMappings" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfApiMapping",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "Apis" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfApi",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "Arn" : {
+      "type" : "string"
+    },
+    "AuthorizationScopes" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "StringWithLengthBetween1And64"
+      }
+    },
+    "AuthorizationType" : {
+      "type" : "string",
+      "enum" : [ "NONE", "AWS_IAM", "CUSTOM", "JWT" ]
+    },
+    "Authorizer" : {
+      "type" : "structure",
+      "members" : {
+        "AuthorizerCredentialsArn" : {
+          "shape" : "Arn",
+          "locationName" : "authorizerCredentialsArn"
+        },
+        "AuthorizerId" : {
+          "shape" : "Id",
+          "locationName" : "authorizerId"
+        },
+        "AuthorizerResultTtlInSeconds" : {
+          "shape" : "IntegerWithLengthBetween0And3600",
+          "locationName" : "authorizerResultTtlInSeconds"
+        },
+        "AuthorizerType" : {
+          "shape" : "AuthorizerType",
+          "locationName" : "authorizerType"
+        },
+        "AuthorizerUri" : {
+          "shape" : "UriWithLengthBetween1And2048",
+          "locationName" : "authorizerUri"
+        },
+        "IdentitySource" : {
+          "shape" : "IdentitySourceList",
+          "locationName" : "identitySource"
+        },
+        "IdentityValidationExpression" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "identityValidationExpression"
+        },
+        "JwtConfiguration" : {
+          "shape" : "JWTConfiguration",
+          "locationName" : "jwtConfiguration"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        }
+      },
+      "required" : [ "Name" ]
+    },
+    "AuthorizerType" : {
+      "type" : "string",
+      "enum" : [ "REQUEST", "JWT" ]
+    },
+    "Authorizers" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfAuthorizer",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "BadRequestException" : {
+      "type" : "structure",
+      "members" : {
+        "Message" : {
+          "shape" : "__string",
+          "locationName" : "message"
+        }
+      },
+      "exception" : true,
+      "error" : {
+        "httpStatusCode" : 400
+      }
+    },
+    "ConflictException" : {
+      "type" : "structure",
+      "members" : {
+        "Message" : {
+          "shape" : "__string",
+          "locationName" : "message"
+        }
+      },
+      "exception" : true,
+      "error" : {
+        "httpStatusCode" : 409
+      }
+    },
+    "ConnectionType" : {
+      "type" : "string",
+      "enum" : [ "INTERNET", "VPC_LINK" ]
+    },
+    "ContentHandlingStrategy" : {
+      "type" : "string",
+      "enum" : [ "CONVERT_TO_BINARY", "CONVERT_TO_TEXT" ]
+    },
+    "Cors" : {
+      "type" : "structure",
+      "members" : {
+        "AllowCredentials" : {
+          "shape" : "__boolean",
+          "locationName" : "allowCredentials"
+        },
+        "AllowHeaders" : {
+          "shape" : "CorsHeaderList",
+          "locationName" : "allowHeaders"
+        },
+        "AllowMethods" : {
+          "shape" : "CorsMethodList",
+          "locationName" : "allowMethods"
+        },
+        "AllowOrigins" : {
+          "shape" : "CorsOriginList",
+          "locationName" : "allowOrigins"
+        },
+        "ExposeHeaders" : {
+          "shape" : "CorsHeaderList",
+          "locationName" : "exposeHeaders"
+        },
+        "MaxAge" : {
+          "shape" : "IntegerWithLengthBetweenMinus1And86400",
+          "locationName" : "maxAge"
+        }
+      }
+    },
+    "CorsHeaderList" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "__string"
+      }
+    },
+    "CorsMethodList" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "StringWithLengthBetween1And64"
+      }
+    },
+    "CorsOriginList" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "__string"
+      }
+    },
+    "CreateApiInput" : {
+      "type" : "structure",
+      "members" : {
+        "ApiKeySelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "apiKeySelectionExpression"
+        },
+        "CorsConfiguration" : {
+          "shape" : "Cors",
+          "locationName" : "corsConfiguration"
+        },
+        "CredentialsArn" : {
+          "shape" : "Arn",
+          "locationName" : "credentialsArn"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "DisableSchemaValidation" : {
+          "shape" : "__boolean",
+          "locationName" : "disableSchemaValidation"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "ProtocolType" : {
+          "shape" : "ProtocolType",
+          "locationName" : "protocolType"
+        },
+        "RouteKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "routeKey"
+        },
+        "RouteSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "routeSelectionExpression"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        },
+        "Target" : {
+          "shape" : "UriWithLengthBetween1And2048",
+          "locationName" : "target"
+        },
+        "Version" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "version"
+        }
+      },
+      "required" : [ "ProtocolType", "Name" ]
+    },
+    "CreateApiMappingInput" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "Id",
+          "locationName" : "apiId"
+        },
+        "ApiMappingKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "apiMappingKey"
+        },
+        "Stage" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "stage"
+        }
+      },
+      "required" : [ "Stage", "ApiId" ]
+    },
+    "CreateApiMappingRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "Id",
+          "locationName" : "apiId"
+        },
+        "ApiMappingKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "apiMappingKey"
+        },
+        "DomainName" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "domainName"
+        },
+        "Stage" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "stage"
+        }
+      },
+      "required" : [ "DomainName", "Stage", "ApiId" ]
+    },
+    "CreateApiMappingResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "Id",
+          "locationName" : "apiId"
+        },
+        "ApiMappingId" : {
+          "shape" : "Id",
+          "locationName" : "apiMappingId"
+        },
+        "ApiMappingKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "apiMappingKey"
+        },
+        "Stage" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "stage"
+        }
+      }
+    },
+    "CreateApiRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiKeySelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "apiKeySelectionExpression"
+        },
+        "CorsConfiguration" : {
+          "shape" : "Cors",
+          "locationName" : "corsConfiguration"
+        },
+        "CredentialsArn" : {
+          "shape" : "Arn",
+          "locationName" : "credentialsArn"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "DisableSchemaValidation" : {
+          "shape" : "__boolean",
+          "locationName" : "disableSchemaValidation"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "ProtocolType" : {
+          "shape" : "ProtocolType",
+          "locationName" : "protocolType"
+        },
+        "RouteKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "routeKey"
+        },
+        "RouteSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "routeSelectionExpression"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        },
+        "Target" : {
+          "shape" : "UriWithLengthBetween1And2048",
+          "locationName" : "target"
+        },
+        "Version" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "version"
+        }
+      },
+      "required" : [ "ProtocolType", "Name" ]
+    },
+    "CreateApiResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ApiEndpoint" : {
+          "shape" : "__string",
+          "locationName" : "apiEndpoint"
+        },
+        "ApiId" : {
+          "shape" : "Id",
+          "locationName" : "apiId"
+        },
+        "ApiKeySelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "apiKeySelectionExpression"
+        },
+        "CorsConfiguration" : {
+          "shape" : "Cors",
+          "locationName" : "corsConfiguration"
+        },
+        "CreatedDate" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "createdDate"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "DisableSchemaValidation" : {
+          "shape" : "__boolean",
+          "locationName" : "disableSchemaValidation"
+        },
+        "ImportInfo" : {
+          "shape" : "__listOf__string",
+          "locationName" : "importInfo"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "ProtocolType" : {
+          "shape" : "ProtocolType",
+          "locationName" : "protocolType"
+        },
+        "RouteSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "routeSelectionExpression"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        },
+        "Version" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "version"
+        },
+        "Warnings" : {
+          "shape" : "__listOf__string",
+          "locationName" : "warnings"
+        }
+      }
+    },
+    "CreateAuthorizerInput" : {
+      "type" : "structure",
+      "members" : {
+        "AuthorizerCredentialsArn" : {
+          "shape" : "Arn",
+          "locationName" : "authorizerCredentialsArn"
+        },
+        "AuthorizerResultTtlInSeconds" : {
+          "shape" : "IntegerWithLengthBetween0And3600",
+          "locationName" : "authorizerResultTtlInSeconds"
+        },
+        "AuthorizerType" : {
+          "shape" : "AuthorizerType",
+          "locationName" : "authorizerType"
+        },
+        "AuthorizerUri" : {
+          "shape" : "UriWithLengthBetween1And2048",
+          "locationName" : "authorizerUri"
+        },
+        "IdentitySource" : {
+          "shape" : "IdentitySourceList",
+          "locationName" : "identitySource"
+        },
+        "IdentityValidationExpression" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "identityValidationExpression"
+        },
+        "JwtConfiguration" : {
+          "shape" : "JWTConfiguration",
+          "locationName" : "jwtConfiguration"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        }
+      },
+      "required" : [ "AuthorizerType", "IdentitySource", "Name" ]
+    },
+    "CreateAuthorizerRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "AuthorizerCredentialsArn" : {
+          "shape" : "Arn",
+          "locationName" : "authorizerCredentialsArn"
+        },
+        "AuthorizerResultTtlInSeconds" : {
+          "shape" : "IntegerWithLengthBetween0And3600",
+          "locationName" : "authorizerResultTtlInSeconds"
+        },
+        "AuthorizerType" : {
+          "shape" : "AuthorizerType",
+          "locationName" : "authorizerType"
+        },
+        "AuthorizerUri" : {
+          "shape" : "UriWithLengthBetween1And2048",
+          "locationName" : "authorizerUri"
+        },
+        "IdentitySource" : {
+          "shape" : "IdentitySourceList",
+          "locationName" : "identitySource"
+        },
+        "IdentityValidationExpression" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "identityValidationExpression"
+        },
+        "JwtConfiguration" : {
+          "shape" : "JWTConfiguration",
+          "locationName" : "jwtConfiguration"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        }
+      },
+      "required" : [ "ApiId", "AuthorizerType", "IdentitySource", "Name" ]
+    },
+    "CreateAuthorizerResponse" : {
+      "type" : "structure",
+      "members" : {
+        "AuthorizerCredentialsArn" : {
+          "shape" : "Arn",
+          "locationName" : "authorizerCredentialsArn"
+        },
+        "AuthorizerId" : {
+          "shape" : "Id",
+          "locationName" : "authorizerId"
+        },
+        "AuthorizerResultTtlInSeconds" : {
+          "shape" : "IntegerWithLengthBetween0And3600",
+          "locationName" : "authorizerResultTtlInSeconds"
+        },
+        "AuthorizerType" : {
+          "shape" : "AuthorizerType",
+          "locationName" : "authorizerType"
+        },
+        "AuthorizerUri" : {
+          "shape" : "UriWithLengthBetween1And2048",
+          "locationName" : "authorizerUri"
+        },
+        "IdentitySource" : {
+          "shape" : "IdentitySourceList",
+          "locationName" : "identitySource"
+        },
+        "IdentityValidationExpression" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "identityValidationExpression"
+        },
+        "JwtConfiguration" : {
+          "shape" : "JWTConfiguration",
+          "locationName" : "jwtConfiguration"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        }
+      }
+    },
+    "CreateDeploymentInput" : {
+      "type" : "structure",
+      "members" : {
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "StageName" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "stageName"
+        }
+      }
+    },
+    "CreateDeploymentRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "StageName" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "stageName"
+        }
+      },
+      "required" : [ "ApiId" ]
+    },
+    "CreateDeploymentResponse" : {
+      "type" : "structure",
+      "members" : {
+        "AutoDeployed" : {
+          "shape" : "__boolean",
+          "locationName" : "autoDeployed"
+        },
+        "CreatedDate" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "createdDate"
+        },
+        "DeploymentId" : {
+          "shape" : "Id",
+          "locationName" : "deploymentId"
+        },
+        "DeploymentStatus" : {
+          "shape" : "DeploymentStatus",
+          "locationName" : "deploymentStatus"
+        },
+        "DeploymentStatusMessage" : {
+          "shape" : "__string",
+          "locationName" : "deploymentStatusMessage"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        }
+      }
+    },
+    "CreateDomainNameInput" : {
+      "type" : "structure",
+      "members" : {
+        "DomainName" : {
+          "shape" : "StringWithLengthBetween1And512",
+          "locationName" : "domainName"
+        },
+        "DomainNameConfigurations" : {
+          "shape" : "DomainNameConfigurations",
+          "locationName" : "domainNameConfigurations"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        }
+      },
+      "required" : [ "DomainName" ]
+    },
+    "CreateDomainNameRequest" : {
+      "type" : "structure",
+      "members" : {
+        "DomainName" : {
+          "shape" : "StringWithLengthBetween1And512",
+          "locationName" : "domainName"
+        },
+        "DomainNameConfigurations" : {
+          "shape" : "DomainNameConfigurations",
+          "locationName" : "domainNameConfigurations"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        }
+      },
+      "required" : [ "DomainName" ]
+    },
+    "CreateDomainNameResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ApiMappingSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "apiMappingSelectionExpression"
+        },
+        "DomainName" : {
+          "shape" : "StringWithLengthBetween1And512",
+          "locationName" : "domainName"
+        },
+        "DomainNameConfigurations" : {
+          "shape" : "DomainNameConfigurations",
+          "locationName" : "domainNameConfigurations"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        }
+      }
+    },
+    "CreateIntegrationInput" : {
+      "type" : "structure",
+      "members" : {
+        "ConnectionId" : {
+          "shape" : "StringWithLengthBetween1And1024",
+          "locationName" : "connectionId"
+        },
+        "ConnectionType" : {
+          "shape" : "ConnectionType",
+          "locationName" : "connectionType"
+        },
+        "ContentHandlingStrategy" : {
+          "shape" : "ContentHandlingStrategy",
+          "locationName" : "contentHandlingStrategy"
+        },
+        "CredentialsArn" : {
+          "shape" : "Arn",
+          "locationName" : "credentialsArn"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "IntegrationMethod" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "integrationMethod"
+        },
+        "IntegrationType" : {
+          "shape" : "IntegrationType",
+          "locationName" : "integrationType"
+        },
+        "IntegrationUri" : {
+          "shape" : "UriWithLengthBetween1And2048",
+          "locationName" : "integrationUri"
+        },
+        "PassthroughBehavior" : {
+          "shape" : "PassthroughBehavior",
+          "locationName" : "passthroughBehavior"
+        },
+        "PayloadFormatVersion" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "payloadFormatVersion"
+        },
+        "RequestParameters" : {
+          "shape" : "IntegrationParameters",
+          "locationName" : "requestParameters"
+        },
+        "RequestTemplates" : {
+          "shape" : "TemplateMap",
+          "locationName" : "requestTemplates"
+        },
+        "TemplateSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "templateSelectionExpression"
+        },
+        "TimeoutInMillis" : {
+          "shape" : "IntegerWithLengthBetween50And30000",
+          "locationName" : "timeoutInMillis"
+        },
+        "TlsConfig" : {
+          "shape" : "TlsConfigInput",
+          "locationName" : "tlsConfig"
+        }
+      },
+      "required" : [ "IntegrationType" ]
+    },
+    "CreateIntegrationRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "ConnectionId" : {
+          "shape" : "StringWithLengthBetween1And1024",
+          "locationName" : "connectionId"
+        },
+        "ConnectionType" : {
+          "shape" : "ConnectionType",
+          "locationName" : "connectionType"
+        },
+        "ContentHandlingStrategy" : {
+          "shape" : "ContentHandlingStrategy",
+          "locationName" : "contentHandlingStrategy"
+        },
+        "CredentialsArn" : {
+          "shape" : "Arn",
+          "locationName" : "credentialsArn"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "IntegrationMethod" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "integrationMethod"
+        },
+        "IntegrationType" : {
+          "shape" : "IntegrationType",
+          "locationName" : "integrationType"
+        },
+        "IntegrationUri" : {
+          "shape" : "UriWithLengthBetween1And2048",
+          "locationName" : "integrationUri"
+        },
+        "PassthroughBehavior" : {
+          "shape" : "PassthroughBehavior",
+          "locationName" : "passthroughBehavior"
+        },
+        "PayloadFormatVersion" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "payloadFormatVersion"
+        },
+        "RequestParameters" : {
+          "shape" : "IntegrationParameters",
+          "locationName" : "requestParameters"
+        },
+        "RequestTemplates" : {
+          "shape" : "TemplateMap",
+          "locationName" : "requestTemplates"
+        },
+        "TemplateSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "templateSelectionExpression"
+        },
+        "TimeoutInMillis" : {
+          "shape" : "IntegerWithLengthBetween50And30000",
+          "locationName" : "timeoutInMillis"
+        },
+        "TlsConfig" : {
+          "shape" : "TlsConfigInput",
+          "locationName" : "tlsConfig"
+        }
+      },
+      "required" : [ "ApiId", "IntegrationType" ]
+    },
+    "CreateIntegrationResult" : {
+      "type" : "structure",
+      "members" : {
+        "ApiGatewayManaged" : {
+          "shape" : "__boolean",
+          "locationName" : "apiGatewayManaged"
+        },
+        "ConnectionId" : {
+          "shape" : "StringWithLengthBetween1And1024",
+          "locationName" : "connectionId"
+        },
+        "ConnectionType" : {
+          "shape" : "ConnectionType",
+          "locationName" : "connectionType"
+        },
+        "ContentHandlingStrategy" : {
+          "shape" : "ContentHandlingStrategy",
+          "locationName" : "contentHandlingStrategy"
+        },
+        "CredentialsArn" : {
+          "shape" : "Arn",
+          "locationName" : "credentialsArn"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "IntegrationId" : {
+          "shape" : "Id",
+          "locationName" : "integrationId"
+        },
+        "IntegrationMethod" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "integrationMethod"
+        },
+        "IntegrationResponseSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "integrationResponseSelectionExpression"
+        },
+        "IntegrationType" : {
+          "shape" : "IntegrationType",
+          "locationName" : "integrationType"
+        },
+        "IntegrationUri" : {
+          "shape" : "UriWithLengthBetween1And2048",
+          "locationName" : "integrationUri"
+        },
+        "PassthroughBehavior" : {
+          "shape" : "PassthroughBehavior",
+          "locationName" : "passthroughBehavior"
+        },
+        "PayloadFormatVersion" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "payloadFormatVersion"
+        },
+        "RequestParameters" : {
+          "shape" : "IntegrationParameters",
+          "locationName" : "requestParameters"
+        },
+        "RequestTemplates" : {
+          "shape" : "TemplateMap",
+          "locationName" : "requestTemplates"
+        },
+        "TemplateSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "templateSelectionExpression"
+        },
+        "TimeoutInMillis" : {
+          "shape" : "IntegerWithLengthBetween50And30000",
+          "locationName" : "timeoutInMillis"
+        },
+        "TlsConfig" : {
+          "shape" : "TlsConfig",
+          "locationName" : "tlsConfig"
+        }
+      }
+    },
+    "CreateIntegrationResponseInput" : {
+      "type" : "structure",
+      "members" : {
+        "ContentHandlingStrategy" : {
+          "shape" : "ContentHandlingStrategy",
+          "locationName" : "contentHandlingStrategy"
+        },
+        "IntegrationResponseKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "integrationResponseKey"
+        },
+        "ResponseParameters" : {
+          "shape" : "IntegrationParameters",
+          "locationName" : "responseParameters"
+        },
+        "ResponseTemplates" : {
+          "shape" : "TemplateMap",
+          "locationName" : "responseTemplates"
+        },
+        "TemplateSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "templateSelectionExpression"
+        }
+      },
+      "required" : [ "IntegrationResponseKey" ]
+    },
+    "CreateIntegrationResponseRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "ContentHandlingStrategy" : {
+          "shape" : "ContentHandlingStrategy",
+          "locationName" : "contentHandlingStrategy"
+        },
+        "IntegrationId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "integrationId"
+        },
+        "IntegrationResponseKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "integrationResponseKey"
+        },
+        "ResponseParameters" : {
+          "shape" : "IntegrationParameters",
+          "locationName" : "responseParameters"
+        },
+        "ResponseTemplates" : {
+          "shape" : "TemplateMap",
+          "locationName" : "responseTemplates"
+        },
+        "TemplateSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "templateSelectionExpression"
+        }
+      },
+      "required" : [ "ApiId", "IntegrationId", "IntegrationResponseKey" ]
+    },
+    "CreateIntegrationResponseResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ContentHandlingStrategy" : {
+          "shape" : "ContentHandlingStrategy",
+          "locationName" : "contentHandlingStrategy"
+        },
+        "IntegrationResponseId" : {
+          "shape" : "Id",
+          "locationName" : "integrationResponseId"
+        },
+        "IntegrationResponseKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "integrationResponseKey"
+        },
+        "ResponseParameters" : {
+          "shape" : "IntegrationParameters",
+          "locationName" : "responseParameters"
+        },
+        "ResponseTemplates" : {
+          "shape" : "TemplateMap",
+          "locationName" : "responseTemplates"
+        },
+        "TemplateSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "templateSelectionExpression"
+        }
+      }
+    },
+    "CreateModelInput" : {
+      "type" : "structure",
+      "members" : {
+        "ContentType" : {
+          "shape" : "StringWithLengthBetween1And256",
+          "locationName" : "contentType"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "Schema" : {
+          "shape" : "StringWithLengthBetween0And32K",
+          "locationName" : "schema"
+        }
+      },
+      "required" : [ "Schema", "Name" ]
+    },
+    "CreateModelRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "ContentType" : {
+          "shape" : "StringWithLengthBetween1And256",
+          "locationName" : "contentType"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "Schema" : {
+          "shape" : "StringWithLengthBetween0And32K",
+          "locationName" : "schema"
+        }
+      },
+      "required" : [ "ApiId", "Schema", "Name" ]
+    },
+    "CreateModelResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ContentType" : {
+          "shape" : "StringWithLengthBetween1And256",
+          "locationName" : "contentType"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "ModelId" : {
+          "shape" : "Id",
+          "locationName" : "modelId"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "Schema" : {
+          "shape" : "StringWithLengthBetween0And32K",
+          "locationName" : "schema"
+        }
+      }
+    },
+    "CreateRouteInput" : {
+      "type" : "structure",
+      "members" : {
+        "ApiKeyRequired" : {
+          "shape" : "__boolean",
+          "locationName" : "apiKeyRequired"
+        },
+        "AuthorizationScopes" : {
+          "shape" : "AuthorizationScopes",
+          "locationName" : "authorizationScopes"
+        },
+        "AuthorizationType" : {
+          "shape" : "AuthorizationType",
+          "locationName" : "authorizationType"
+        },
+        "AuthorizerId" : {
+          "shape" : "Id",
+          "locationName" : "authorizerId"
+        },
+        "ModelSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "modelSelectionExpression"
+        },
+        "OperationName" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "operationName"
+        },
+        "RequestModels" : {
+          "shape" : "RouteModels",
+          "locationName" : "requestModels"
+        },
+        "RequestParameters" : {
+          "shape" : "RouteParameters",
+          "locationName" : "requestParameters"
+        },
+        "RouteKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "routeKey"
+        },
+        "RouteResponseSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "routeResponseSelectionExpression"
+        },
+        "Target" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "target"
+        }
+      },
+      "required" : [ "RouteKey" ]
+    },
+    "CreateRouteRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "ApiKeyRequired" : {
+          "shape" : "__boolean",
+          "locationName" : "apiKeyRequired"
+        },
+        "AuthorizationScopes" : {
+          "shape" : "AuthorizationScopes",
+          "locationName" : "authorizationScopes"
+        },
+        "AuthorizationType" : {
+          "shape" : "AuthorizationType",
+          "locationName" : "authorizationType"
+        },
+        "AuthorizerId" : {
+          "shape" : "Id",
+          "locationName" : "authorizerId"
+        },
+        "ModelSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "modelSelectionExpression"
+        },
+        "OperationName" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "operationName"
+        },
+        "RequestModels" : {
+          "shape" : "RouteModels",
+          "locationName" : "requestModels"
+        },
+        "RequestParameters" : {
+          "shape" : "RouteParameters",
+          "locationName" : "requestParameters"
+        },
+        "RouteKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "routeKey"
+        },
+        "RouteResponseSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "routeResponseSelectionExpression"
+        },
+        "Target" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "target"
+        }
+      },
+      "required" : [ "ApiId", "RouteKey" ]
+    },
+    "CreateRouteResult" : {
+      "type" : "structure",
+      "members" : {
+        "ApiGatewayManaged" : {
+          "shape" : "__boolean",
+          "locationName" : "apiGatewayManaged"
+        },
+        "ApiKeyRequired" : {
+          "shape" : "__boolean",
+          "locationName" : "apiKeyRequired"
+        },
+        "AuthorizationScopes" : {
+          "shape" : "AuthorizationScopes",
+          "locationName" : "authorizationScopes"
+        },
+        "AuthorizationType" : {
+          "shape" : "AuthorizationType",
+          "locationName" : "authorizationType"
+        },
+        "AuthorizerId" : {
+          "shape" : "Id",
+          "locationName" : "authorizerId"
+        },
+        "ModelSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "modelSelectionExpression"
+        },
+        "OperationName" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "operationName"
+        },
+        "RequestModels" : {
+          "shape" : "RouteModels",
+          "locationName" : "requestModels"
+        },
+        "RequestParameters" : {
+          "shape" : "RouteParameters",
+          "locationName" : "requestParameters"
+        },
+        "RouteId" : {
+          "shape" : "Id",
+          "locationName" : "routeId"
+        },
+        "RouteKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "routeKey"
+        },
+        "RouteResponseSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "routeResponseSelectionExpression"
+        },
+        "Target" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "target"
+        }
+      }
+    },
+    "CreateRouteResponseInput" : {
+      "type" : "structure",
+      "members" : {
+        "ModelSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "modelSelectionExpression"
+        },
+        "ResponseModels" : {
+          "shape" : "RouteModels",
+          "locationName" : "responseModels"
+        },
+        "ResponseParameters" : {
+          "shape" : "RouteParameters",
+          "locationName" : "responseParameters"
+        },
+        "RouteResponseKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "routeResponseKey"
+        }
+      },
+      "required" : [ "RouteResponseKey" ]
+    },
+    "CreateRouteResponseRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "ModelSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "modelSelectionExpression"
+        },
+        "ResponseModels" : {
+          "shape" : "RouteModels",
+          "locationName" : "responseModels"
+        },
+        "ResponseParameters" : {
+          "shape" : "RouteParameters",
+          "locationName" : "responseParameters"
+        },
+        "RouteId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "routeId"
+        },
+        "RouteResponseKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "routeResponseKey"
+        }
+      },
+      "required" : [ "ApiId", "RouteId", "RouteResponseKey" ]
+    },
+    "CreateRouteResponseResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ModelSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "modelSelectionExpression"
+        },
+        "ResponseModels" : {
+          "shape" : "RouteModels",
+          "locationName" : "responseModels"
+        },
+        "ResponseParameters" : {
+          "shape" : "RouteParameters",
+          "locationName" : "responseParameters"
+        },
+        "RouteResponseId" : {
+          "shape" : "Id",
+          "locationName" : "routeResponseId"
+        },
+        "RouteResponseKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "routeResponseKey"
+        }
+      }
+    },
+    "CreateStageInput" : {
+      "type" : "structure",
+      "members" : {
+        "AccessLogSettings" : {
+          "shape" : "AccessLogSettings",
+          "locationName" : "accessLogSettings"
+        },
+        "AutoDeploy" : {
+          "shape" : "__boolean",
+          "locationName" : "autoDeploy"
+        },
+        "ClientCertificateId" : {
+          "shape" : "Id",
+          "locationName" : "clientCertificateId"
+        },
+        "DefaultRouteSettings" : {
+          "shape" : "RouteSettings",
+          "locationName" : "defaultRouteSettings"
+        },
+        "DeploymentId" : {
+          "shape" : "Id",
+          "locationName" : "deploymentId"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "RouteSettings" : {
+          "shape" : "RouteSettingsMap",
+          "locationName" : "routeSettings"
+        },
+        "StageName" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "stageName"
+        },
+        "StageVariables" : {
+          "shape" : "StageVariablesMap",
+          "locationName" : "stageVariables"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        }
+      },
+      "required" : [ "StageName" ]
+    },
+    "CreateStageRequest" : {
+      "type" : "structure",
+      "members" : {
+        "AccessLogSettings" : {
+          "shape" : "AccessLogSettings",
+          "locationName" : "accessLogSettings"
+        },
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "AutoDeploy" : {
+          "shape" : "__boolean",
+          "locationName" : "autoDeploy"
+        },
+        "ClientCertificateId" : {
+          "shape" : "Id",
+          "locationName" : "clientCertificateId"
+        },
+        "DefaultRouteSettings" : {
+          "shape" : "RouteSettings",
+          "locationName" : "defaultRouteSettings"
+        },
+        "DeploymentId" : {
+          "shape" : "Id",
+          "locationName" : "deploymentId"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "RouteSettings" : {
+          "shape" : "RouteSettingsMap",
+          "locationName" : "routeSettings"
+        },
+        "StageName" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "stageName"
+        },
+        "StageVariables" : {
+          "shape" : "StageVariablesMap",
+          "locationName" : "stageVariables"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        }
+      },
+      "required" : [ "ApiId", "StageName" ]
+    },
+    "CreateStageResponse" : {
+      "type" : "structure",
+      "members" : {
+        "AccessLogSettings" : {
+          "shape" : "AccessLogSettings",
+          "locationName" : "accessLogSettings"
+        },
+        "ApiGatewayManaged" : {
+          "shape" : "__boolean",
+          "locationName" : "apiGatewayManaged"
+        },
+        "AutoDeploy" : {
+          "shape" : "__boolean",
+          "locationName" : "autoDeploy"
+        },
+        "ClientCertificateId" : {
+          "shape" : "Id",
+          "locationName" : "clientCertificateId"
+        },
+        "CreatedDate" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "createdDate"
+        },
+        "DefaultRouteSettings" : {
+          "shape" : "RouteSettings",
+          "locationName" : "defaultRouteSettings"
+        },
+        "DeploymentId" : {
+          "shape" : "Id",
+          "locationName" : "deploymentId"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "LastDeploymentStatusMessage" : {
+          "shape" : "__string",
+          "locationName" : "lastDeploymentStatusMessage"
+        },
+        "LastUpdatedDate" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "lastUpdatedDate"
+        },
+        "RouteSettings" : {
+          "shape" : "RouteSettingsMap",
+          "locationName" : "routeSettings"
+        },
+        "StageName" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "stageName"
+        },
+        "StageVariables" : {
+          "shape" : "StageVariablesMap",
+          "locationName" : "stageVariables"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        }
+      }
+    },
+    "CreateVpcLinkInput" : {
+      "type" : "structure",
+      "members" : {
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "SecurityGroupIds" : {
+          "shape" : "SecurityGroupIdList",
+          "locationName" : "securityGroupIds"
+        },
+        "SubnetIds" : {
+          "shape" : "SubnetIdList",
+          "locationName" : "subnetIds"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        }
+      },
+      "required" : [ "SubnetIds", "Name" ]
+    },
+    "CreateVpcLinkRequest" : {
+      "type" : "structure",
+      "members" : {
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "SecurityGroupIds" : {
+          "shape" : "SecurityGroupIdList",
+          "locationName" : "securityGroupIds"
+        },
+        "SubnetIds" : {
+          "shape" : "SubnetIdList",
+          "locationName" : "subnetIds"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        }
+      },
+      "required" : [ "SubnetIds", "Name" ]
+    },
+    "CreateVpcLinkResponse" : {
+      "type" : "structure",
+      "members" : {
+        "CreatedDate" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "createdDate"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "SecurityGroupIds" : {
+          "shape" : "SecurityGroupIdList",
+          "locationName" : "securityGroupIds"
+        },
+        "SubnetIds" : {
+          "shape" : "SubnetIdList",
+          "locationName" : "subnetIds"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        },
+        "VpcLinkId" : {
+          "shape" : "Id",
+          "locationName" : "vpcLinkId"
+        },
+        "VpcLinkStatus" : {
+          "shape" : "VpcLinkStatus",
+          "locationName" : "vpcLinkStatus"
+        },
+        "VpcLinkStatusMessage" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "vpcLinkStatusMessage"
+        },
+        "VpcLinkVersion" : {
+          "shape" : "VpcLinkVersion",
+          "locationName" : "vpcLinkVersion"
+        }
+      }
+    },
+    "DeleteAccessLogSettingsRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "StageName" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "stageName"
+        }
+      },
+      "required" : [ "StageName", "ApiId" ]
+    },
+    "DeleteApiMappingRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiMappingId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiMappingId"
+        },
+        "DomainName" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "domainName"
+        }
+      },
+      "required" : [ "ApiMappingId", "DomainName" ]
+    },
+    "DeleteApiRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        }
+      },
+      "required" : [ "ApiId" ]
+    },
+    "DeleteAuthorizerRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "AuthorizerId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "authorizerId"
+        }
+      },
+      "required" : [ "AuthorizerId", "ApiId" ]
+    },
+    "DeleteCorsConfigurationRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        }
+      },
+      "required" : [ "ApiId" ]
+    },
+    "DeleteDeploymentRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "DeploymentId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "deploymentId"
+        }
+      },
+      "required" : [ "ApiId", "DeploymentId" ]
+    },
+    "DeleteDomainNameRequest" : {
+      "type" : "structure",
+      "members" : {
+        "DomainName" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "domainName"
+        }
+      },
+      "required" : [ "DomainName" ]
+    },
+    "DeleteIntegrationRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "IntegrationId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "integrationId"
+        }
+      },
+      "required" : [ "ApiId", "IntegrationId" ]
+    },
+    "DeleteIntegrationResponseRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "IntegrationId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "integrationId"
+        },
+        "IntegrationResponseId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "integrationResponseId"
+        }
+      },
+      "required" : [ "ApiId", "IntegrationResponseId", "IntegrationId" ]
+    },
+    "DeleteModelRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "ModelId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "modelId"
+        }
+      },
+      "required" : [ "ModelId", "ApiId" ]
+    },
+    "DeleteRouteRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "RouteId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "routeId"
+        }
+      },
+      "required" : [ "ApiId", "RouteId" ]
+    },
+    "DeleteRouteRequestParameterRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "RequestParameterKey" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "requestParameterKey"
+        },
+        "RouteId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "routeId"
+        }
+      },
+      "required" : [ "RequestParameterKey", "ApiId", "RouteId" ]
+    },
+    "DeleteRouteResponseRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "RouteId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "routeId"
+        },
+        "RouteResponseId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "routeResponseId"
+        }
+      },
+      "required" : [ "RouteResponseId", "ApiId", "RouteId" ]
+    },
+    "DeleteRouteSettingsRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "RouteKey" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "routeKey"
+        },
+        "StageName" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "stageName"
+        }
+      },
+      "required" : [ "StageName", "RouteKey", "ApiId" ]
+    },
+    "DeleteStageRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "StageName" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "stageName"
+        }
+      },
+      "required" : [ "StageName", "ApiId" ]
+    },
+    "DeleteVpcLinkRequest" : {
+      "type" : "structure",
+      "members" : {
+        "VpcLinkId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "vpcLinkId"
+        }
+      },
+      "required" : [ "VpcLinkId" ]
+    },
+    "DeleteVpcLinkResponse" : {
+      "type" : "structure",
+      "members" : { }
+    },
+    "Deployment" : {
+      "type" : "structure",
+      "members" : {
+        "AutoDeployed" : {
+          "shape" : "__boolean",
+          "locationName" : "autoDeployed"
+        },
+        "CreatedDate" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "createdDate"
+        },
+        "DeploymentId" : {
+          "shape" : "Id",
+          "locationName" : "deploymentId"
+        },
+        "DeploymentStatus" : {
+          "shape" : "DeploymentStatus",
+          "locationName" : "deploymentStatus"
+        },
+        "DeploymentStatusMessage" : {
+          "shape" : "__string",
+          "locationName" : "deploymentStatusMessage"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        }
+      }
+    },
+    "DeploymentStatus" : {
+      "type" : "string",
+      "enum" : [ "PENDING", "FAILED", "DEPLOYED" ]
+    },
+    "Deployments" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfDeployment",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "DomainName" : {
+      "type" : "structure",
+      "members" : {
+        "ApiMappingSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "apiMappingSelectionExpression"
+        },
+        "DomainName" : {
+          "shape" : "StringWithLengthBetween1And512",
+          "locationName" : "domainName"
+        },
+        "DomainNameConfigurations" : {
+          "shape" : "DomainNameConfigurations",
+          "locationName" : "domainNameConfigurations"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        }
+      },
+      "required" : [ "DomainName" ]
+    },
+    "DomainNameConfiguration" : {
+      "type" : "structure",
+      "members" : {
+        "ApiGatewayDomainName" : {
+          "shape" : "__string",
+          "locationName" : "apiGatewayDomainName"
+        },
+        "CertificateArn" : {
+          "shape" : "Arn",
+          "locationName" : "certificateArn"
+        },
+        "CertificateName" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "certificateName"
+        },
+        "CertificateUploadDate" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "certificateUploadDate"
+        },
+        "DomainNameStatus" : {
+          "shape" : "DomainNameStatus",
+          "locationName" : "domainNameStatus"
+        },
+        "DomainNameStatusMessage" : {
+          "shape" : "__string",
+          "locationName" : "domainNameStatusMessage"
+        },
+        "EndpointType" : {
+          "shape" : "EndpointType",
+          "locationName" : "endpointType"
+        },
+        "HostedZoneId" : {
+          "shape" : "__string",
+          "locationName" : "hostedZoneId"
+        },
+        "SecurityPolicy" : {
+          "shape" : "SecurityPolicy",
+          "locationName" : "securityPolicy"
+        }
+      }
+    },
+    "DomainNameConfigurations" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "DomainNameConfiguration"
+      }
+    },
+    "DomainNameStatus" : {
+      "type" : "string",
+      "enum" : [ "AVAILABLE", "UPDATING" ]
+    },
+    "DomainNames" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfDomainName",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "EndpointType" : {
+      "type" : "string",
+      "enum" : [ "REGIONAL", "EDGE" ]
+    },
+    "ExportApiRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "ExportVersion" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "exportVersion"
+        },
+        "IncludeExtensions" : {
+          "shape" : "__boolean",
+          "location" : "querystring",
+          "locationName" : "includeExtensions"
+        },
+        "OutputType" : {
+          "shape" : "__string",
+          "enum" : ["YAML", "JSON"],
+          "location" : "querystring",
+          "locationName" : "outputType"
+        },
+        "Specification" : {
+          "shape" : "__string",
+          "enum" : ["OAS30"],
+          "location" : "uri",
+          "locationName" : "specification"
+        },
+        "StageName" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "stageName"
+        }
+      },
+      "required" : [ "Specification", "OutputType", "ApiId" ]
+    },
+    "ExportApiResponse" : {
+      "type" : "structure",
+      "members" : { 
+        "body":{
+          "shape":"ExportedApi"
+        }
+      },
+      "payload":"body"
+    },
+    "ExportedApi" : {
+      "type" : "blob"
+    },
+    "GetApiMappingRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiMappingId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiMappingId"
+        },
+        "DomainName" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "domainName"
+        }
+      },
+      "required" : [ "ApiMappingId", "DomainName" ]
+    },
+    "GetApiMappingResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "Id",
+          "locationName" : "apiId"
+        },
+        "ApiMappingId" : {
+          "shape" : "Id",
+          "locationName" : "apiMappingId"
+        },
+        "ApiMappingKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "apiMappingKey"
+        },
+        "Stage" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "stage"
+        }
+      }
+    },
+    "GetApiMappingsRequest" : {
+      "type" : "structure",
+      "members" : {
+        "DomainName" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "domainName"
+        },
+        "MaxResults" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "nextToken"
+        }
+      },
+      "required" : [ "DomainName" ]
+    },
+    "GetApiMappingsResponse" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfApiMapping",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "GetApiRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        }
+      },
+      "required" : [ "ApiId" ]
+    },
+    "GetApiResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ApiEndpoint" : {
+          "shape" : "__string",
+          "locationName" : "apiEndpoint"
+        },
+        "ApiId" : {
+          "shape" : "Id",
+          "locationName" : "apiId"
+        },
+        "ApiKeySelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "apiKeySelectionExpression"
+        },
+        "CorsConfiguration" : {
+          "shape" : "Cors",
+          "locationName" : "corsConfiguration"
+        },
+        "CreatedDate" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "createdDate"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "DisableSchemaValidation" : {
+          "shape" : "__boolean",
+          "locationName" : "disableSchemaValidation"
+        },
+        "ImportInfo" : {
+          "shape" : "__listOf__string",
+          "locationName" : "importInfo"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "ProtocolType" : {
+          "shape" : "ProtocolType",
+          "locationName" : "protocolType"
+        },
+        "RouteSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "routeSelectionExpression"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        },
+        "Version" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "version"
+        },
+        "Warnings" : {
+          "shape" : "__listOf__string",
+          "locationName" : "warnings"
+        }
+      }
+    },
+    "GetApisRequest" : {
+      "type" : "structure",
+      "members" : {
+        "MaxResults" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "GetApisResponse" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfApi",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "GetAuthorizerRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "AuthorizerId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "authorizerId"
+        }
+      },
+      "required" : [ "AuthorizerId", "ApiId" ]
+    },
+    "GetAuthorizerResponse" : {
+      "type" : "structure",
+      "members" : {
+        "AuthorizerCredentialsArn" : {
+          "shape" : "Arn",
+          "locationName" : "authorizerCredentialsArn"
+        },
+        "AuthorizerId" : {
+          "shape" : "Id",
+          "locationName" : "authorizerId"
+        },
+        "AuthorizerResultTtlInSeconds" : {
+          "shape" : "IntegerWithLengthBetween0And3600",
+          "locationName" : "authorizerResultTtlInSeconds"
+        },
+        "AuthorizerType" : {
+          "shape" : "AuthorizerType",
+          "locationName" : "authorizerType"
+        },
+        "AuthorizerUri" : {
+          "shape" : "UriWithLengthBetween1And2048",
+          "locationName" : "authorizerUri"
+        },
+        "IdentitySource" : {
+          "shape" : "IdentitySourceList",
+          "locationName" : "identitySource"
+        },
+        "IdentityValidationExpression" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "identityValidationExpression"
+        },
+        "JwtConfiguration" : {
+          "shape" : "JWTConfiguration",
+          "locationName" : "jwtConfiguration"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        }
+      }
+    },
+    "GetAuthorizersRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "MaxResults" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "nextToken"
+        }
+      },
+      "required" : [ "ApiId" ]
+    },
+    "GetAuthorizersResponse" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfAuthorizer",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "GetDeploymentRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "DeploymentId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "deploymentId"
+        }
+      },
+      "required" : [ "ApiId", "DeploymentId" ]
+    },
+    "GetDeploymentResponse" : {
+      "type" : "structure",
+      "members" : {
+        "AutoDeployed" : {
+          "shape" : "__boolean",
+          "locationName" : "autoDeployed"
+        },
+        "CreatedDate" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "createdDate"
+        },
+        "DeploymentId" : {
+          "shape" : "Id",
+          "locationName" : "deploymentId"
+        },
+        "DeploymentStatus" : {
+          "shape" : "DeploymentStatus",
+          "locationName" : "deploymentStatus"
+        },
+        "DeploymentStatusMessage" : {
+          "shape" : "__string",
+          "locationName" : "deploymentStatusMessage"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        }
+      }
+    },
+    "GetDeploymentsRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "MaxResults" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "nextToken"
+        }
+      },
+      "required" : [ "ApiId" ]
+    },
+    "GetDeploymentsResponse" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfDeployment",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "GetDomainNameRequest" : {
+      "type" : "structure",
+      "members" : {
+        "DomainName" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "domainName"
+        }
+      },
+      "required" : [ "DomainName" ]
+    },
+    "GetDomainNameResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ApiMappingSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "apiMappingSelectionExpression"
+        },
+        "DomainName" : {
+          "shape" : "StringWithLengthBetween1And512",
+          "locationName" : "domainName"
+        },
+        "DomainNameConfigurations" : {
+          "shape" : "DomainNameConfigurations",
+          "locationName" : "domainNameConfigurations"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        }
+      }
+    },
+    "GetDomainNamesRequest" : {
+      "type" : "structure",
+      "members" : {
+        "MaxResults" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "GetDomainNamesResponse" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfDomainName",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "GetIntegrationRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "IntegrationId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "integrationId"
+        }
+      },
+      "required" : [ "ApiId", "IntegrationId" ]
+    },
+    "GetIntegrationResult" : {
+      "type" : "structure",
+      "members" : {
+        "ApiGatewayManaged" : {
+          "shape" : "__boolean",
+          "locationName" : "apiGatewayManaged"
+        },
+        "ConnectionId" : {
+          "shape" : "StringWithLengthBetween1And1024",
+          "locationName" : "connectionId"
+        },
+        "ConnectionType" : {
+          "shape" : "ConnectionType",
+          "locationName" : "connectionType"
+        },
+        "ContentHandlingStrategy" : {
+          "shape" : "ContentHandlingStrategy",
+          "locationName" : "contentHandlingStrategy"
+        },
+        "CredentialsArn" : {
+          "shape" : "Arn",
+          "locationName" : "credentialsArn"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "IntegrationId" : {
+          "shape" : "Id",
+          "locationName" : "integrationId"
+        },
+        "IntegrationMethod" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "integrationMethod"
+        },
+        "IntegrationResponseSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "integrationResponseSelectionExpression"
+        },
+        "IntegrationType" : {
+          "shape" : "IntegrationType",
+          "locationName" : "integrationType"
+        },
+        "IntegrationUri" : {
+          "shape" : "UriWithLengthBetween1And2048",
+          "locationName" : "integrationUri"
+        },
+        "PassthroughBehavior" : {
+          "shape" : "PassthroughBehavior",
+          "locationName" : "passthroughBehavior"
+        },
+        "PayloadFormatVersion" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "payloadFormatVersion"
+        },
+        "RequestParameters" : {
+          "shape" : "IntegrationParameters",
+          "locationName" : "requestParameters"
+        },
+        "RequestTemplates" : {
+          "shape" : "TemplateMap",
+          "locationName" : "requestTemplates"
+        },
+        "TemplateSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "templateSelectionExpression"
+        },
+        "TimeoutInMillis" : {
+          "shape" : "IntegerWithLengthBetween50And30000",
+          "locationName" : "timeoutInMillis"
+        },
+        "TlsConfig" : {
+          "shape" : "TlsConfig",
+          "locationName" : "tlsConfig"
+        }
+      }
+    },
+    "GetIntegrationResponseRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "IntegrationId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "integrationId"
+        },
+        "IntegrationResponseId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "integrationResponseId"
+        }
+      },
+      "required" : [ "ApiId", "IntegrationResponseId", "IntegrationId" ]
+    },
+    "GetIntegrationResponseResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ContentHandlingStrategy" : {
+          "shape" : "ContentHandlingStrategy",
+          "locationName" : "contentHandlingStrategy"
+        },
+        "IntegrationResponseId" : {
+          "shape" : "Id",
+          "locationName" : "integrationResponseId"
+        },
+        "IntegrationResponseKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "integrationResponseKey"
+        },
+        "ResponseParameters" : {
+          "shape" : "IntegrationParameters",
+          "locationName" : "responseParameters"
+        },
+        "ResponseTemplates" : {
+          "shape" : "TemplateMap",
+          "locationName" : "responseTemplates"
+        },
+        "TemplateSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "templateSelectionExpression"
+        }
+      }
+    },
+    "GetIntegrationResponsesRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "IntegrationId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "integrationId"
+        },
+        "MaxResults" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "nextToken"
+        }
+      },
+      "required" : [ "IntegrationId", "ApiId" ]
+    },
+    "GetIntegrationResponsesResponse" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfIntegrationResponse",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "GetIntegrationsRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "MaxResults" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "nextToken"
+        }
+      },
+      "required" : [ "ApiId" ]
+    },
+    "GetIntegrationsResponse" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfIntegration",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "GetModelRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "ModelId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "modelId"
+        }
+      },
+      "required" : [ "ModelId", "ApiId" ]
+    },
+    "GetModelResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ContentType" : {
+          "shape" : "StringWithLengthBetween1And256",
+          "locationName" : "contentType"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "ModelId" : {
+          "shape" : "Id",
+          "locationName" : "modelId"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "Schema" : {
+          "shape" : "StringWithLengthBetween0And32K",
+          "locationName" : "schema"
+        }
+      }
+    },
+    "GetModelTemplateRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "ModelId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "modelId"
+        }
+      },
+      "required" : [ "ModelId", "ApiId" ]
+    },
+    "GetModelTemplateResponse" : {
+      "type" : "structure",
+      "members" : {
+        "Value" : {
+          "shape" : "__string",
+          "locationName" : "value"
+        }
+      }
+    },
+    "GetModelsRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "MaxResults" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "nextToken"
+        }
+      },
+      "required" : [ "ApiId" ]
+    },
+    "GetModelsResponse" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfModel",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "GetRouteRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "RouteId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "routeId"
+        }
+      },
+      "required" : [ "ApiId", "RouteId" ]
+    },
+    "GetRouteResult" : {
+      "type" : "structure",
+      "members" : {
+        "ApiGatewayManaged" : {
+          "shape" : "__boolean",
+          "locationName" : "apiGatewayManaged"
+        },
+        "ApiKeyRequired" : {
+          "shape" : "__boolean",
+          "locationName" : "apiKeyRequired"
+        },
+        "AuthorizationScopes" : {
+          "shape" : "AuthorizationScopes",
+          "locationName" : "authorizationScopes"
+        },
+        "AuthorizationType" : {
+          "shape" : "AuthorizationType",
+          "locationName" : "authorizationType"
+        },
+        "AuthorizerId" : {
+          "shape" : "Id",
+          "locationName" : "authorizerId"
+        },
+        "ModelSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "modelSelectionExpression"
+        },
+        "OperationName" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "operationName"
+        },
+        "RequestModels" : {
+          "shape" : "RouteModels",
+          "locationName" : "requestModels"
+        },
+        "RequestParameters" : {
+          "shape" : "RouteParameters",
+          "locationName" : "requestParameters"
+        },
+        "RouteId" : {
+          "shape" : "Id",
+          "locationName" : "routeId"
+        },
+        "RouteKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "routeKey"
+        },
+        "RouteResponseSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "routeResponseSelectionExpression"
+        },
+        "Target" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "target"
+        }
+      }
+    },
+    "GetRouteResponseRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "RouteId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "routeId"
+        },
+        "RouteResponseId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "routeResponseId"
+        }
+      },
+      "required" : [ "RouteResponseId", "ApiId", "RouteId" ]
+    },
+    "GetRouteResponseResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ModelSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "modelSelectionExpression"
+        },
+        "ResponseModels" : {
+          "shape" : "RouteModels",
+          "locationName" : "responseModels"
+        },
+        "ResponseParameters" : {
+          "shape" : "RouteParameters",
+          "locationName" : "responseParameters"
+        },
+        "RouteResponseId" : {
+          "shape" : "Id",
+          "locationName" : "routeResponseId"
+        },
+        "RouteResponseKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "routeResponseKey"
+        }
+      }
+    },
+    "GetRouteResponsesRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "MaxResults" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "nextToken"
+        },
+        "RouteId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "routeId"
+        }
+      },
+      "required" : [ "RouteId", "ApiId" ]
+    },
+    "GetRouteResponsesResponse" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfRouteResponse",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "GetRoutesRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "MaxResults" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "nextToken"
+        }
+      },
+      "required" : [ "ApiId" ]
+    },
+    "GetRoutesResponse" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfRoute",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "GetStageRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "StageName" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "stageName"
+        }
+      },
+      "required" : [ "StageName", "ApiId" ]
+    },
+    "GetStageResponse" : {
+      "type" : "structure",
+      "members" : {
+        "AccessLogSettings" : {
+          "shape" : "AccessLogSettings",
+          "locationName" : "accessLogSettings"
+        },
+        "ApiGatewayManaged" : {
+          "shape" : "__boolean",
+          "locationName" : "apiGatewayManaged"
+        },
+        "AutoDeploy" : {
+          "shape" : "__boolean",
+          "locationName" : "autoDeploy"
+        },
+        "ClientCertificateId" : {
+          "shape" : "Id",
+          "locationName" : "clientCertificateId"
+        },
+        "CreatedDate" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "createdDate"
+        },
+        "DefaultRouteSettings" : {
+          "shape" : "RouteSettings",
+          "locationName" : "defaultRouteSettings"
+        },
+        "DeploymentId" : {
+          "shape" : "Id",
+          "locationName" : "deploymentId"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "LastDeploymentStatusMessage" : {
+          "shape" : "__string",
+          "locationName" : "lastDeploymentStatusMessage"
+        },
+        "LastUpdatedDate" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "lastUpdatedDate"
+        },
+        "RouteSettings" : {
+          "shape" : "RouteSettingsMap",
+          "locationName" : "routeSettings"
+        },
+        "StageName" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "stageName"
+        },
+        "StageVariables" : {
+          "shape" : "StageVariablesMap",
+          "locationName" : "stageVariables"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        }
+      }
+    },
+    "GetStagesRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "MaxResults" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "nextToken"
+        }
+      },
+      "required" : [ "ApiId" ]
+    },
+    "GetStagesResponse" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfStage",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "GetTagsRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ResourceArn" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "resource-arn"
+        }
+      },
+      "required" : [ "ResourceArn" ]
+    },
+    "GetTagsResponse" : {
+      "type" : "structure",
+      "members" : {
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName": "tags"
+        }
+      }
+    },
+    "GetVpcLinkRequest" : {
+      "type" : "structure",
+      "members" : {
+        "VpcLinkId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "vpcLinkId"
+        }
+      },
+      "required" : [ "VpcLinkId" ]
+    },
+    "GetVpcLinkResponse" : {
+      "type" : "structure",
+      "members" : {
+        "CreatedDate" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "createdDate"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "SecurityGroupIds" : {
+          "shape" : "SecurityGroupIdList",
+          "locationName" : "securityGroupIds"
+        },
+        "SubnetIds" : {
+          "shape" : "SubnetIdList",
+          "locationName" : "subnetIds"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        },
+        "VpcLinkId" : {
+          "shape" : "Id",
+          "locationName" : "vpcLinkId"
+        },
+        "VpcLinkStatus" : {
+          "shape" : "VpcLinkStatus",
+          "locationName" : "vpcLinkStatus"
+        },
+        "VpcLinkStatusMessage" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "vpcLinkStatusMessage"
+        },
+        "VpcLinkVersion" : {
+          "shape" : "VpcLinkVersion",
+          "locationName" : "vpcLinkVersion"
+        }
+      }
+    },
+    "GetVpcLinksRequest" : {
+      "type" : "structure",
+      "members" : {
+        "MaxResults" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "maxResults"
+        },
+        "NextToken" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "GetVpcLinksResponse" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfVpcLink",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "Id" : {
+      "type" : "string"
+    },
+    "IdentitySourceList" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "__string"
+      }
+    },
+    "ImportApiInput" : {
+      "type" : "structure",
+      "members" : {
+        "Body" : {
+          "shape" : "__string",
+          "locationName" : "body"
+        }
+      },
+      "required" : [ "Body" ]
+    },
+    "ImportApiRequest" : {
+      "type" : "structure",
+      "members" : {
+        "Basepath" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "basepath"
+        },
+        "Body" : {
+          "shape" : "__string",
+          "locationName" : "body"
+        },
+        "FailOnWarnings" : {
+          "shape" : "__boolean",
+          "location" : "querystring",
+          "locationName" : "failOnWarnings"
+        }
+      },
+      "required" : [ "Body" ]
+    },
+    "ImportApiResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ApiEndpoint" : {
+          "shape" : "__string",
+          "locationName" : "apiEndpoint"
+        },
+        "ApiId" : {
+          "shape" : "Id",
+          "locationName" : "apiId"
+        },
+        "ApiKeySelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "apiKeySelectionExpression"
+        },
+        "CorsConfiguration" : {
+          "shape" : "Cors",
+          "locationName" : "corsConfiguration"
+        },
+        "CreatedDate" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "createdDate"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "DisableSchemaValidation" : {
+          "shape" : "__boolean",
+          "locationName" : "disableSchemaValidation"
+        },
+        "ImportInfo" : {
+          "shape" : "__listOf__string",
+          "locationName" : "importInfo"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "ProtocolType" : {
+          "shape" : "ProtocolType",
+          "locationName" : "protocolType"
+        },
+        "RouteSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "routeSelectionExpression"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        },
+        "Version" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "version"
+        },
+        "Warnings" : {
+          "shape" : "__listOf__string",
+          "locationName" : "warnings"
+        }
+      }
+    },
+    "IntegerWithLengthBetween0And3600" : {
+      "type" : "integer",
+      "min" : 0,
+      "max" : 3600
+    },
+    "IntegerWithLengthBetween50And30000" : {
+      "type" : "integer",
+      "min" : 50,
+      "max" : 30000
+    },
+    "IntegerWithLengthBetweenMinus1And86400" : {
+      "type" : "integer",
+      "min" : -1,
+      "max" : 86400
+    },
+    "Integration" : {
+      "type" : "structure",
+      "members" : {
+        "ApiGatewayManaged" : {
+          "shape" : "__boolean",
+          "locationName" : "apiGatewayManaged"
+        },
+        "ConnectionId" : {
+          "shape" : "StringWithLengthBetween1And1024",
+          "locationName" : "connectionId"
+        },
+        "ConnectionType" : {
+          "shape" : "ConnectionType",
+          "locationName" : "connectionType"
+        },
+        "ContentHandlingStrategy" : {
+          "shape" : "ContentHandlingStrategy",
+          "locationName" : "contentHandlingStrategy"
+        },
+        "CredentialsArn" : {
+          "shape" : "Arn",
+          "locationName" : "credentialsArn"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "IntegrationId" : {
+          "shape" : "Id",
+          "locationName" : "integrationId"
+        },
+        "IntegrationMethod" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "integrationMethod"
+        },
+        "IntegrationResponseSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "integrationResponseSelectionExpression"
+        },
+        "IntegrationType" : {
+          "shape" : "IntegrationType",
+          "locationName" : "integrationType"
+        },
+        "IntegrationUri" : {
+          "shape" : "UriWithLengthBetween1And2048",
+          "locationName" : "integrationUri"
+        },
+        "PassthroughBehavior" : {
+          "shape" : "PassthroughBehavior",
+          "locationName" : "passthroughBehavior"
+        },
+        "PayloadFormatVersion" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "payloadFormatVersion"
+        },
+        "RequestParameters" : {
+          "shape" : "IntegrationParameters",
+          "locationName" : "requestParameters"
+        },
+        "RequestTemplates" : {
+          "shape" : "TemplateMap",
+          "locationName" : "requestTemplates"
+        },
+        "TemplateSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "templateSelectionExpression"
+        },
+        "TimeoutInMillis" : {
+          "shape" : "IntegerWithLengthBetween50And30000",
+          "locationName" : "timeoutInMillis"
+        },
+        "TlsConfig" : {
+          "shape" : "TlsConfig",
+          "locationName" : "tlsConfig"
+        }
+      }
+    },
+    "IntegrationParameters" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "StringWithLengthBetween1And512"
+      }
+    },
+    "IntegrationResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ContentHandlingStrategy" : {
+          "shape" : "ContentHandlingStrategy",
+          "locationName" : "contentHandlingStrategy"
+        },
+        "IntegrationResponseId" : {
+          "shape" : "Id",
+          "locationName" : "integrationResponseId"
+        },
+        "IntegrationResponseKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "integrationResponseKey"
+        },
+        "ResponseParameters" : {
+          "shape" : "IntegrationParameters",
+          "locationName" : "responseParameters"
+        },
+        "ResponseTemplates" : {
+          "shape" : "TemplateMap",
+          "locationName" : "responseTemplates"
+        },
+        "TemplateSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "templateSelectionExpression"
+        }
+      },
+      "required" : [ "IntegrationResponseKey" ]
+    },
+    "IntegrationResponses" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfIntegrationResponse",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "IntegrationType" : {
+      "type" : "string",
+      "enum" : [ "AWS", "HTTP", "MOCK", "HTTP_PROXY", "AWS_PROXY" ]
+    },
+    "Integrations" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfIntegration",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "JWTConfiguration" : {
+      "type" : "structure",
+      "members" : {
+        "Audience" : {
+          "shape" : "__listOf__string",
+          "locationName" : "audience"
+        },
+        "Issuer" : {
+          "shape" : "UriWithLengthBetween1And2048",
+          "locationName" : "issuer"
+        }
+      }
+    },
+    "LimitExceededException" : {
+      "type" : "structure",
+      "members" : {
+        "LimitType" : {
+          "shape" : "__string",
+          "locationName" : "limitType"
+        },
+        "Message" : {
+          "shape" : "__string",
+          "locationName" : "message"
+        }
+      }
+    },
+    "LoggingLevel" : {
+      "type" : "string",
+      "enum" : [ "ERROR", "INFO", "OFF" ]
+    },
+    "Model" : {
+      "type" : "structure",
+      "members" : {
+        "ContentType" : {
+          "shape" : "StringWithLengthBetween1And256",
+          "locationName" : "contentType"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "ModelId" : {
+          "shape" : "Id",
+          "locationName" : "modelId"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "Schema" : {
+          "shape" : "StringWithLengthBetween0And32K",
+          "locationName" : "schema"
+        }
+      },
+      "required" : [ "Name" ]
+    },
+    "Models" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfModel",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "NextToken" : {
+      "type" : "string"
+    },
+    "NotFoundException" : {
+      "type" : "structure",
+      "members" : {
+        "Message" : {
+          "shape" : "__string",
+          "locationName" : "message"
+        },
+        "ResourceType" : {
+          "shape" : "__string",
+          "locationName" : "resourceType"
+        }
+      },
+      "exception" : true,
+      "error" : {
+        "httpStatusCode" : 404
+      }
+    },
+    "ParameterConstraints" : {
+      "type" : "structure",
+      "members" : {
+        "Required" : {
+          "shape" : "__boolean",
+          "locationName" : "required"
+        }
+      }
+    },
+    "PassthroughBehavior" : {
+      "type" : "string",
+      "enum" : [ "WHEN_NO_MATCH", "NEVER", "WHEN_NO_TEMPLATES" ]
+    },
+    "ProtocolType" : {
+      "type" : "string",
+      "enum" : [ "WEBSOCKET", "HTTP" ]
+    },
+    "ReimportApiInput" : {
+      "type" : "structure",
+      "members" : {
+        "Body" : {
+          "shape" : "__string",
+          "locationName" : "body"
+        }
+      },
+      "required" : [ "Body" ]
+    },
+    "ReimportApiRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "Basepath" : {
+          "shape" : "__string",
+          "location" : "querystring",
+          "locationName" : "basepath"
+        },
+        "Body" : {
+          "shape" : "__string",
+          "locationName" : "body"
+        },
+        "FailOnWarnings" : {
+          "shape" : "__boolean",
+          "location" : "querystring",
+          "locationName" : "failOnWarnings"
+        }
+      },
+      "required" : [ "ApiId", "Body" ]
+    },
+    "ReimportApiResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ApiEndpoint" : {
+          "shape" : "__string",
+          "locationName" : "apiEndpoint"
+        },
+        "ApiId" : {
+          "shape" : "Id",
+          "locationName" : "apiId"
+        },
+        "ApiKeySelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "apiKeySelectionExpression"
+        },
+        "CorsConfiguration" : {
+          "shape" : "Cors",
+          "locationName" : "corsConfiguration"
+        },
+        "CreatedDate" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "createdDate"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "DisableSchemaValidation" : {
+          "shape" : "__boolean",
+          "locationName" : "disableSchemaValidation"
+        },
+        "ImportInfo" : {
+          "shape" : "__listOf__string",
+          "locationName" : "importInfo"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "ProtocolType" : {
+          "shape" : "ProtocolType",
+          "locationName" : "protocolType"
+        },
+        "RouteSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "routeSelectionExpression"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        },
+        "Version" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "version"
+        },
+        "Warnings" : {
+          "shape" : "__listOf__string",
+          "locationName" : "warnings"
+        }
+      }
+    },
+    "Route" : {
+      "type" : "structure",
+      "members" : {
+        "ApiGatewayManaged" : {
+          "shape" : "__boolean",
+          "locationName" : "apiGatewayManaged"
+        },
+        "ApiKeyRequired" : {
+          "shape" : "__boolean",
+          "locationName" : "apiKeyRequired"
+        },
+        "AuthorizationScopes" : {
+          "shape" : "AuthorizationScopes",
+          "locationName" : "authorizationScopes"
+        },
+        "AuthorizationType" : {
+          "shape" : "AuthorizationType",
+          "locationName" : "authorizationType"
+        },
+        "AuthorizerId" : {
+          "shape" : "Id",
+          "locationName" : "authorizerId"
+        },
+        "ModelSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "modelSelectionExpression"
+        },
+        "OperationName" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "operationName"
+        },
+        "RequestModels" : {
+          "shape" : "RouteModels",
+          "locationName" : "requestModels"
+        },
+        "RequestParameters" : {
+          "shape" : "RouteParameters",
+          "locationName" : "requestParameters"
+        },
+        "RouteId" : {
+          "shape" : "Id",
+          "locationName" : "routeId"
+        },
+        "RouteKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "routeKey"
+        },
+        "RouteResponseSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "routeResponseSelectionExpression"
+        },
+        "Target" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "target"
+        }
+      },
+      "required" : [ "RouteKey" ]
+    },
+    "RouteModels" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "StringWithLengthBetween1And128"
+      }
+    },
+    "RouteParameters" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "ParameterConstraints"
+      }
+    },
+    "RouteResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ModelSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "modelSelectionExpression"
+        },
+        "ResponseModels" : {
+          "shape" : "RouteModels",
+          "locationName" : "responseModels"
+        },
+        "ResponseParameters" : {
+          "shape" : "RouteParameters",
+          "locationName" : "responseParameters"
+        },
+        "RouteResponseId" : {
+          "shape" : "Id",
+          "locationName" : "routeResponseId"
+        },
+        "RouteResponseKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "routeResponseKey"
+        }
+      },
+      "required" : [ "RouteResponseKey" ]
+    },
+    "RouteResponses" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfRouteResponse",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "RouteSettings" : {
+      "type" : "structure",
+      "members" : {
+        "DataTraceEnabled" : {
+          "shape" : "__boolean",
+          "locationName" : "dataTraceEnabled"
+        },
+        "DetailedMetricsEnabled" : {
+          "shape" : "__boolean",
+          "locationName" : "detailedMetricsEnabled"
+        },
+        "LoggingLevel" : {
+          "shape" : "LoggingLevel",
+          "locationName" : "loggingLevel"
+        },
+        "ThrottlingBurstLimit" : {
+          "shape" : "__integer",
+          "locationName" : "throttlingBurstLimit"
+        },
+        "ThrottlingRateLimit" : {
+          "shape" : "__double",
+          "locationName" : "throttlingRateLimit"
+        }
+      }
+    },
+    "RouteSettingsMap" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "RouteSettings"
+      }
+    },
+    "Routes" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfRoute",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "SecurityGroupIdList" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "__string"
+      }
+    },
+    "SecurityPolicy" : {
+      "type" : "string",
+      "enum" : [ "TLS_1_0", "TLS_1_2" ]
+    },
+    "SelectionExpression" : {
+      "type" : "string"
+    },
+    "SelectionKey" : {
+      "type" : "string"
+    },
+    "Stage" : {
+      "type" : "structure",
+      "members" : {
+        "AccessLogSettings" : {
+          "shape" : "AccessLogSettings",
+          "locationName" : "accessLogSettings"
+        },
+        "ApiGatewayManaged" : {
+          "shape" : "__boolean",
+          "locationName" : "apiGatewayManaged"
+        },
+        "AutoDeploy" : {
+          "shape" : "__boolean",
+          "locationName" : "autoDeploy"
+        },
+        "ClientCertificateId" : {
+          "shape" : "Id",
+          "locationName" : "clientCertificateId"
+        },
+        "CreatedDate" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "createdDate"
+        },
+        "DefaultRouteSettings" : {
+          "shape" : "RouteSettings",
+          "locationName" : "defaultRouteSettings"
+        },
+        "DeploymentId" : {
+          "shape" : "Id",
+          "locationName" : "deploymentId"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "LastDeploymentStatusMessage" : {
+          "shape" : "__string",
+          "locationName" : "lastDeploymentStatusMessage"
+        },
+        "LastUpdatedDate" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "lastUpdatedDate"
+        },
+        "RouteSettings" : {
+          "shape" : "RouteSettingsMap",
+          "locationName" : "routeSettings"
+        },
+        "StageName" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "stageName"
+        },
+        "StageVariables" : {
+          "shape" : "StageVariablesMap",
+          "locationName" : "stageVariables"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        }
+      },
+      "required" : [ "StageName" ]
+    },
+    "StageVariablesMap" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "StringWithLengthBetween0And2048"
+      }
+    },
+    "Stages" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfStage",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "StringWithLengthBetween0And1024" : {
+      "type" : "string"
+    },
+    "StringWithLengthBetween0And2048" : {
+      "type" : "string"
+    },
+    "StringWithLengthBetween0And32K" : {
+      "type" : "string"
+    },
+    "StringWithLengthBetween1And1024" : {
+      "type" : "string"
+    },
+    "StringWithLengthBetween1And128" : {
+      "type" : "string"
+    },
+    "StringWithLengthBetween1And1600" : {
+      "type" : "string"
+    },
+    "StringWithLengthBetween1And256" : {
+      "type" : "string"
+    },
+    "StringWithLengthBetween1And512" : {
+      "type" : "string"
+    },
+    "StringWithLengthBetween1And64" : {
+      "type" : "string"
+    },
+    "SubnetIdList" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "__string"
+      }
+    },
+    "TagResourceInput" : {
+      "type" : "structure",
+      "members" : {
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        }
+      }
+    },
+    "TagResourceRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ResourceArn" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "resource-arn"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        }
+      },
+      "required" : [ "ResourceArn" ]
+    },
+    "TagResourceResponse" : {
+      "type" : "structure",
+      "members" : { }
+    },
+    "Tags" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "StringWithLengthBetween1And1600"
+      }
+    },
+    "Template" : {
+      "type" : "structure",
+      "members" : {
+        "Value" : {
+          "shape" : "__string",
+          "locationName" : "value"
+        }
+      }
+    },
+    "TemplateMap" : {
+      "type" : "map",
+      "key" : {
+        "shape" : "__string"
+      },
+      "value" : {
+        "shape" : "StringWithLengthBetween0And32K"
+      }
+    },
+    "TlsConfig" : {
+      "type" : "structure",
+      "members" : {
+        "ServerNameToVerify" : {
+          "shape" : "StringWithLengthBetween1And512",
+          "locationName" : "serverNameToVerify"
+        }
+      }
+    },
+    "TlsConfigInput" : {
+      "type" : "structure",
+      "members" : {
+        "ServerNameToVerify" : {
+          "shape" : "StringWithLengthBetween1And512",
+          "locationName" : "serverNameToVerify"
+        }
+      }
+    },
+    "TooManyRequestsException" : {
+      "type" : "structure",
+      "members" : {
+        "LimitType" : {
+          "shape" : "__string",
+          "locationName" : "limitType"
+        },
+        "Message" : {
+          "shape" : "__string",
+          "locationName" : "message"
+        }
+      },
+      "exception" : true,
+      "error" : {
+        "httpStatusCode" : 429
+      }
+    },
+    "UntagResourceRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ResourceArn" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "resource-arn"
+        },
+        "TagKeys" : {
+          "shape" : "__listOf__string",
+          "location" : "querystring",
+          "locationName" : "tagKeys"
+        }
+      },
+      "required" : [ "ResourceArn", "TagKeys" ]
+    },
+    "UpdateApiInput" : {
+      "type" : "structure",
+      "members" : {
+        "ApiKeySelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "apiKeySelectionExpression"
+        },
+        "CorsConfiguration" : {
+          "shape" : "Cors",
+          "locationName" : "corsConfiguration"
+        },
+        "CredentialsArn" : {
+          "shape" : "Arn",
+          "locationName" : "credentialsArn"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "DisableSchemaValidation" : {
+          "shape" : "__boolean",
+          "locationName" : "disableSchemaValidation"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "RouteKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "routeKey"
+        },
+        "RouteSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "routeSelectionExpression"
+        },
+        "Target" : {
+          "shape" : "UriWithLengthBetween1And2048",
+          "locationName" : "target"
+        },
+        "Version" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "version"
+        }
+      }
+    },
+    "UpdateApiMappingInput" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "Id",
+          "locationName" : "apiId"
+        },
+        "ApiMappingKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "apiMappingKey"
+        },
+        "Stage" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "stage"
+        }
+      }
+    },
+    "UpdateApiMappingRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "Id",
+          "locationName" : "apiId"
+        },
+        "ApiMappingId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiMappingId"
+        },
+        "ApiMappingKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "apiMappingKey"
+        },
+        "DomainName" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "domainName"
+        },
+        "Stage" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "stage"
+        }
+      },
+      "required" : [ "ApiMappingId", "ApiId", "DomainName" ]
+    },
+    "UpdateApiMappingResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "Id",
+          "locationName" : "apiId"
+        },
+        "ApiMappingId" : {
+          "shape" : "Id",
+          "locationName" : "apiMappingId"
+        },
+        "ApiMappingKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "apiMappingKey"
+        },
+        "Stage" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "stage"
+        }
+      }
+    },
+    "UpdateApiRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "ApiKeySelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "apiKeySelectionExpression"
+        },
+        "CorsConfiguration" : {
+          "shape" : "Cors",
+          "locationName" : "corsConfiguration"
+        },
+        "CredentialsArn" : {
+          "shape" : "Arn",
+          "locationName" : "credentialsArn"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "DisableSchemaValidation" : {
+          "shape" : "__boolean",
+          "locationName" : "disableSchemaValidation"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "RouteKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "routeKey"
+        },
+        "RouteSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "routeSelectionExpression"
+        },
+        "Target" : {
+          "shape" : "UriWithLengthBetween1And2048",
+          "locationName" : "target"
+        },
+        "Version" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "version"
+        }
+      },
+      "required" : [ "ApiId" ]
+    },
+    "UpdateApiResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ApiEndpoint" : {
+          "shape" : "__string",
+          "locationName" : "apiEndpoint"
+        },
+        "ApiId" : {
+          "shape" : "Id",
+          "locationName" : "apiId"
+        },
+        "ApiKeySelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "apiKeySelectionExpression"
+        },
+        "CorsConfiguration" : {
+          "shape" : "Cors",
+          "locationName" : "corsConfiguration"
+        },
+        "CreatedDate" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "createdDate"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "DisableSchemaValidation" : {
+          "shape" : "__boolean",
+          "locationName" : "disableSchemaValidation"
+        },
+        "ImportInfo" : {
+          "shape" : "__listOf__string",
+          "locationName" : "importInfo"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "ProtocolType" : {
+          "shape" : "ProtocolType",
+          "locationName" : "protocolType"
+        },
+        "RouteSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "routeSelectionExpression"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        },
+        "Version" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "version"
+        },
+        "Warnings" : {
+          "shape" : "__listOf__string",
+          "locationName" : "warnings"
+        }
+      }
+    },
+    "UpdateAuthorizerInput" : {
+      "type" : "structure",
+      "members" : {
+        "AuthorizerCredentialsArn" : {
+          "shape" : "Arn",
+          "locationName" : "authorizerCredentialsArn"
+        },
+        "AuthorizerResultTtlInSeconds" : {
+          "shape" : "IntegerWithLengthBetween0And3600",
+          "locationName" : "authorizerResultTtlInSeconds"
+        },
+        "AuthorizerType" : {
+          "shape" : "AuthorizerType",
+          "locationName" : "authorizerType"
+        },
+        "AuthorizerUri" : {
+          "shape" : "UriWithLengthBetween1And2048",
+          "locationName" : "authorizerUri"
+        },
+        "IdentitySource" : {
+          "shape" : "IdentitySourceList",
+          "locationName" : "identitySource"
+        },
+        "IdentityValidationExpression" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "identityValidationExpression"
+        },
+        "JwtConfiguration" : {
+          "shape" : "JWTConfiguration",
+          "locationName" : "jwtConfiguration"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        }
+      }
+    },
+    "UpdateAuthorizerRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "AuthorizerCredentialsArn" : {
+          "shape" : "Arn",
+          "locationName" : "authorizerCredentialsArn"
+        },
+        "AuthorizerId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "authorizerId"
+        },
+        "AuthorizerResultTtlInSeconds" : {
+          "shape" : "IntegerWithLengthBetween0And3600",
+          "locationName" : "authorizerResultTtlInSeconds"
+        },
+        "AuthorizerType" : {
+          "shape" : "AuthorizerType",
+          "locationName" : "authorizerType"
+        },
+        "AuthorizerUri" : {
+          "shape" : "UriWithLengthBetween1And2048",
+          "locationName" : "authorizerUri"
+        },
+        "IdentitySource" : {
+          "shape" : "IdentitySourceList",
+          "locationName" : "identitySource"
+        },
+        "IdentityValidationExpression" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "identityValidationExpression"
+        },
+        "JwtConfiguration" : {
+          "shape" : "JWTConfiguration",
+          "locationName" : "jwtConfiguration"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        }
+      },
+      "required" : [ "AuthorizerId", "ApiId" ]
+    },
+    "UpdateAuthorizerResponse" : {
+      "type" : "structure",
+      "members" : {
+        "AuthorizerCredentialsArn" : {
+          "shape" : "Arn",
+          "locationName" : "authorizerCredentialsArn"
+        },
+        "AuthorizerId" : {
+          "shape" : "Id",
+          "locationName" : "authorizerId"
+        },
+        "AuthorizerResultTtlInSeconds" : {
+          "shape" : "IntegerWithLengthBetween0And3600",
+          "locationName" : "authorizerResultTtlInSeconds"
+        },
+        "AuthorizerType" : {
+          "shape" : "AuthorizerType",
+          "locationName" : "authorizerType"
+        },
+        "AuthorizerUri" : {
+          "shape" : "UriWithLengthBetween1And2048",
+          "locationName" : "authorizerUri"
+        },
+        "IdentitySource" : {
+          "shape" : "IdentitySourceList",
+          "locationName" : "identitySource"
+        },
+        "IdentityValidationExpression" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "identityValidationExpression"
+        },
+        "JwtConfiguration" : {
+          "shape" : "JWTConfiguration",
+          "locationName" : "jwtConfiguration"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        }
+      }
+    },
+    "UpdateDeploymentInput" : {
+      "type" : "structure",
+      "members" : {
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        }
+      }
+    },
+    "UpdateDeploymentRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "DeploymentId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "deploymentId"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        }
+      },
+      "required" : [ "ApiId", "DeploymentId" ]
+    },
+    "UpdateDeploymentResponse" : {
+      "type" : "structure",
+      "members" : {
+        "AutoDeployed" : {
+          "shape" : "__boolean",
+          "locationName" : "autoDeployed"
+        },
+        "CreatedDate" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "createdDate"
+        },
+        "DeploymentId" : {
+          "shape" : "Id",
+          "locationName" : "deploymentId"
+        },
+        "DeploymentStatus" : {
+          "shape" : "DeploymentStatus",
+          "locationName" : "deploymentStatus"
+        },
+        "DeploymentStatusMessage" : {
+          "shape" : "__string",
+          "locationName" : "deploymentStatusMessage"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        }
+      }
+    },
+    "UpdateDomainNameInput" : {
+      "type" : "structure",
+      "members" : {
+        "DomainNameConfigurations" : {
+          "shape" : "DomainNameConfigurations",
+          "locationName" : "domainNameConfigurations"
+        }
+      }
+    },
+    "UpdateDomainNameRequest" : {
+      "type" : "structure",
+      "members" : {
+        "DomainName" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "domainName"
+        },
+        "DomainNameConfigurations" : {
+          "shape" : "DomainNameConfigurations",
+          "locationName" : "domainNameConfigurations"
+        }
+      },
+      "required" : [ "DomainName" ]
+    },
+    "UpdateDomainNameResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ApiMappingSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "apiMappingSelectionExpression"
+        },
+        "DomainName" : {
+          "shape" : "StringWithLengthBetween1And512",
+          "locationName" : "domainName"
+        },
+        "DomainNameConfigurations" : {
+          "shape" : "DomainNameConfigurations",
+          "locationName" : "domainNameConfigurations"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        }
+      }
+    },
+    "UpdateIntegrationInput" : {
+      "type" : "structure",
+      "members" : {
+        "ConnectionId" : {
+          "shape" : "StringWithLengthBetween1And1024",
+          "locationName" : "connectionId"
+        },
+        "ConnectionType" : {
+          "shape" : "ConnectionType",
+          "locationName" : "connectionType"
+        },
+        "ContentHandlingStrategy" : {
+          "shape" : "ContentHandlingStrategy",
+          "locationName" : "contentHandlingStrategy"
+        },
+        "CredentialsArn" : {
+          "shape" : "Arn",
+          "locationName" : "credentialsArn"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "IntegrationMethod" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "integrationMethod"
+        },
+        "IntegrationType" : {
+          "shape" : "IntegrationType",
+          "locationName" : "integrationType"
+        },
+        "IntegrationUri" : {
+          "shape" : "UriWithLengthBetween1And2048",
+          "locationName" : "integrationUri"
+        },
+        "PassthroughBehavior" : {
+          "shape" : "PassthroughBehavior",
+          "locationName" : "passthroughBehavior"
+        },
+        "PayloadFormatVersion" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "payloadFormatVersion"
+        },
+        "RequestParameters" : {
+          "shape" : "IntegrationParameters",
+          "locationName" : "requestParameters"
+        },
+        "RequestTemplates" : {
+          "shape" : "TemplateMap",
+          "locationName" : "requestTemplates"
+        },
+        "TemplateSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "templateSelectionExpression"
+        },
+        "TimeoutInMillis" : {
+          "shape" : "IntegerWithLengthBetween50And30000",
+          "locationName" : "timeoutInMillis"
+        },
+        "TlsConfig" : {
+          "shape" : "TlsConfigInput",
+          "locationName" : "tlsConfig"
+        }
+      }
+    },
+    "UpdateIntegrationRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "ConnectionId" : {
+          "shape" : "StringWithLengthBetween1And1024",
+          "locationName" : "connectionId"
+        },
+        "ConnectionType" : {
+          "shape" : "ConnectionType",
+          "locationName" : "connectionType"
+        },
+        "ContentHandlingStrategy" : {
+          "shape" : "ContentHandlingStrategy",
+          "locationName" : "contentHandlingStrategy"
+        },
+        "CredentialsArn" : {
+          "shape" : "Arn",
+          "locationName" : "credentialsArn"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "IntegrationId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "integrationId"
+        },
+        "IntegrationMethod" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "integrationMethod"
+        },
+        "IntegrationType" : {
+          "shape" : "IntegrationType",
+          "locationName" : "integrationType"
+        },
+        "IntegrationUri" : {
+          "shape" : "UriWithLengthBetween1And2048",
+          "locationName" : "integrationUri"
+        },
+        "PassthroughBehavior" : {
+          "shape" : "PassthroughBehavior",
+          "locationName" : "passthroughBehavior"
+        },
+        "PayloadFormatVersion" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "payloadFormatVersion"
+        },
+        "RequestParameters" : {
+          "shape" : "IntegrationParameters",
+          "locationName" : "requestParameters"
+        },
+        "RequestTemplates" : {
+          "shape" : "TemplateMap",
+          "locationName" : "requestTemplates"
+        },
+        "TemplateSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "templateSelectionExpression"
+        },
+        "TimeoutInMillis" : {
+          "shape" : "IntegerWithLengthBetween50And30000",
+          "locationName" : "timeoutInMillis"
+        },
+        "TlsConfig" : {
+          "shape" : "TlsConfigInput",
+          "locationName" : "tlsConfig"
+        }
+      },
+      "required" : [ "ApiId", "IntegrationId" ]
+    },
+    "UpdateIntegrationResult" : {
+      "type" : "structure",
+      "members" : {
+        "ApiGatewayManaged" : {
+          "shape" : "__boolean",
+          "locationName" : "apiGatewayManaged"
+        },
+        "ConnectionId" : {
+          "shape" : "StringWithLengthBetween1And1024",
+          "locationName" : "connectionId"
+        },
+        "ConnectionType" : {
+          "shape" : "ConnectionType",
+          "locationName" : "connectionType"
+        },
+        "ContentHandlingStrategy" : {
+          "shape" : "ContentHandlingStrategy",
+          "locationName" : "contentHandlingStrategy"
+        },
+        "CredentialsArn" : {
+          "shape" : "Arn",
+          "locationName" : "credentialsArn"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "IntegrationId" : {
+          "shape" : "Id",
+          "locationName" : "integrationId"
+        },
+        "IntegrationMethod" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "integrationMethod"
+        },
+        "IntegrationResponseSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "integrationResponseSelectionExpression"
+        },
+        "IntegrationType" : {
+          "shape" : "IntegrationType",
+          "locationName" : "integrationType"
+        },
+        "IntegrationUri" : {
+          "shape" : "UriWithLengthBetween1And2048",
+          "locationName" : "integrationUri"
+        },
+        "PassthroughBehavior" : {
+          "shape" : "PassthroughBehavior",
+          "locationName" : "passthroughBehavior"
+        },
+        "PayloadFormatVersion" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "payloadFormatVersion"
+        },
+        "RequestParameters" : {
+          "shape" : "IntegrationParameters",
+          "locationName" : "requestParameters"
+        },
+        "RequestTemplates" : {
+          "shape" : "TemplateMap",
+          "locationName" : "requestTemplates"
+        },
+        "TemplateSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "templateSelectionExpression"
+        },
+        "TimeoutInMillis" : {
+          "shape" : "IntegerWithLengthBetween50And30000",
+          "locationName" : "timeoutInMillis"
+        },
+        "TlsConfig" : {
+          "shape" : "TlsConfig",
+          "locationName" : "tlsConfig"
+        }
+      }
+    },
+    "UpdateIntegrationResponseInput" : {
+      "type" : "structure",
+      "members" : {
+        "ContentHandlingStrategy" : {
+          "shape" : "ContentHandlingStrategy",
+          "locationName" : "contentHandlingStrategy"
+        },
+        "IntegrationResponseKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "integrationResponseKey"
+        },
+        "ResponseParameters" : {
+          "shape" : "IntegrationParameters",
+          "locationName" : "responseParameters"
+        },
+        "ResponseTemplates" : {
+          "shape" : "TemplateMap",
+          "locationName" : "responseTemplates"
+        },
+        "TemplateSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "templateSelectionExpression"
+        }
+      }
+    },
+    "UpdateIntegrationResponseRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "ContentHandlingStrategy" : {
+          "shape" : "ContentHandlingStrategy",
+          "locationName" : "contentHandlingStrategy"
+        },
+        "IntegrationId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "integrationId"
+        },
+        "IntegrationResponseId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "integrationResponseId"
+        },
+        "IntegrationResponseKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "integrationResponseKey"
+        },
+        "ResponseParameters" : {
+          "shape" : "IntegrationParameters",
+          "locationName" : "responseParameters"
+        },
+        "ResponseTemplates" : {
+          "shape" : "TemplateMap",
+          "locationName" : "responseTemplates"
+        },
+        "TemplateSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "templateSelectionExpression"
+        }
+      },
+      "required" : [ "ApiId", "IntegrationResponseId", "IntegrationId" ]
+    },
+    "UpdateIntegrationResponseResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ContentHandlingStrategy" : {
+          "shape" : "ContentHandlingStrategy",
+          "locationName" : "contentHandlingStrategy"
+        },
+        "IntegrationResponseId" : {
+          "shape" : "Id",
+          "locationName" : "integrationResponseId"
+        },
+        "IntegrationResponseKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "integrationResponseKey"
+        },
+        "ResponseParameters" : {
+          "shape" : "IntegrationParameters",
+          "locationName" : "responseParameters"
+        },
+        "ResponseTemplates" : {
+          "shape" : "TemplateMap",
+          "locationName" : "responseTemplates"
+        },
+        "TemplateSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "templateSelectionExpression"
+        }
+      }
+    },
+    "UpdateModelInput" : {
+      "type" : "structure",
+      "members" : {
+        "ContentType" : {
+          "shape" : "StringWithLengthBetween1And256",
+          "locationName" : "contentType"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "Schema" : {
+          "shape" : "StringWithLengthBetween0And32K",
+          "locationName" : "schema"
+        }
+      }
+    },
+    "UpdateModelRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "ContentType" : {
+          "shape" : "StringWithLengthBetween1And256",
+          "locationName" : "contentType"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "ModelId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "modelId"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "Schema" : {
+          "shape" : "StringWithLengthBetween0And32K",
+          "locationName" : "schema"
+        }
+      },
+      "required" : [ "ModelId", "ApiId" ]
+    },
+    "UpdateModelResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ContentType" : {
+          "shape" : "StringWithLengthBetween1And256",
+          "locationName" : "contentType"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "ModelId" : {
+          "shape" : "Id",
+          "locationName" : "modelId"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "Schema" : {
+          "shape" : "StringWithLengthBetween0And32K",
+          "locationName" : "schema"
+        }
+      }
+    },
+    "UpdateRouteInput" : {
+      "type" : "structure",
+      "members" : {
+        "ApiKeyRequired" : {
+          "shape" : "__boolean",
+          "locationName" : "apiKeyRequired"
+        },
+        "AuthorizationScopes" : {
+          "shape" : "AuthorizationScopes",
+          "locationName" : "authorizationScopes"
+        },
+        "AuthorizationType" : {
+          "shape" : "AuthorizationType",
+          "locationName" : "authorizationType"
+        },
+        "AuthorizerId" : {
+          "shape" : "Id",
+          "locationName" : "authorizerId"
+        },
+        "ModelSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "modelSelectionExpression"
+        },
+        "OperationName" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "operationName"
+        },
+        "RequestModels" : {
+          "shape" : "RouteModels",
+          "locationName" : "requestModels"
+        },
+        "RequestParameters" : {
+          "shape" : "RouteParameters",
+          "locationName" : "requestParameters"
+        },
+        "RouteKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "routeKey"
+        },
+        "RouteResponseSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "routeResponseSelectionExpression"
+        },
+        "Target" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "target"
+        }
+      }
+    },
+    "UpdateRouteRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "ApiKeyRequired" : {
+          "shape" : "__boolean",
+          "locationName" : "apiKeyRequired"
+        },
+        "AuthorizationScopes" : {
+          "shape" : "AuthorizationScopes",
+          "locationName" : "authorizationScopes"
+        },
+        "AuthorizationType" : {
+          "shape" : "AuthorizationType",
+          "locationName" : "authorizationType"
+        },
+        "AuthorizerId" : {
+          "shape" : "Id",
+          "locationName" : "authorizerId"
+        },
+        "ModelSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "modelSelectionExpression"
+        },
+        "OperationName" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "operationName"
+        },
+        "RequestModels" : {
+          "shape" : "RouteModels",
+          "locationName" : "requestModels"
+        },
+        "RequestParameters" : {
+          "shape" : "RouteParameters",
+          "locationName" : "requestParameters"
+        },
+        "RouteId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "routeId"
+        },
+        "RouteKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "routeKey"
+        },
+        "RouteResponseSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "routeResponseSelectionExpression"
+        },
+        "Target" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "target"
+        }
+      },
+      "required" : [ "ApiId", "RouteId" ]
+    },
+    "UpdateRouteResult" : {
+      "type" : "structure",
+      "members" : {
+        "ApiGatewayManaged" : {
+          "shape" : "__boolean",
+          "locationName" : "apiGatewayManaged"
+        },
+        "ApiKeyRequired" : {
+          "shape" : "__boolean",
+          "locationName" : "apiKeyRequired"
+        },
+        "AuthorizationScopes" : {
+          "shape" : "AuthorizationScopes",
+          "locationName" : "authorizationScopes"
+        },
+        "AuthorizationType" : {
+          "shape" : "AuthorizationType",
+          "locationName" : "authorizationType"
+        },
+        "AuthorizerId" : {
+          "shape" : "Id",
+          "locationName" : "authorizerId"
+        },
+        "ModelSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "modelSelectionExpression"
+        },
+        "OperationName" : {
+          "shape" : "StringWithLengthBetween1And64",
+          "locationName" : "operationName"
+        },
+        "RequestModels" : {
+          "shape" : "RouteModels",
+          "locationName" : "requestModels"
+        },
+        "RequestParameters" : {
+          "shape" : "RouteParameters",
+          "locationName" : "requestParameters"
+        },
+        "RouteId" : {
+          "shape" : "Id",
+          "locationName" : "routeId"
+        },
+        "RouteKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "routeKey"
+        },
+        "RouteResponseSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "routeResponseSelectionExpression"
+        },
+        "Target" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "target"
+        }
+      }
+    },
+    "UpdateRouteResponseInput" : {
+      "type" : "structure",
+      "members" : {
+        "ModelSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "modelSelectionExpression"
+        },
+        "ResponseModels" : {
+          "shape" : "RouteModels",
+          "locationName" : "responseModels"
+        },
+        "ResponseParameters" : {
+          "shape" : "RouteParameters",
+          "locationName" : "responseParameters"
+        },
+        "RouteResponseKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "routeResponseKey"
+        }
+      }
+    },
+    "UpdateRouteResponseRequest" : {
+      "type" : "structure",
+      "members" : {
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "ModelSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "modelSelectionExpression"
+        },
+        "ResponseModels" : {
+          "shape" : "RouteModels",
+          "locationName" : "responseModels"
+        },
+        "ResponseParameters" : {
+          "shape" : "RouteParameters",
+          "locationName" : "responseParameters"
+        },
+        "RouteId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "routeId"
+        },
+        "RouteResponseId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "routeResponseId"
+        },
+        "RouteResponseKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "routeResponseKey"
+        }
+      },
+      "required" : [ "RouteResponseId", "ApiId", "RouteId" ]
+    },
+    "UpdateRouteResponseResponse" : {
+      "type" : "structure",
+      "members" : {
+        "ModelSelectionExpression" : {
+          "shape" : "SelectionExpression",
+          "locationName" : "modelSelectionExpression"
+        },
+        "ResponseModels" : {
+          "shape" : "RouteModels",
+          "locationName" : "responseModels"
+        },
+        "ResponseParameters" : {
+          "shape" : "RouteParameters",
+          "locationName" : "responseParameters"
+        },
+        "RouteResponseId" : {
+          "shape" : "Id",
+          "locationName" : "routeResponseId"
+        },
+        "RouteResponseKey" : {
+          "shape" : "SelectionKey",
+          "locationName" : "routeResponseKey"
+        }
+      }
+    },
+    "UpdateStageInput" : {
+      "type" : "structure",
+      "members" : {
+        "AccessLogSettings" : {
+          "shape" : "AccessLogSettings",
+          "locationName" : "accessLogSettings"
+        },
+        "AutoDeploy" : {
+          "shape" : "__boolean",
+          "locationName" : "autoDeploy"
+        },
+        "ClientCertificateId" : {
+          "shape" : "Id",
+          "locationName" : "clientCertificateId"
+        },
+        "DefaultRouteSettings" : {
+          "shape" : "RouteSettings",
+          "locationName" : "defaultRouteSettings"
+        },
+        "DeploymentId" : {
+          "shape" : "Id",
+          "locationName" : "deploymentId"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "RouteSettings" : {
+          "shape" : "RouteSettingsMap",
+          "locationName" : "routeSettings"
+        },
+        "StageVariables" : {
+          "shape" : "StageVariablesMap",
+          "locationName" : "stageVariables"
+        }
+      }
+    },
+    "UpdateStageRequest" : {
+      "type" : "structure",
+      "members" : {
+        "AccessLogSettings" : {
+          "shape" : "AccessLogSettings",
+          "locationName" : "accessLogSettings"
+        },
+        "ApiId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "apiId"
+        },
+        "AutoDeploy" : {
+          "shape" : "__boolean",
+          "locationName" : "autoDeploy"
+        },
+        "ClientCertificateId" : {
+          "shape" : "Id",
+          "locationName" : "clientCertificateId"
+        },
+        "DefaultRouteSettings" : {
+          "shape" : "RouteSettings",
+          "locationName" : "defaultRouteSettings"
+        },
+        "DeploymentId" : {
+          "shape" : "Id",
+          "locationName" : "deploymentId"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "RouteSettings" : {
+          "shape" : "RouteSettingsMap",
+          "locationName" : "routeSettings"
+        },
+        "StageName" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "stageName"
+        },
+        "StageVariables" : {
+          "shape" : "StageVariablesMap",
+          "locationName" : "stageVariables"
+        }
+      },
+      "required" : [ "StageName", "ApiId" ]
+    },
+    "UpdateStageResponse" : {
+      "type" : "structure",
+      "members" : {
+        "AccessLogSettings" : {
+          "shape" : "AccessLogSettings",
+          "locationName" : "accessLogSettings"
+        },
+        "ApiGatewayManaged" : {
+          "shape" : "__boolean",
+          "locationName" : "apiGatewayManaged"
+        },
+        "AutoDeploy" : {
+          "shape" : "__boolean",
+          "locationName" : "autoDeploy"
+        },
+        "ClientCertificateId" : {
+          "shape" : "Id",
+          "locationName" : "clientCertificateId"
+        },
+        "CreatedDate" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "createdDate"
+        },
+        "DefaultRouteSettings" : {
+          "shape" : "RouteSettings",
+          "locationName" : "defaultRouteSettings"
+        },
+        "DeploymentId" : {
+          "shape" : "Id",
+          "locationName" : "deploymentId"
+        },
+        "Description" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "description"
+        },
+        "LastDeploymentStatusMessage" : {
+          "shape" : "__string",
+          "locationName" : "lastDeploymentStatusMessage"
+        },
+        "LastUpdatedDate" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "lastUpdatedDate"
+        },
+        "RouteSettings" : {
+          "shape" : "RouteSettingsMap",
+          "locationName" : "routeSettings"
+        },
+        "StageName" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "stageName"
+        },
+        "StageVariables" : {
+          "shape" : "StageVariablesMap",
+          "locationName" : "stageVariables"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        }
+      }
+    },
+    "UpdateVpcLinkInput" : {
+      "type" : "structure",
+      "members" : {
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        }
+      }
+    },
+    "UpdateVpcLinkRequest" : {
+      "type" : "structure",
+      "members" : {
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "VpcLinkId" : {
+          "shape" : "__string",
+          "location" : "uri",
+          "locationName" : "vpcLinkId"
+        }
+      },
+      "required" : [ "VpcLinkId" ]
+    },
+    "UpdateVpcLinkResponse" : {
+      "type" : "structure",
+      "members" : {
+        "CreatedDate" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "createdDate"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "SecurityGroupIds" : {
+          "shape" : "SecurityGroupIdList",
+          "locationName" : "securityGroupIds"
+        },
+        "SubnetIds" : {
+          "shape" : "SubnetIdList",
+          "locationName" : "subnetIds"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        },
+        "VpcLinkId" : {
+          "shape" : "Id",
+          "locationName" : "vpcLinkId"
+        },
+        "VpcLinkStatus" : {
+          "shape" : "VpcLinkStatus",
+          "locationName" : "vpcLinkStatus"
+        },
+        "VpcLinkStatusMessage" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "vpcLinkStatusMessage"
+        },
+        "VpcLinkVersion" : {
+          "shape" : "VpcLinkVersion",
+          "locationName" : "vpcLinkVersion"
+        }
+      }
+    },
+    "UriWithLengthBetween1And2048" : {
+      "type" : "string"
+    },
+    "VpcLink" : {
+      "type" : "structure",
+      "members" : {
+        "CreatedDate" : {
+          "shape" : "__timestampIso8601",
+          "locationName" : "createdDate"
+        },
+        "Name" : {
+          "shape" : "StringWithLengthBetween1And128",
+          "locationName" : "name"
+        },
+        "SecurityGroupIds" : {
+          "shape" : "SecurityGroupIdList",
+          "locationName" : "securityGroupIds"
+        },
+        "SubnetIds" : {
+          "shape" : "SubnetIdList",
+          "locationName" : "subnetIds"
+        },
+        "Tags" : {
+          "shape" : "Tags",
+          "locationName" : "tags"
+        },
+        "VpcLinkId" : {
+          "shape" : "Id",
+          "locationName" : "vpcLinkId"
+        },
+        "VpcLinkStatus" : {
+          "shape" : "VpcLinkStatus",
+          "locationName" : "vpcLinkStatus"
+        },
+        "VpcLinkStatusMessage" : {
+          "shape" : "StringWithLengthBetween0And1024",
+          "locationName" : "vpcLinkStatusMessage"
+        },
+        "VpcLinkVersion" : {
+          "shape" : "VpcLinkVersion",
+          "locationName" : "vpcLinkVersion"
+        }
+      },
+      "required" : [ "VpcLinkId", "SecurityGroupIds", "SubnetIds", "Name" ]
+    },
+    "VpcLinkStatus" : {
+      "type" : "string",
+      "enum" : [ "PENDING", "AVAILABLE", "DELETING", "FAILED", "INACTIVE" ]
+    },
+    "VpcLinkVersion" : {
+      "type" : "string",
+      "enum" : [ "V2" ]
+    },
+    "VpcLinks" : {
+      "type" : "structure",
+      "members" : {
+        "Items" : {
+          "shape" : "__listOfVpcLink",
+          "locationName" : "items"
+        },
+        "NextToken" : {
+          "shape" : "NextToken",
+          "locationName" : "nextToken"
+        }
+      }
+    },
+    "__boolean" : {
+      "type" : "boolean"
+    },
+    "__double" : {
+      "type" : "double"
+    },
+    "__integer" : {
+      "type" : "integer"
+    },
+    "__listOfApi" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "Api"
+      }
+    },
+    "__listOfApiMapping" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "ApiMapping"
+      }
+    },
+    "__listOfAuthorizer" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "Authorizer"
+      }
+    },
+    "__listOfDeployment" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "Deployment"
+      }
+    },
+    "__listOfDomainName" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "DomainName"
+      }
+    },
+    "__listOfIntegration" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "Integration"
+      }
+    },
+    "__listOfIntegrationResponse" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "IntegrationResponse"
+      }
+    },
+    "__listOfModel" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "Model"
+      }
+    },
+    "__listOfRoute" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "Route"
+      }
+    },
+    "__listOfRouteResponse" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "RouteResponse"
+      }
+    },
+    "__listOfStage" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "Stage"
+      }
+    },
+    "__listOfVpcLink" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "VpcLink"
+      }
+    },
+    "__listOf__string" : {
+      "type" : "list",
+      "member" : {
+        "shape" : "__string"
+      }
+    },
+    "__long" : {
+      "type" : "long"
+    },
+    "__string" : {
+      "type" : "string"
+    },
+    "__timestampIso8601" : {
+      "type" : "timestamp",
+      "timestampFormat" : "iso8601"
+    },
+    "__timestampUnix" : {
+      "type" : "timestamp",
+      "timestampFormat" : "unixTimestamp"
+    }
+  }
+}

--- a/pkg/model/testdata/models/apis/apigatewayv2/0000-00-00/docs-2.json
+++ b/pkg/model/testdata/models/apis/apigatewayv2/0000-00-00/docs-2.json
@@ -1,0 +1,1041 @@
+{
+  "version" : "2.0",
+  "service" : "<p>Amazon API Gateway V2</p>",
+  "operations" : {
+    "CreateApi" : "<p>Creates an Api resource.</p>",
+    "CreateApiMapping" : "<p>Creates an API mapping.</p>",
+    "CreateAuthorizer" : "<p>Creates an Authorizer for an API.</p>",
+    "CreateDeployment" : "<p>Creates a Deployment for an API.</p>",
+    "CreateDomainName" : "<p>Creates a domain name.</p>",
+    "CreateIntegration" : "<p>Creates an Integration.</p>",
+    "CreateIntegrationResponse" : "<p>Creates an IntegrationResponses.</p>",
+    "CreateModel" : "<p>Creates a Model for an API.</p>",
+    "CreateRoute" : "<p>Creates a Route for an API.</p>",
+    "CreateRouteResponse" : "<p>Creates a RouteResponse for a Route.</p>",
+    "CreateStage" : "<p>Creates a Stage for an API.</p>",
+    "CreateVpcLink" : "<p>Creates a VPC link.</p>",
+    "DeleteAccessLogSettings" : "<p>Deletes the AccessLogSettings for a Stage. To disable access logging for a Stage, delete its AccessLogSettings.</p>",
+    "DeleteApi" : "<p>Deletes an Api resource.</p>",
+    "DeleteApiMapping" : "<p>Deletes an API mapping.</p>",
+    "DeleteAuthorizer" : "<p>Deletes an Authorizer.</p>",
+    "DeleteCorsConfiguration" : "<p>Deletes a CORS configuration.</p>",
+    "DeleteDeployment" : "<p>Deletes a Deployment.</p>",
+    "DeleteDomainName" : "<p>Deletes a domain name.</p>",
+    "DeleteIntegration" : "<p>Deletes an Integration.</p>",
+    "DeleteIntegrationResponse" : "<p>Deletes an IntegrationResponses.</p>",
+    "DeleteModel" : "<p>Deletes a Model.</p>",
+    "DeleteRoute" : "<p>Deletes a Route.</p>",
+    "DeleteRouteRequestParameter" : "<p>Deletes a route request parameter.</p>",
+    "DeleteRouteResponse" : "<p>Deletes a RouteResponse.</p>",
+    "DeleteRouteSettings" : "<p>Deletes the RouteSettings for a stage.</p>",
+    "DeleteStage" : "<p>Deletes a Stage.</p>",
+    "DeleteVpcLink" : "<p>Deletes a VPC link.</p>",
+    "ExportApi" : "<p>Exports a definition of an API in a particular output format and specification.</p>",
+    "GetApi" : "<p>Gets an Api resource.</p>",
+    "GetApiMapping" : "<p>Gets an API mapping.</p>",
+    "GetApiMappings" : "<p>Gets API mappings.</p>",
+    "GetApis" : "<p>Gets a collection of Api resources.</p>",
+    "GetAuthorizer" : "<p>Gets an Authorizer.</p>",
+    "GetAuthorizers" : "<p>Gets the Authorizers for an API.</p>",
+    "GetDeployment" : "<p>Gets a Deployment.</p>",
+    "GetDeployments" : "<p>Gets the Deployments for an API.</p>",
+    "GetDomainName" : "<p>Gets a domain name.</p>",
+    "GetDomainNames" : "<p>Gets the domain names for an AWS account.</p>",
+    "GetIntegration" : "<p>Gets an Integration.</p>",
+    "GetIntegrationResponse" : "<p>Gets an IntegrationResponses.</p>",
+    "GetIntegrationResponses" : "<p>Gets the IntegrationResponses for an Integration.</p>",
+    "GetIntegrations" : "<p>Gets the Integrations for an API.</p>",
+    "GetModel" : "<p>Gets a Model.</p>",
+    "GetModelTemplate" : "<p>Gets a model template.</p>",
+    "GetModels" : "<p>Gets the Models for an API.</p>",
+    "GetRoute" : "<p>Gets a Route.</p>",
+    "GetRouteResponse" : "<p>Gets a RouteResponse.</p>",
+    "GetRouteResponses" : "<p>Gets the RouteResponses for a Route.</p>",
+    "GetRoutes" : "<p>Gets the Routes for an API.</p>",
+    "GetStage" : "<p>Gets a Stage.</p>",
+    "GetStages" : "<p>Gets the Stages for an API.</p>",
+    "GetTags" : "<p>Gets a collection of Tag resources.</p>",
+    "GetVpcLink" : "<p>Gets a VPC link.</p>",
+    "GetVpcLinks" : "<p>Gets a collection of VPC links.</p>",
+    "ImportApi" : "<p>Imports an API.</p>",
+    "ReimportApi" : "<p>Puts an Api resource.</p>",
+    "TagResource" : "<p>Creates a new Tag resource to represent a tag.</p>",
+    "UntagResource" : "<p>Deletes a Tag.</p>",
+    "UpdateApi" : "<p>Updates an Api resource.</p>",
+    "UpdateApiMapping" : "<p>The API mapping.</p>",
+    "UpdateAuthorizer" : "<p>Updates an Authorizer.</p>",
+    "UpdateDeployment" : "<p>Updates a Deployment.</p>",
+    "UpdateDomainName" : "<p>Updates a domain name.</p>",
+    "UpdateIntegration" : "<p>Updates an Integration.</p>",
+    "UpdateIntegrationResponse" : "<p>Updates an IntegrationResponses.</p>",
+    "UpdateModel" : "<p>Updates a Model.</p>",
+    "UpdateRoute" : "<p>Updates a Route.</p>",
+    "UpdateRouteResponse" : "<p>Updates a RouteResponse.</p>",
+    "UpdateStage" : "<p>Updates a Stage.</p>",
+    "UpdateVpcLink" : "<p>Updates a VPC link.</p>"
+  },
+  "shapes" : {
+    "AccessDeniedException" : {
+      "base" : null,
+      "refs" : { }
+    },
+    "AccessLogSettings" : {
+      "base" : "<p>Settings for logging access in a stage.</p>",
+      "refs" : {
+        "CreateStageInput$AccessLogSettings" : "<p>Settings for logging access in this stage.</p>",
+        "Stage$AccessLogSettings" : "<p>Settings for logging access in this stage.</p>",
+        "UpdateStageInput$AccessLogSettings" : "<p>Settings for logging access in this stage.</p>"
+      }
+    },
+    "Api" : {
+      "base" : "<p>Represents an API.</p>",
+      "refs" : {
+        "__listOfApi$member" : null
+      }
+    },
+    "ApiMapping" : {
+      "base" : "<p>Represents an API mapping.</p>",
+      "refs" : {
+        "__listOfApiMapping$member" : null
+      }
+    },
+    "ApiMappings" : {
+      "base" : "<p>Represents a collection of ApiMappings resources.</p>",
+      "refs" : { }
+    },
+    "Apis" : {
+      "base" : "<p>Represents a collection of APIs.</p>",
+      "refs" : { }
+    },
+    "Arn" : {
+      "base" : "<p>Represents an Amazon Resource Name (ARN).</p>",
+      "refs" : {
+        "AccessLogSettings$DestinationArn" : "<p>The ARN of the CloudWatch Logs log group to receive access logs.</p>",
+        "Authorizer$AuthorizerCredentialsArn" : "<p>Specifies the required credentials as an IAM role for API Gateway to invoke the authorizer. To specify an IAM role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To use resource-based permissions on the Lambda function, specify null. Supported only for REQUEST authorizers.</p>",
+        "CreateApiInput$CredentialsArn" : "<p>This property is part of quick create. It specifies the credentials required for the integration, if any. For a Lambda integration, three options are available. To specify an IAM Role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To require that the caller's identity be passed through from the request, specify arn:aws:iam::*:user/*. To use resource-based permissions on supported AWS services, specify null. Currently, this property is not used for HTTP integrations. Supported only for HTTP APIs.</p>",
+        "CreateAuthorizerInput$AuthorizerCredentialsArn" : "<p>Specifies the required credentials as an IAM role for API Gateway to invoke the authorizer. To specify an IAM role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To use resource-based permissions on the Lambda function, specify null. Supported only for REQUEST authorizers.</p>",
+        "CreateIntegrationInput$CredentialsArn" : "<p>Specifies the credentials required for the integration, if any. For AWS integrations, three options are available. To specify an IAM Role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To require that the caller's identity be passed through from the request, specify the string arn:aws:iam::*:user/*. To use resource-based permissions on supported AWS services, specify null.</p>",
+        "DomainNameConfiguration$CertificateArn" : "<p>An AWS-managed certificate that will be used by the edge-optimized endpoint for this domain name. AWS Certificate Manager is the only supported source.</p>",
+        "Integration$CredentialsArn" : "<p>Specifies the credentials required for the integration, if any. For AWS integrations, three options are available. To specify an IAM Role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To require that the caller's identity be passed through from the request, specify the string arn:aws:iam::*:user/*. To use resource-based permissions on supported AWS services, specify null.</p>",
+        "UpdateApiInput$CredentialsArn" : "<p>This property is part of quick create. It specifies the credentials required for the integration, if any. For a Lambda integration, three options are available. To specify an IAM Role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To require that the caller's identity be passed through from the request, specify arn:aws:iam::*:user/*. To use resource-based permissions on supported AWS services, specify null. Currently, this property is not used for HTTP integrations. If provided, this value replaces the credentials associated with the quick create integration. Supported only for HTTP APIs.</p>",
+        "UpdateAuthorizerInput$AuthorizerCredentialsArn" : "<p>Specifies the required credentials as an IAM role for API Gateway to invoke the authorizer. To specify an IAM role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To use resource-based permissions on the Lambda function, specify null.</p>",
+        "UpdateIntegrationInput$CredentialsArn" : "<p>Specifies the credentials required for the integration, if any. For AWS integrations, three options are available. To specify an IAM Role for API Gateway to assume, use the role's Amazon Resource Name (ARN). To require that the caller's identity be passed through from the request, specify the string arn:aws:iam::*:user/*. To use resource-based permissions on supported AWS services, specify null.</p>"
+      }
+    },
+    "AuthorizationScopes" : {
+      "base" : "<p>A list of authorization scopes configured on a route. The scopes are used with a JWT authorizer to authorize the method invocation. The authorization works by matching the route scopes against the scopes parsed from the access token in the incoming request. The method invocation is authorized if any route scope matches a claimed scope in the access token. Otherwise, the invocation is not authorized. When the route scope is configured, the client must provide an access token instead of an identity token for authorization purposes.</p>",
+      "refs" : {
+        "CreateRouteInput$AuthorizationScopes" : "<p>The authorization scopes supported by this route.</p>",
+        "Route$AuthorizationScopes" : "<p>A list of authorization scopes configured on a route. The scopes are used with a JWT authorizer to authorize the method invocation. The authorization works by matching the route scopes against the scopes parsed from the access token in the incoming request. The method invocation is authorized if any route scope matches a claimed scope in the access token. Otherwise, the invocation is not authorized. When the route scope is configured, the client must provide an access token instead of an identity token for authorization purposes.</p>",
+        "UpdateRouteInput$AuthorizationScopes" : "<p>The authorization scopes supported by this route.</p>"
+      }
+    },
+    "AuthorizationType" : {
+      "base" : "<p>The authorization type. For WebSocket APIs, valid values are NONE for open access, AWS_IAM for using AWS IAM permissions, and CUSTOM for using a Lambda authorizer. For HTTP APIs, valid values are NONE for open access, or JWT for using JSON Web Tokens.</p>",
+      "refs" : {
+        "CreateRouteInput$AuthorizationType" : "<p>The authorization type for the route. For WebSocket APIs, valid values are NONE for open access, AWS_IAM for using AWS IAM permissions, and CUSTOM for using a Lambda authorizer For HTTP APIs, valid values are NONE for open access, or JWT for using JSON Web Tokens.</p>",
+        "Route$AuthorizationType" : "<p>The authorization type for the route. For WebSocket APIs, valid values are NONE for open access, AWS_IAM for using AWS IAM permissions, and CUSTOM for using a Lambda authorizer For HTTP APIs, valid values are NONE for open access, or JWT for using JSON Web Tokens.</p>",
+        "UpdateRouteInput$AuthorizationType" : "<p>The authorization type for the route. For WebSocket APIs, valid values are NONE for open access, AWS_IAM for using AWS IAM permissions, and CUSTOM for using a Lambda authorizer For HTTP APIs, valid values are NONE for open access, or JWT for using JSON Web Tokens.</p>"
+      }
+    },
+    "Authorizer" : {
+      "base" : "<p>Represents an authorizer.</p>",
+      "refs" : {
+        "__listOfAuthorizer$member" : null
+      }
+    },
+    "AuthorizerType" : {
+      "base" : "<p>The authorizer type. For WebSocket APIs, specify REQUEST for a Lambda function using incoming request parameters. For HTTP APIs, specify JWT to use JSON Web Tokens.</p>",
+      "refs" : {
+        "Authorizer$AuthorizerType" : "<p>The authorizer type. For WebSocket APIs, specify REQUEST for a Lambda function using incoming request parameters. For HTTP APIs, specify JWT to use JSON Web Tokens.</p>",
+        "CreateAuthorizerInput$AuthorizerType" : "<p>The authorizer type. For WebSocket APIs, specify REQUEST for a Lambda function using incoming request parameters. For HTTP APIs, specify JWT to use JSON Web Tokens.</p>",
+        "UpdateAuthorizerInput$AuthorizerType" : "<p>The authorizer type. For WebSocket APIs, specify REQUEST for a Lambda function using incoming request parameters. For HTTP APIs, specify JWT to use JSON Web Tokens.</p>"
+      }
+    },
+    "Authorizers" : {
+      "base" : "<p>Represents a collection of authorizers.</p>",
+      "refs" : { }
+    },
+    "BadRequestException" : {
+      "base" : "<p>The request is not valid, for example, the input is incomplete or incorrect. See the accompanying error message for details.</p>",
+      "refs" : { }
+    },
+    "ConflictException" : {
+      "base" : "<p>The requested operation would cause a conflict with the current state of a service resource associated with the request. Resolve the conflict before retrying this request. See the accompanying error message for details.</p>",
+      "refs" : { }
+    },
+    "ConnectionType" : {
+      "base" : "<p>Represents a connection type.</p>",
+      "refs" : {
+        "CreateIntegrationInput$ConnectionType" : "<p>The type of the network connection to the integration endpoint. Specify INTERNET for connections through the public routable internet or VPC_LINK for private connections between API Gateway and resources in a VPC. The default value is INTERNET.</p>",
+        "Integration$ConnectionType" : "<p>The type of the network connection to the integration endpoint. Specify INTERNET for connections through the public routable internet or VPC_LINK for private connections between API Gateway and resources in a VPC. The default value is INTERNET.</p>",
+        "UpdateIntegrationInput$ConnectionType" : "<p>The type of the network connection to the integration endpoint. Specify INTERNET for connections through the public routable internet or VPC_LINK for private connections between API Gateway and resources in a VPC. The default value is INTERNET.</p>"
+      }
+    },
+    "ContentHandlingStrategy" : {
+      "base" : "<p>Specifies how to handle response payload content type conversions. Supported only for WebSocket APIs.</p>",
+      "refs" : {
+        "CreateIntegrationInput$ContentHandlingStrategy" : "<p>Supported only for WebSocket APIs. Specifies how to handle response payload content type conversions. Supported values are CONVERT_TO_BINARY and CONVERT_TO_TEXT, with the following behaviors:</p> <p>CONVERT_TO_BINARY: Converts a response payload from a Base64-encoded string to the corresponding binary blob.</p> <p>CONVERT_TO_TEXT: Converts a response payload from a binary blob to a Base64-encoded string.</p> <p>If this property is not defined, the response payload will be passed through from the integration response to the route response or method response without modification.</p>",
+        "CreateIntegrationResponseInput$ContentHandlingStrategy" : "<p>Specifies how to handle response payload content type conversions. Supported values are CONVERT_TO_BINARY and CONVERT_TO_TEXT, with the following behaviors:</p> <p>CONVERT_TO_BINARY: Converts a response payload from a Base64-encoded string to the corresponding binary blob.</p> <p>CONVERT_TO_TEXT: Converts a response payload from a binary blob to a Base64-encoded string.</p> <p>If this property is not defined, the response payload will be passed through from the integration response to the route response or method response without modification.</p>",
+        "Integration$ContentHandlingStrategy" : "<p>Supported only for WebSocket APIs. Specifies how to handle response payload content type conversions. Supported values are CONVERT_TO_BINARY and CONVERT_TO_TEXT, with the following behaviors:</p> <p>CONVERT_TO_BINARY: Converts a response payload from a Base64-encoded string to the corresponding binary blob.</p> <p>CONVERT_TO_TEXT: Converts a response payload from a binary blob to a Base64-encoded string.</p> <p>If this property is not defined, the response payload will be passed through from the integration response to the route response or method response without modification.</p>",
+        "IntegrationResponse$ContentHandlingStrategy" : "<p>Supported only for WebSocket APIs. Specifies how to handle response payload content type conversions. Supported values are CONVERT_TO_BINARY and CONVERT_TO_TEXT, with the following behaviors:</p> <p>CONVERT_TO_BINARY: Converts a response payload from a Base64-encoded string to the corresponding binary blob.</p> <p>CONVERT_TO_TEXT: Converts a response payload from a binary blob to a Base64-encoded string.</p> <p>If this property is not defined, the response payload will be passed through from the integration response to the route response or method response without modification.</p>",
+        "UpdateIntegrationInput$ContentHandlingStrategy" : "<p>Supported only for WebSocket APIs. Specifies how to handle response payload content type conversions. Supported values are CONVERT_TO_BINARY and CONVERT_TO_TEXT, with the following behaviors:</p> <p>CONVERT_TO_BINARY: Converts a response payload from a Base64-encoded string to the corresponding binary blob.</p> <p>CONVERT_TO_TEXT: Converts a response payload from a binary blob to a Base64-encoded string.</p> <p>If this property is not defined, the response payload will be passed through from the integration response to the route response or method response without modification.</p>",
+        "UpdateIntegrationResponseInput$ContentHandlingStrategy" : "<p>Supported only for WebSocket APIs. Specifies how to handle response payload content type conversions. Supported values are CONVERT_TO_BINARY and CONVERT_TO_TEXT, with the following behaviors:</p> <p>CONVERT_TO_BINARY: Converts a response payload from a Base64-encoded string to the corresponding binary blob.</p> <p>CONVERT_TO_TEXT: Converts a response payload from a binary blob to a Base64-encoded string.</p> <p>If this property is not defined, the response payload will be passed through from the integration response to the route response or method response without modification.</p>"
+      }
+    },
+    "Cors" : {
+      "base" : "<p>Represents a CORS configuration. Supported only for HTTP APIs. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-cors.html\">Configuring CORS</a> for more information.</p>",
+      "refs" : {
+        "Api$CorsConfiguration" : "<p>A CORS configuration. Supported only for HTTP APIs.</p>",
+        "CreateApiInput$CorsConfiguration" : "<p>A CORS configuration. Supported only for HTTP APIs. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-cors.html\">Configuring CORS</a> for more information.</p>",
+        "UpdateApiInput$CorsConfiguration" : "<p>A CORS configuration. Supported only for HTTP APIs.</p>"
+      }
+    },
+    "CorsHeaderList" : {
+      "base" : "<p>Represents a collection of allowed headers. Supported only for HTTP APIs.</p>",
+      "refs" : {
+        "Cors$AllowHeaders" : "<p>Represents a collection of allowed headers. Supported only for HTTP APIs.</p>",
+        "Cors$ExposeHeaders" : "<p>Represents a collection of exposed headers. Supported only for HTTP APIs.</p>"
+      }
+    },
+    "CorsMethodList" : {
+      "base" : "<p>Represents a collection of methods. Supported only for HTTP APIs.</p>",
+      "refs" : {
+        "Cors$AllowMethods" : "<p>Represents a collection of allowed HTTP methods. Supported only for HTTP APIs.</p>"
+      }
+    },
+    "CorsOriginList" : {
+      "base" : "<p>Represents a collection of origins. Supported only for HTTP APIs.</p>",
+      "refs" : {
+        "Cors$AllowOrigins" : "<p>Represents a collection of allowed origins. Supported only for HTTP APIs.</p>"
+      }
+    },
+    "CreateApiInput" : {
+      "base" : "<p>Represents the input parameters for a CreateApi request.</p>",
+      "refs" : { }
+    },
+    "CreateApiMappingInput" : {
+      "base" : "<p>Represents the input parameters for a CreateApiMapping request.</p>",
+      "refs" : { }
+    },
+    "CreateAuthorizerInput" : {
+      "base" : "<p>Represents the input parameters for a CreateAuthorizer request.</p>",
+      "refs" : { }
+    },
+    "CreateDeploymentInput" : {
+      "base" : "<p>Represents the input parameters for a CreateDeployment request.</p>",
+      "refs" : { }
+    },
+    "CreateDomainNameInput" : {
+      "base" : "<p>Represents the input parameters for a CreateDomainName request.</p>",
+      "refs" : { }
+    },
+    "CreateIntegrationInput" : {
+      "base" : "<p>Represents the input parameters for a CreateIntegration request.</p>",
+      "refs" : { }
+    },
+    "CreateIntegrationResponseInput" : {
+      "base" : "<p>Represents the input parameters for a CreateIntegrationResponse request.</p>",
+      "refs" : { }
+    },
+    "CreateModelInput" : {
+      "base" : "<p>Represents the input parameters for a CreateModel request.</p>",
+      "refs" : { }
+    },
+    "CreateRouteInput" : {
+      "base" : "<p>Represents the input parameters for a CreateRoute request.</p>",
+      "refs" : { }
+    },
+    "CreateRouteResponseInput" : {
+      "base" : "<p>Represents the input parameters for an CreateRouteResponse request.</p>",
+      "refs" : { }
+    },
+    "CreateStageInput" : {
+      "base" : "<p>Represents the input parameters for a CreateStage request.</p>",
+      "refs" : { }
+    },
+    "CreateVpcLinkInput" : {
+      "base" : "<p>Represents the input parameters for a CreateVpcLink request.</p>",
+      "refs" : { }
+    },
+    "Deployment" : {
+      "base" : "<p>An immutable representation of an API that can be called by users. A Deployment must be associated with a Stage for it to be callable over the internet.</p>",
+      "refs" : {
+        "__listOfDeployment$member" : null
+      }
+    },
+    "DeploymentStatus" : {
+      "base" : "<p>Represents a deployment status.</p>",
+      "refs" : {
+        "Deployment$DeploymentStatus" : "<p>The status of the deployment: PENDING, FAILED, or SUCCEEDED.</p>"
+      }
+    },
+    "Deployments" : {
+      "base" : "<p>A collection resource that contains zero or more references to your existing deployments, and links that guide you on how to interact with your collection. The collection offers a paginated view of the contained deployments.</p>",
+      "refs" : { }
+    },
+    "DomainName" : {
+      "base" : "<p>Represents a domain name.</p>",
+      "refs" : {
+        "__listOfDomainName$member" : null
+      }
+    },
+    "DomainNameConfiguration" : {
+      "base" : "<p>The domain name configuration.</p>",
+      "refs" : {
+        "DomainNameConfigurations$member" : null
+      }
+    },
+    "DomainNameConfigurations" : {
+      "base" : "<p>The domain name configurations.</p>",
+      "refs" : {
+        "CreateDomainNameInput$DomainNameConfigurations" : "<p>The domain name configurations.</p>",
+        "DomainName$DomainNameConfigurations" : "<p>The domain name configurations.</p>",
+        "UpdateDomainNameInput$DomainNameConfigurations" : "<p>The domain name configurations.</p>"
+      }
+    },
+    "DomainNameStatus" : {
+      "base" : "<p>The status of the domain name migration. The valid values are AVAILABLE and UPDATING. If the status is UPDATING, the domain cannot be modified further until the existing operation is complete. If it is AVAILABLE, the domain can be updated.</p>",
+      "refs" : {
+        "DomainNameConfiguration$DomainNameStatus" : "<p>The status of the domain name migration. The valid values are AVAILABLE and UPDATING. If the status is UPDATING, the domain cannot be modified further until the existing operation is complete. If it is AVAILABLE, the domain can be updated.</p>"
+      }
+    },
+    "DomainNames" : {
+      "base" : "<p>Represents a collection of domain names.</p>",
+      "refs" : { }
+    },
+    "EndpointType" : {
+      "base" : "<p>Represents an endpoint type.</p>",
+      "refs" : {
+        "DomainNameConfiguration$EndpointType" : "<p>The endpoint type.</p>"
+      }
+    },
+    "ExportedApi" : {
+      "base" : "<p>Represents an exported definition of an API in a particular output format, for example, YAML. The API is serialized to the requested specification, for example, OpenAPI 3.0.</p>",
+      "refs" : { }
+    },
+    "Id" : {
+      "base" : "<p>The identifier.</p>",
+      "refs" : {
+        "Api$ApiId" : "<p>The API ID.</p>",
+        "ApiMapping$ApiId" : "<p>The API identifier.</p>",
+        "ApiMapping$ApiMappingId" : "<p>The API mapping identifier.</p>",
+        "Authorizer$AuthorizerId" : "<p>The authorizer identifier.</p>",
+        "CreateApiMappingInput$ApiId" : "<p>The API identifier.</p>",
+        "CreateRouteInput$AuthorizerId" : "<p>The identifier of the Authorizer resource to be associated with this route. The authorizer identifier is generated by API Gateway when you created the authorizer.</p>",
+        "CreateStageInput$ClientCertificateId" : "<p>The identifier of a client certificate for a Stage. Supported only for WebSocket APIs.</p>",
+        "CreateStageInput$DeploymentId" : "<p>The deployment identifier of the API stage.</p>",
+        "Deployment$DeploymentId" : "<p>The identifier for the deployment.</p>",
+        "Integration$IntegrationId" : "<p>Represents the identifier of an integration.</p>",
+        "IntegrationResponse$IntegrationResponseId" : "<p>The integration response ID.</p>",
+        "Model$ModelId" : "<p>The model identifier.</p>",
+        "Route$AuthorizerId" : "<p>The identifier of the Authorizer resource to be associated with this route. The authorizer identifier is generated by API Gateway when you created the authorizer.</p>",
+        "Route$RouteId" : "<p>The route ID.</p>",
+        "RouteResponse$RouteResponseId" : "<p>Represents the identifier of a route response.</p>",
+        "Stage$ClientCertificateId" : "<p>The identifier of a client certificate for a Stage. Supported only for WebSocket APIs.</p>",
+        "Stage$DeploymentId" : "<p>The identifier of the Deployment that the Stage is associated with. Can't be updated if autoDeploy is enabled.</p>",
+        "UpdateApiMappingInput$ApiId" : "<p>The API identifier.</p>",
+        "UpdateRouteInput$AuthorizerId" : "<p>The identifier of the Authorizer resource to be associated with this route. The authorizer identifier is generated by API Gateway when you created the authorizer.</p>",
+        "UpdateStageInput$ClientCertificateId" : "<p>The identifier of a client certificate for a Stage.</p>",
+        "UpdateStageInput$DeploymentId" : "<p>The deployment identifier for the API stage. Can't be updated if autoDeploy is enabled.</p>",
+        "VpcLink$VpcLinkId" : "<p>The ID of the VPC link.</p>"
+      }
+    },
+    "IdentitySourceList" : {
+      "base" : "<p>The identity source for which authorization is requested. For the REQUEST authorizer, this is required when authorization caching is enabled. The value is a comma-separated string of one or more mapping expressions of the specified request parameters. For example, if an Auth header, a Name query string parameter are defined as identity sources, this value is $method.request.header.Auth, $method.request.querystring.Name. These parameters will be used to derive the authorization caching key and to perform runtime validation of the REQUEST authorizer by verifying all of the identity-related request parameters are present, not null and non-empty. Only when this is true does the authorizer invoke the authorizer Lambda function, otherwise, it returns a 401 Unauthorized response without calling the Lambda function. The valid value is a string of comma-separated mapping expressions of the specified request parameters. When the authorization caching is not enabled, this property is optional.</p>",
+      "refs" : {
+        "Authorizer$IdentitySource" : "<p>The identity source for which authorization is requested.</p> <p>For a REQUEST authorizer, this is optional. The value is a set of one or more mapping expressions of the specified request parameters. Currently, the identity source can be headers, query string parameters, stage variables, and context parameters. For example, if an Auth header and a Name query string parameter are defined as identity sources, this value is route.request.header.Auth, route.request.querystring.Name. These parameters will be used to perform runtime validation for Lambda-based authorizers by verifying all of the identity-related request parameters are present in the request, not null, and non-empty. Only when this is true does the authorizer invoke the authorizer Lambda function. Otherwise, it returns a 401 Unauthorized response without calling the Lambda function.</p> <p>For JWT, a single entry that specifies where to extract the JSON Web Token (JWT) from inbound requests. Currently only header-based and query parameter-based selections are supported, for example \"$request.header.Authorization\".</p>",
+        "CreateAuthorizerInput$IdentitySource" : "<p>The identity source for which authorization is requested.</p> <p>For a REQUEST authorizer, this is optional. The value is a set of one or more mapping expressions of the specified request parameters. Currently, the identity source can be headers, query string parameters, stage variables, and context parameters. For example, if an Auth header and a Name query string parameter are defined as identity sources, this value is route.request.header.Auth, route.request.querystring.Name. These parameters will be used to perform runtime validation for Lambda-based authorizers by verifying all of the identity-related request parameters are present in the request, not null, and non-empty. Only when this is true does the authorizer invoke the authorizer Lambda function. Otherwise, it returns a 401 Unauthorized response without calling the Lambda function.</p> <p>For JWT, a single entry that specifies where to extract the JSON Web Token (JWT )from inbound requests. Currently only header-based and query parameter-based selections are supported, for example \"$request.header.Authorization\".</p>",
+        "UpdateAuthorizerInput$IdentitySource" : "<p>The identity source for which authorization is requested.</p> <p>For a REQUEST authorizer, this is optional. The value is a set of one or more mapping expressions of the specified request parameters. Currently, the identity source can be headers, query string parameters, stage variables, and context parameters. For example, if an Auth header and a Name query string parameter are defined as identity sources, this value is route.request.header.Auth, route.request.querystring.Name. These parameters will be used to perform runtime validation for Lambda-based authorizers by verifying all of the identity-related request parameters are present in the request, not null, and non-empty. Only when this is true does the authorizer invoke the authorizer Lambda function. Otherwise, it returns a 401 Unauthorized response without calling the Lambda function.</p> <p>For JWT, a single entry that specifies where to extract the JSON Web Token (JWT) from inbound requests. Currently only header-based and query parameter-based selections are supported, for example \"$request.header.Authorization\".</p>"
+      }
+    },
+    "ImportApiInput" : {
+      "base" : "<p>Represents the input to ImportAPI. Supported only for HTTP APIs.</p>",
+      "refs" : { }
+    },
+    "IntegerWithLengthBetween0And3600" : {
+      "base" : "<p>An integer with a value between [0-3600].</p>",
+      "refs" : {
+        "Authorizer$AuthorizerResultTtlInSeconds" : "<p>Authorizer caching is not currently supported. Don't specify this value for authorizers.</p>",
+        "CreateAuthorizerInput$AuthorizerResultTtlInSeconds" : "<p>Authorizer caching is not currently supported. Don't specify this value for authorizers.</p>",
+        "UpdateAuthorizerInput$AuthorizerResultTtlInSeconds" : "<p>Authorizer caching is not currently supported. Don't specify this value for authorizers.</p>"
+      }
+    },
+    "IntegerWithLengthBetween50And30000" : {
+      "base" : "<p>An integer with a value between [50-30000].</p>",
+      "refs" : {
+        "CreateIntegrationInput$TimeoutInMillis" : "<p>Custom timeout between 50 and 29,000 milliseconds for WebSocket APIs and between 50 and 30,000 milliseconds for HTTP APIs. The default timeout is 29 seconds for WebSocket APIs and 30 seconds for HTTP APIs.</p>",
+        "Integration$TimeoutInMillis" : "<p>Custom timeout between 50 and 29,000 milliseconds for WebSocket APIs and between 50 and 30,000 milliseconds for HTTP APIs. The default timeout is 29 seconds for WebSocket APIs and 30 seconds for HTTP APIs.</p>",
+        "UpdateIntegrationInput$TimeoutInMillis" : "<p>Custom timeout between 50 and 29,000 milliseconds for WebSocket APIs and between 50 and 30,000 milliseconds for HTTP APIs. The default timeout is 29 seconds for WebSocket APIs and 30 seconds for HTTP APIs.</p>"
+      }
+    },
+    "IntegerWithLengthBetweenMinus1And86400" : {
+      "base" : "<p>An integer with a value between -1 and 86400. Supported only for HTTP APIs.</p>",
+      "refs" : {
+        "Cors$MaxAge" : "<p>The number of seconds that the browser should cache preflight request results. Supported only for HTTP APIs.</p>"
+      }
+    },
+    "Integration" : {
+      "base" : "<p>Represents an integration.</p>",
+      "refs" : {
+        "__listOfIntegration$member" : null
+      }
+    },
+    "IntegrationParameters" : {
+      "base" : "<p>A key-value map specifying response parameters that are passed to the method response from the backend. The key is a method response header parameter name and the mapped value is an integration response header value, a static value enclosed within a pair of single quotes, or a JSON expression from the integration response body. The mapping key must match the pattern of method.response.header.{name}, where name is a valid and unique header name. The mapped non-static value must match the pattern of integration.response.header.{name} or integration.response.body.{JSON-expression}, where name is a valid and unique response header name and JSON-expression is a valid JSON expression without the $ prefix.</p>",
+      "refs" : {
+        "CreateIntegrationInput$RequestParameters" : "<p>A key-value map specifying request parameters that are passed from the method request to the backend. The key is an integration request parameter name and the associated value is a method request parameter value or static value that must be enclosed within single quotes and pre-encoded as required by the backend. The method request parameter value must match the pattern of method.request.<replaceable>{location}</replaceable>.<replaceable>{name}</replaceable>\n               , where \n                  <replaceable>{location}</replaceable>\n                is querystring, path, or header; and \n                  <replaceable>{name}</replaceable>\n                must be a valid and unique method request parameter name. Supported only for WebSocket APIs.</p>",
+        "CreateIntegrationResponseInput$ResponseParameters" : "<p>A key-value map specifying response parameters that are passed to the method response from the backend. The key is a method response header parameter name and the mapped value is an integration response header value, a static value enclosed within a pair of single quotes, or a JSON expression from the integration response body. The mapping key must match the pattern of method.response.header.{name}, where {name} is a valid and unique header name. The mapped non-static value must match the pattern of integration.response.header.{name} or integration.response.body.{JSON-expression}, where {name} is a valid and unique response header name and {JSON-expression} is a valid JSON expression without the $ prefix.</p>",
+        "Integration$RequestParameters" : "<p>A key-value map specifying request parameters that are passed from the method request to the backend. The key is an integration request parameter name and the associated value is a method request parameter value or static value that must be enclosed within single quotes and pre-encoded as required by the backend. The method request parameter value must match the pattern of method.request.<replaceable>{location}</replaceable>.<replaceable>{name}</replaceable>\n               , where \n                  <replaceable>{location}</replaceable>\n                is querystring, path, or header; and \n                  <replaceable>{name}</replaceable>\n                must be a valid and unique method request parameter name. Supported only for WebSocket APIs.</p>",
+        "IntegrationResponse$ResponseParameters" : "<p>A key-value map specifying response parameters that are passed to the method response from the backend. The key is a method response header parameter name and the mapped value is an integration response header value, a static value enclosed within a pair of single quotes, or a JSON expression from the integration response body. The mapping key must match the pattern of method.response.header.{name}, where name is a valid and unique header name. The mapped non-static value must match the pattern of integration.response.header.{name} or integration.response.body.{JSON-expression}, where name is a valid and unique response header name and JSON-expression is a valid JSON expression without the $ prefix.</p>",
+        "UpdateIntegrationInput$RequestParameters" : "<p>A key-value map specifying request parameters that are passed from the method request to the backend. The key is an integration request parameter name and the associated value is a method request parameter value or static value that must be enclosed within single quotes and pre-encoded as required by the backend. The method request parameter value must match the pattern of method.request.<replaceable>{location}</replaceable>.<replaceable>{name}</replaceable>\n               , where \n                  <replaceable>{location}</replaceable>\n                is querystring, path, or header; and \n                  <replaceable>{name}</replaceable>\n                must be a valid and unique method request parameter name. Supported only for WebSocket APIs.</p>",
+        "UpdateIntegrationResponseInput$ResponseParameters" : "<p>A key-value map specifying response parameters that are passed to the method response from the backend. The key is a method response header parameter name and the mapped value is an integration response header value, a static value enclosed within a pair of single quotes, or a JSON expression from the integration response body. The mapping key must match the pattern of method.response.header.<replaceable>{name}</replaceable>\n               , where name is a valid and unique header name. The mapped non-static value must match the pattern of integration.response.header.<replaceable>{name}</replaceable>\n                or integration.response.body.<replaceable>{JSON-expression}</replaceable>\n               , where \n                  <replaceable>{name}</replaceable>\n                is a valid and unique response header name and \n                  <replaceable>{JSON-expression}</replaceable>\n                is a valid JSON expression without the $ prefix.</p>"
+      }
+    },
+    "IntegrationResponse" : {
+      "base" : "<p>Represents an integration response.</p>",
+      "refs" : {
+        "__listOfIntegrationResponse$member" : null
+      }
+    },
+    "IntegrationResponses" : {
+      "base" : "<p>Represents a collection of integration responses.</p>",
+      "refs" : { }
+    },
+    "IntegrationType" : {
+      "base" : "<p>Represents an API method integration type.</p>",
+      "refs" : {
+        "CreateIntegrationInput$IntegrationType" : "<p>The integration type of an integration. One of the following:</p> <p>AWS: for integrating the route or method request with an AWS service action, including the Lambda function-invoking action. With the Lambda function-invoking action, this is referred to as the Lambda custom integration. With any other AWS service action, this is known as AWS integration. Supported only for WebSocket APIs.</p> <p>AWS_PROXY: for integrating the route or method request with the Lambda function-invoking action with the client request passed through as-is. This integration is also referred to as Lambda proxy integration.</p> <p>HTTP: for integrating the route or method request with an HTTP endpoint. This integration is also referred to as the HTTP custom integration. Supported only for WebSocket APIs.</p> <p>HTTP_PROXY: for integrating the route or method request with an HTTP endpoint, with the client request passed through as-is. This is also referred to as HTTP proxy integration. For HTTP API private integrations, use an HTTP_PROXY integration.</p> <p>MOCK: for integrating the route or method request with API Gateway as a \"loopback\" endpoint without invoking any backend. Supported only for WebSocket APIs.</p>",
+        "Integration$IntegrationType" : "<p>The integration type of an integration. One of the following:</p> <p>AWS: for integrating the route or method request with an AWS service action, including the Lambda function-invoking action. With the Lambda function-invoking action, this is referred to as the Lambda custom integration. With any other AWS service action, this is known as AWS integration. Supported only for WebSocket APIs.</p> <p>AWS_PROXY: for integrating the route or method request with the Lambda function-invoking action with the client request passed through as-is. This integration is also referred to as Lambda proxy integration.</p> <p>HTTP: for integrating the route or method request with an HTTP endpoint. This integration is also referred to as the HTTP custom integration. Supported only for WebSocket APIs.</p> <p>HTTP_PROXY: for integrating the route or method request with an HTTP endpoint, with the client request passed through as-is. This is also referred to as HTTP proxy integration.</p> <p>MOCK: for integrating the route or method request with API Gateway as a \"loopback\" endpoint without invoking any backend. Supported only for WebSocket APIs.</p>",
+        "UpdateIntegrationInput$IntegrationType" : "<p>The integration type of an integration. One of the following:</p> <p>AWS: for integrating the route or method request with an AWS service action, including the Lambda function-invoking action. With the Lambda function-invoking action, this is referred to as the Lambda custom integration. With any other AWS service action, this is known as AWS integration. Supported only for WebSocket APIs.</p> <p>AWS_PROXY: for integrating the route or method request with the Lambda function-invoking action with the client request passed through as-is. This integration is also referred to as Lambda proxy integration.</p> <p>HTTP: for integrating the route or method request with an HTTP endpoint. This integration is also referred to as the HTTP custom integration. Supported only for WebSocket APIs.</p> <p>HTTP_PROXY: for integrating the route or method request with an HTTP endpoint, with the client request passed through as-is. This is also referred to as HTTP proxy integration. For HTTP API private integrations, use an HTTP_PROXY integration.</p> <p>MOCK: for integrating the route or method request with API Gateway as a \"loopback\" endpoint without invoking any backend. Supported only for WebSocket APIs.</p>"
+      }
+    },
+    "Integrations" : {
+      "base" : "<p>Represents a collection of integrations.</p>",
+      "refs" : { }
+    },
+    "JWTConfiguration" : {
+      "base" : "<p>Represents the configuration of a JWT authorizer. Required for the JWT authorizer type. Supported only for HTTP APIs.</p>",
+      "refs" : {
+        "Authorizer$JwtConfiguration" : "<p>Represents the configuration of a JWT authorizer. Required for the JWT authorizer type. Supported only for HTTP APIs.</p>",
+        "CreateAuthorizerInput$JwtConfiguration" : "<p>Represents the configuration of a JWT authorizer. Required for the JWT authorizer type. Supported only for HTTP APIs.</p>",
+        "UpdateAuthorizerInput$JwtConfiguration" : "<p>Represents the configuration of a JWT authorizer. Required for the JWT authorizer type. Supported only for HTTP APIs.</p>"
+      }
+    },
+    "LimitExceededException" : {
+      "base" : "<p>A limit has been exceeded. See the accompanying error message for details.</p>",
+      "refs" : { }
+    },
+    "LoggingLevel" : {
+      "base" : "<p>The logging level.</p>",
+      "refs" : {
+        "RouteSettings$LoggingLevel" : "<p>Specifies the logging level for this route: INFO, ERROR, or OFF. This property affects the log entries pushed to Amazon CloudWatch Logs. Supported only for WebSocket APIs.</p>"
+      }
+    },
+    "Model" : {
+      "base" : "<p>Represents a data model for an API. Supported only for WebSocket APIs. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html\">Create Models and Mapping Templates for Request and Response Mappings</a>.</p>",
+      "refs" : {
+        "__listOfModel$member" : null
+      }
+    },
+    "Models" : {
+      "base" : "<p>Represents a collection of data models. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/models-mappings.html\">Create Models and Mapping Templates for Request and Response Mappings</a>.</p>",
+      "refs" : { }
+    },
+    "NextToken" : {
+      "base" : "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+      "refs" : {
+        "ApiMappings$NextToken" : "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+        "Apis$NextToken" : "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+        "Authorizers$NextToken" : "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+        "Deployments$NextToken" : "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+        "DomainNames$NextToken" : "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+        "IntegrationResponses$NextToken" : "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+        "Integrations$NextToken" : "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+        "Models$NextToken" : "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+        "RouteResponses$NextToken" : "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+        "Routes$NextToken" : "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+        "Stages$NextToken" : "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>",
+        "VpcLinks$NextToken" : "<p>The next page of elements from this collection. Not valid for the last element of the collection.</p>"
+      }
+    },
+    "NotFoundException" : {
+      "base" : "<p>The resource specified in the request was not found. See the message field for more information.</p>",
+      "refs" : { }
+    },
+    "ParameterConstraints" : {
+      "base" : "<p>Validation constraints imposed on parameters of a request (path, query string, headers).</p>",
+      "refs" : {
+        "RouteParameters$member" : null
+      }
+    },
+    "PassthroughBehavior" : {
+      "base" : "<p>Represents passthrough behavior for an integration response. Supported only for WebSocket APIs.</p>",
+      "refs" : {
+        "CreateIntegrationInput$PassthroughBehavior" : "<p>Specifies the pass-through behavior for incoming requests based on the Content-Type header in the request, and the available mapping templates specified as the requestTemplates property on the Integration resource. There are three valid values: WHEN_NO_MATCH, WHEN_NO_TEMPLATES, and NEVER. Supported only for WebSocket APIs.</p> <p>WHEN_NO_MATCH passes the request body for unmapped content types through to the integration backend without transformation.</p> <p>NEVER rejects unmapped content types with an HTTP 415 Unsupported Media Type response.</p> <p>WHEN_NO_TEMPLATES allows pass-through when the integration has no content types mapped to templates. However, if there is at least one content type defined, unmapped content types will be rejected with the same HTTP 415 Unsupported Media Type response.</p>",
+        "Integration$PassthroughBehavior" : "<p>Specifies the pass-through behavior for incoming requests based on the Content-Type header in the request, and the available mapping templates specified as the requestTemplates property on the Integration resource. There are three valid values: WHEN_NO_MATCH, WHEN_NO_TEMPLATES, and NEVER. Supported only for WebSocket APIs.</p> <p>WHEN_NO_MATCH passes the request body for unmapped content types through to the integration backend without transformation.</p> <p>NEVER rejects unmapped content types with an HTTP 415 Unsupported Media Type response.</p> <p>WHEN_NO_TEMPLATES allows pass-through when the integration has no content types mapped to templates. However, if there is at least one content type defined, unmapped content types will be rejected with the same HTTP 415 Unsupported Media Type response.</p>",
+        "UpdateIntegrationInput$PassthroughBehavior" : "<p>Specifies the pass-through behavior for incoming requests based on the Content-Type header in the request, and the available mapping templates specified as the requestTemplates property on the Integration resource. There are three valid values: WHEN_NO_MATCH, WHEN_NO_TEMPLATES, and NEVER. Supported only for WebSocket APIs.</p> <p>WHEN_NO_MATCH passes the request body for unmapped content types through to the integration backend without transformation.</p> <p>NEVER rejects unmapped content types with an HTTP 415 Unsupported Media Type response.</p> <p>WHEN_NO_TEMPLATES allows pass-through when the integration has no content types mapped to templates. However, if there is at least one content type defined, unmapped content types will be rejected with the same HTTP 415 Unsupported Media Type response.</p>"
+      }
+    },
+    "ProtocolType" : {
+      "base" : "Represents a protocol type.",
+      "refs" : {
+        "Api$ProtocolType" : "<p>The API protocol.</p>",
+        "CreateApiInput$ProtocolType" : "<p>The API protocol.</p>"
+      }
+    },
+    "ReimportApiInput" : {
+      "base" : "<p>Overwrites the configuration of an existing API using the provided definition. Supported only for HTTP APIs.</p>",
+      "refs" : { }
+    },
+    "Route" : {
+      "base" : "<p>Represents a route.</p>",
+      "refs" : {
+        "__listOfRoute$member" : null
+      }
+    },
+    "RouteModels" : {
+      "base" : "<p>The route models.</p>",
+      "refs" : {
+        "CreateRouteInput$RequestModels" : "<p>The request models for the route. Supported only for WebSocket APIs.</p>",
+        "CreateRouteResponseInput$ResponseModels" : "<p>The response models for the route response.</p>",
+        "Route$RequestModels" : "<p>The request models for the route. Supported only for WebSocket APIs.</p>",
+        "RouteResponse$ResponseModels" : "<p>Represents the response models of a route response.</p>",
+        "UpdateRouteInput$RequestModels" : "<p>The request models for the route. Supported only for WebSocket APIs.</p>",
+        "UpdateRouteResponseInput$ResponseModels" : "<p>The response models for the route response.</p>"
+      }
+    },
+    "RouteParameters" : {
+      "base" : "<p>The route parameters.</p>",
+      "refs" : {
+        "CreateRouteInput$RequestParameters" : "<p>The request parameters for the route. Supported only for WebSocket APIs.</p>",
+        "CreateRouteResponseInput$ResponseParameters" : "<p>The route response parameters.</p>",
+        "Route$RequestParameters" : "<p>The request parameters for the route. Supported only for WebSocket APIs.</p>",
+        "RouteResponse$ResponseParameters" : "<p>Represents the response parameters of a route response.</p>",
+        "UpdateRouteInput$RequestParameters" : "<p>The request parameters for the route. Supported only for WebSocket APIs.</p>",
+        "UpdateRouteResponseInput$ResponseParameters" : "<p>The route response parameters.</p>"
+      }
+    },
+    "RouteResponse" : {
+      "base" : "<p>Represents a route response.</p>",
+      "refs" : {
+        "__listOfRouteResponse$member" : null
+      }
+    },
+    "RouteResponses" : {
+      "base" : "<p>Represents a collection of route responses.</p>",
+      "refs" : { }
+    },
+    "RouteSettings" : {
+      "base" : "<p>Represents a collection of route settings.</p>",
+      "refs" : {
+        "CreateStageInput$DefaultRouteSettings" : "<p>The default route settings for the stage.</p>",
+        "RouteSettingsMap$member" : null,
+        "Stage$DefaultRouteSettings" : "<p>Default route settings for the stage.</p>",
+        "UpdateStageInput$DefaultRouteSettings" : "<p>The default route settings for the stage.</p>"
+      }
+    },
+    "RouteSettingsMap" : {
+      "base" : "<p>The route settings map.</p>",
+      "refs" : {
+        "CreateStageInput$RouteSettings" : "<p>Route settings for the stage, by routeKey.</p>",
+        "Stage$RouteSettings" : "<p>Route settings for the stage, by routeKey.</p>",
+        "UpdateStageInput$RouteSettings" : "<p>Route settings for the stage.</p>"
+      }
+    },
+    "Routes" : {
+      "base" : "<p>Represents a collection of routes.</p>",
+      "refs" : { }
+    },
+    "SecurityGroupIdList" : {
+      "base" : "<p>A list of security group IDs for the VPC link.</p>",
+      "refs" : {
+        "CreateVpcLinkInput$SecurityGroupIds" : "<p>A list of security group IDs for the VPC link.</p>",
+        "VpcLink$SecurityGroupIds" : "<p>A list of security group IDs for the VPC link.</p>"
+      }
+    },
+    "SecurityPolicy" : {
+      "base" : "<p>The Transport Layer Security (TLS) version of the security policy for this domain name. The valid values are TLS_1_0 and TLS_1_2.</p>",
+      "refs" : {
+        "DomainNameConfiguration$SecurityPolicy" : "<p>The Transport Layer Security (TLS) version of the security policy for this domain name. The valid values are TLS_1_0 and TLS_1_2.</p>"
+      }
+    },
+    "SelectionExpression" : {
+      "base" : "<p>An expression used to extract information at runtime. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-apikey-selection-expressions\">Selection Expressions</a> for more information.</p>",
+      "refs" : {
+        "Api$ApiKeySelectionExpression" : "<p>An API key selection expression. Supported only for WebSocket APIs. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-apikey-selection-expressions\">API Key Selection Expressions</a>.</p>",
+        "Api$RouteSelectionExpression" : "<p>The route selection expression for the API. For HTTP APIs, the routeSelectionExpression must be ${request.method} ${request.path}. If not provided, this will be the default for HTTP APIs. This property is required for WebSocket APIs.</p>",
+        "CreateApiInput$ApiKeySelectionExpression" : "<p>An API key selection expression. Supported only for WebSocket APIs. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-apikey-selection-expressions\">API Key Selection Expressions</a>.</p>",
+        "CreateApiInput$RouteSelectionExpression" : "<p>The route selection expression for the API. For HTTP APIs, the routeSelectionExpression must be ${request.method} ${request.path}. If not provided, this will be the default for HTTP APIs. This property is required for WebSocket APIs.</p>",
+        "CreateIntegrationInput$TemplateSelectionExpression" : "<p>The template selection expression for the integration.</p>",
+        "CreateIntegrationResponseInput$TemplateSelectionExpression" : "<p>The template selection expression for the integration response. Supported only for WebSocket APIs.</p>",
+        "CreateRouteInput$ModelSelectionExpression" : "<p>The model selection expression for the route. Supported only for WebSocket APIs.</p>",
+        "CreateRouteInput$RouteResponseSelectionExpression" : "<p>The route response selection expression for the route. Supported only for WebSocket APIs.</p>",
+        "CreateRouteResponseInput$ModelSelectionExpression" : "<p>The model selection expression for the route response. Supported only for WebSocket APIs.</p>",
+        "DomainName$ApiMappingSelectionExpression" : "<p>The API mapping selection expression.</p>",
+        "Integration$IntegrationResponseSelectionExpression" : "<p>The integration response selection expression for the integration. Supported only for WebSocket APIs. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-integration-response-selection-expressions\">Integration Response Selection Expressions</a>.</p>",
+        "Integration$TemplateSelectionExpression" : "<p>The template selection expression for the integration. Supported only for WebSocket APIs.</p>",
+        "IntegrationResponse$TemplateSelectionExpression" : "<p>The template selection expressions for the integration response.</p>",
+        "Route$ModelSelectionExpression" : "<p>The model selection expression for the route. Supported only for WebSocket APIs.</p>",
+        "Route$RouteResponseSelectionExpression" : "<p>The route response selection expression for the route. Supported only for WebSocket APIs.</p>",
+        "RouteResponse$ModelSelectionExpression" : "<p>Represents the model selection expression of a route response. Supported only for WebSocket APIs.</p>",
+        "UpdateApiInput$ApiKeySelectionExpression" : "<p>An API key selection expression. Supported only for WebSocket APIs. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-apikey-selection-expressions\">API Key Selection Expressions</a>.</p>",
+        "UpdateApiInput$RouteSelectionExpression" : "<p>The route selection expression for the API. For HTTP APIs, the routeSelectionExpression must be ${request.method} ${request.path}. If not provided, this will be the default for HTTP APIs. This property is required for WebSocket APIs.</p>",
+        "UpdateIntegrationInput$TemplateSelectionExpression" : "<p>The template selection expression for the integration.</p>",
+        "UpdateIntegrationResponseInput$TemplateSelectionExpression" : "<p>The template selection expression for the integration response. Supported only for WebSocket APIs.</p>",
+        "UpdateRouteInput$ModelSelectionExpression" : "<p>The model selection expression for the route. Supported only for WebSocket APIs.</p>",
+        "UpdateRouteInput$RouteResponseSelectionExpression" : "<p>The route response selection expression for the route. Supported only for WebSocket APIs.</p>",
+        "UpdateRouteResponseInput$ModelSelectionExpression" : "<p>The model selection expression for the route response. Supported only for WebSocket APIs.</p>"
+      }
+    },
+    "SelectionKey" : {
+      "base" : "<p>After evaluating a selection expression, the result is compared against one or more selection keys to find a matching key. See <a href=\"https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-websocket-api-selection-expressions.html#apigateway-websocket-api-apikey-selection-expressions\">Selection Expressions</a> for a list of expressions and each expression's associated selection key type.</p>",
+      "refs" : {
+        "ApiMapping$ApiMappingKey" : "<p>The API mapping key.</p>",
+        "CreateApiInput$RouteKey" : "<p>This property is part of quick create. If you don't specify a routeKey, a default route of $default is created. The $default route acts as a catch-all for any request made to your API, for a particular stage. The $default route key can't be modified. You can add routes after creating the API, and you can update the route keys of additional routes. Supported only for HTTP APIs.</p>",
+        "CreateApiMappingInput$ApiMappingKey" : "The API mapping key.",
+        "CreateIntegrationResponseInput$IntegrationResponseKey" : "<p>The integration response key.</p>",
+        "CreateRouteInput$RouteKey" : "<p>The route key for the route.</p>",
+        "CreateRouteResponseInput$RouteResponseKey" : "<p>The route response key.</p>",
+        "IntegrationResponse$IntegrationResponseKey" : "<p>The integration response key.</p>",
+        "Route$RouteKey" : "<p>The route key for the route.</p>",
+        "RouteResponse$RouteResponseKey" : "<p>Represents the route response key of a route response.</p>",
+        "UpdateApiInput$RouteKey" : "<p>This property is part of quick create. If not specified, the route created using quick create is kept. Otherwise, this value replaces the route key of the quick create route. Additional routes may still be added after the API is updated. Supported only for HTTP APIs.</p>",
+        "UpdateApiMappingInput$ApiMappingKey" : "<p>The API mapping key.</p>",
+        "UpdateIntegrationResponseInput$IntegrationResponseKey" : "<p>The integration response key.</p>",
+        "UpdateRouteInput$RouteKey" : "<p>The route key for the route.</p>",
+        "UpdateRouteResponseInput$RouteResponseKey" : "<p>The route response key.</p>"
+      }
+    },
+    "Stage" : {
+      "base" : "<p>Represents an API stage.</p>",
+      "refs" : {
+        "__listOfStage$member" : null
+      }
+    },
+    "StageVariablesMap" : {
+      "base" : "<p>The stage variable map.</p>",
+      "refs" : {
+        "CreateStageInput$StageVariables" : "<p>A map that defines the stage variables for a Stage. Variable names can have alphanumeric and underscore characters, and the values must match [A-Za-z0-9-._~:/?#&amp;=,]+.</p>",
+        "Stage$StageVariables" : "<p>A map that defines the stage variables for a stage resource. Variable names can have alphanumeric and underscore characters, and the values must match [A-Za-z0-9-._~:/?#&amp;=,]+.</p>",
+        "UpdateStageInput$StageVariables" : "<p>A map that defines the stage variables for a Stage. Variable names can have alphanumeric and underscore characters, and the values must match [A-Za-z0-9-._~:/?#&amp;=,]+.</p>"
+      }
+    },
+    "Stages" : {
+      "base" : "<p>A collection of Stage resources that are associated with the ApiKey resource.</p>",
+      "refs" : { }
+    },
+    "StringWithLengthBetween0And1024" : {
+      "base" : "<p>A string with a length between [0-1024].</p>",
+      "refs" : {
+        "Api$Description" : "<p>The description of the API.</p>",
+        "Authorizer$IdentityValidationExpression" : "<p>The validation expression does not apply to the REQUEST authorizer.</p>",
+        "CreateApiInput$Description" : "<p>The description of the API.</p>",
+        "CreateAuthorizerInput$IdentityValidationExpression" : "<p>This parameter is not used.</p>",
+        "CreateDeploymentInput$Description" : "<p>The description for the deployment resource.</p>",
+        "CreateIntegrationInput$Description" : "<p>The description of the integration.</p>",
+        "CreateModelInput$Description" : "<p>The description of the model.</p>",
+        "CreateStageInput$Description" : "<p>The description for the API stage.</p>",
+        "Deployment$Description" : "<p>The description for the deployment.</p>",
+        "Integration$Description" : "<p>Represents the description of an integration.</p>",
+        "Model$Description" : "<p>The description of the model.</p>",
+        "Stage$Description" : "<p>The description of the stage.</p>",
+        "UpdateApiInput$Description" : "<p>The description of the API.</p>",
+        "UpdateAuthorizerInput$IdentityValidationExpression" : "<p>This parameter is not used.</p>",
+        "UpdateDeploymentInput$Description" : "<p>The description for the deployment resource.</p>",
+        "UpdateIntegrationInput$Description" : "<p>The description of the integration</p>",
+        "UpdateModelInput$Description" : "<p>The description of the model.</p>",
+        "UpdateStageInput$Description" : "<p>The description for the API stage.</p>",
+        "VpcLink$VpcLinkStatusMessage" : "<p>A message summarizing the cause of the status of the VPC link.</p>"
+      }
+    },
+    "StringWithLengthBetween0And2048" : {
+      "base" : "<p>A string with a length between [0-2048].</p>",
+      "refs" : {
+        "StageVariablesMap$member" : null
+      }
+    },
+    "StringWithLengthBetween0And32K" : {
+      "base" : "<p>A string with a length between [0-32768].</p>",
+      "refs" : {
+        "CreateModelInput$Schema" : "<p>The schema for the model. For application/json models, this should be JSON schema draft 4 model.</p>",
+        "Model$Schema" : "<p>The schema for the model. For application/json models, this should be JSON schema draft 4 model.</p>",
+        "TemplateMap$member" : null,
+        "UpdateModelInput$Schema" : "<p>The schema for the model. For application/json models, this should be JSON schema draft 4 model.</p>"
+      }
+    },
+    "StringWithLengthBetween1And1024" : {
+      "base" : "<p>A string with a length between [1-1024].</p>",
+      "refs" : {
+        "AccessLogSettings$Format" : "<p>A single line format of the access logs of data, as specified by selected $context variables. The format must include at least $context.requestId.</p>",
+        "CreateIntegrationInput$ConnectionId" : "<p>The ID of the VPC link for a private integration. Supported only for HTTP APIs.</p>",
+        "Integration$ConnectionId" : "<p>The ID of the VPC link for a private integration. Supported only for HTTP APIs.</p>",
+        "UpdateIntegrationInput$ConnectionId" : "<p>The ID of the VPC link for a private integration. Supported only for HTTP APIs.</p>"
+      }
+    },
+    "StringWithLengthBetween1And128" : {
+      "base" : "<p>A string with a length between [1-128].</p>",
+      "refs" : {
+        "Api$Name" : "<p>The name of the API.</p>",
+        "ApiMapping$Stage" : "<p>The API stage.</p>",
+        "Authorizer$Name" : "<p>The name of the authorizer.</p>",
+        "CreateApiInput$Name" : "<p>The name of the API.</p>",
+        "CreateApiMappingInput$Stage" : "<p>The API stage.</p>",
+        "CreateAuthorizerInput$Name" : "<p>The name of the authorizer.</p>",
+        "CreateDeploymentInput$StageName" : "<p>The name of the Stage resource for the Deployment resource to create.</p>",
+        "CreateModelInput$Name" : "<p>The name of the model. Must be alphanumeric.</p>",
+        "CreateRouteInput$Target" : "<p>The target for the route.</p>",
+        "CreateStageInput$StageName" : "<p>The name of the stage.</p>",
+        "CreateVpcLinkInput$Name" : "<p>The name of the VPC link.</p>",
+        "DomainNameConfiguration$CertificateName" : "<p>The user-friendly name of the certificate that will be used by the edge-optimized endpoint for this domain name.</p>",
+        "Model$Name" : "<p>The name of the model. Must be alphanumeric.</p>",
+        "Route$Target" : "<p>The target for the route.</p>",
+        "RouteModels$member" : null,
+        "Stage$StageName" : "<p>The name of the stage.</p>",
+        "UpdateApiInput$Name" : "<p>The name of the API.</p>",
+        "UpdateApiMappingInput$Stage" : "<p>The API stage.</p>",
+        "UpdateAuthorizerInput$Name" : "<p>The name of the authorizer.</p>",
+        "UpdateModelInput$Name" : "<p>The name of the model.</p>",
+        "UpdateRouteInput$Target" : "<p>The target for the route.</p>",
+        "UpdateVpcLinkInput$Name" : "<p>The name of the VPC link.</p>",
+        "VpcLink$Name" : "<p>The name of the VPC link.</p>"
+      }
+    },
+    "StringWithLengthBetween1And1600" : {
+      "base" : "<p>A string with a length between [0-1600].</p>",
+      "refs" : {
+        "Tags$member" : null
+      }
+    },
+    "StringWithLengthBetween1And256" : {
+      "base" : "<p>A string with a length between [1-256].</p>",
+      "refs" : {
+        "CreateModelInput$ContentType" : "<p>The content-type for the model, for example, \"application/json\".</p>",
+        "Model$ContentType" : "<p>The content-type for the model, for example, \"application/json\".</p>",
+        "UpdateModelInput$ContentType" : "<p>The content-type for the model, for example, \"application/json\".</p>"
+      }
+    },
+    "StringWithLengthBetween1And512" : {
+      "base" : "<p>A string with a length between [1-512].</p>",
+      "refs" : {
+        "CreateDomainNameInput$DomainName" : "<p>The domain name.</p>",
+        "DomainName$DomainName" : "<p>The name of the DomainName resource.</p>",
+        "IntegrationParameters$member" : null,
+        "TlsConfig$ServerNameToVerify" : "<p>If you specify a server name, API Gateway uses it to verify the hostname on the integration's certificate. The server name is also included in the TLS handshake to support Server Name Indication (SNI) or virtual hosting.</p>",
+        "TlsConfigInput$ServerNameToVerify" : "<p>If you specify a server name, API Gateway uses it to verify the hostname on the integration's certificate. The server name is also included in the TLS handshake to support Server Name Indication (SNI) or virtual hosting.</p>"
+      }
+    },
+    "StringWithLengthBetween1And64" : {
+      "base" : "<p>A string with a length between [1-64].</p>",
+      "refs" : {
+        "Api$Version" : "<p>A version identifier for the API.</p>",
+        "AuthorizationScopes$member" : null,
+        "CorsMethodList$member" : null,
+        "CreateApiInput$Version" : "<p>A version identifier for the API.</p>",
+        "CreateIntegrationInput$IntegrationMethod" : "<p>Specifies the integration's HTTP method type.</p>",
+        "CreateIntegrationInput$PayloadFormatVersion" : "<p>Specifies the format of the payload sent to an integration. Required for HTTP APIs.</p>",
+        "CreateRouteInput$OperationName" : "<p>The operation name for the route.</p>",
+        "Integration$IntegrationMethod" : "<p>Specifies the integration's HTTP method type.</p>",
+        "Integration$PayloadFormatVersion" : "<p>Specifies the format of the payload sent to an integration. Required for HTTP APIs.</p>",
+        "Route$OperationName" : "<p>The operation name for the route.</p>",
+        "UpdateApiInput$Version" : "<p>A version identifier for the API.</p>",
+        "UpdateIntegrationInput$IntegrationMethod" : "<p>Specifies the integration's HTTP method type.</p>",
+        "UpdateIntegrationInput$PayloadFormatVersion" : "<p>Specifies the format of the payload sent to an integration. Required for HTTP APIs.</p>",
+        "UpdateRouteInput$OperationName" : "<p>The operation name for the route.</p>"
+      }
+    },
+    "SubnetIdList" : {
+      "base" : "<p>A list of subnet IDs to include in the VPC link.</p>",
+      "refs" : {
+        "CreateVpcLinkInput$SubnetIds" : "<p>A list of subnet IDs to include in the VPC link.</p>",
+        "VpcLink$SubnetIds" : "<p>A list of subnet IDs to include in the VPC link.</p>"
+      }
+    },
+    "TagResourceInput" : {
+      "base" : "<p>Represents the input parameters for a TagResource request.</p>",
+      "refs" : { }
+    },
+    "Tags" : {
+      "base" : "<p>Represents a collection of tags associated with the resource.</p>",
+      "refs" : {
+        "Api$Tags" : "<p>A collection of tags associated with the API.</p>",
+        "CreateApiInput$Tags" : "<p>The collection of tags. Each tag element is associated with a given resource.</p>",
+        "CreateDomainNameInput$Tags" : "<p>The collection of tags associated with a domain name.</p>",
+        "CreateStageInput$Tags" : "<p>The collection of tags. Each tag element is associated with a given resource.</p>",
+        "CreateVpcLinkInput$Tags" : "<p>A list of tags.</p>",
+        "DomainName$Tags" : "<p>The collection of tags associated with a domain name.</p>",
+        "Stage$Tags" : "<p>The collection of tags. Each tag element is associated with a given resource.</p>",
+        "TagResourceInput$Tags" : "<p>The collection of tags. Each tag element is associated with a given resource.</p>",
+        "VpcLink$Tags" : "<p>Tags for the VPC link.</p>"
+      }
+    },
+    "Template" : {
+      "base" : "<p>Represents a template.</p>",
+      "refs" : { }
+    },
+    "TemplateMap" : {
+      "base" : "<p>A mapping of identifier keys to templates. The value is an actual template script. The key is typically a SelectionKey which is chosen based on evaluating a selection expression.</p>",
+      "refs" : {
+        "CreateIntegrationInput$RequestTemplates" : "<p>Represents a map of Velocity templates that are applied on the request payload based on the value of the Content-Type header sent by the client. The content type value is the key in this map, and the template (as a String) is the value. Supported only for WebSocket APIs.</p>",
+        "CreateIntegrationResponseInput$ResponseTemplates" : "<p>The collection of response templates for the integration response as a string-to-string map of key-value pairs. Response templates are represented as a key/value map, with a content-type as the key and a template as the value.</p>",
+        "Integration$RequestTemplates" : "<p>Represents a map of Velocity templates that are applied on the request payload based on the value of the Content-Type header sent by the client. The content type value is the key in this map, and the template (as a String) is the value. Supported only for WebSocket APIs.</p>",
+        "IntegrationResponse$ResponseTemplates" : "<p>The collection of response templates for the integration response as a string-to-string map of key-value pairs. Response templates are represented as a key/value map, with a content-type as the key and a template as the value.</p>",
+        "UpdateIntegrationInput$RequestTemplates" : "<p>Represents a map of Velocity templates that are applied on the request payload based on the value of the Content-Type header sent by the client. The content type value is the key in this map, and the template (as a String) is the value. Supported only for WebSocket APIs.</p>",
+        "UpdateIntegrationResponseInput$ResponseTemplates" : "<p>The collection of response templates for the integration response as a string-to-string map of key-value pairs. Response templates are represented as a key/value map, with a content-type as the key and a template as the value.</p>"
+      }
+    },
+    "TlsConfig" : {
+      "base" : "<p>The TLS configuration for a private integration. If you specify a TLS configuration, private integration traffic uses the HTTPS protocol. Supported only for HTTP APIs.</p>",
+      "refs" : {
+        "Integration$TlsConfig" : "<p>The TLS configuration for a private integration. If you specify a TLS configuration, private integration traffic uses the HTTPS protocol. Supported only for HTTP APIs.</p>"
+      }
+    },
+    "TlsConfigInput" : {
+      "base" : "<p>The TLS configuration for a private integration. If you specify a TLS configuration, private integration traffic uses the HTTPS protocol. Supported only for HTTP APIs.</p>",
+      "refs" : {
+        "CreateIntegrationInput$TlsConfig" : "<p>The TLS configuration for a private integration. If you specify a TLS configuration, private integration traffic uses the HTTPS protocol. Supported only for HTTP APIs.</p>",
+        "UpdateIntegrationInput$TlsConfig" : "<p>The TLS configuration for a private integration. If you specify a TLS configuration, private integration traffic uses the HTTPS protocol. Supported only for HTTP APIs.</p>"
+      }
+    },
+    "TooManyRequestsException" : {
+      "base" : "<p>A limit has been exceeded. See the accompanying error message for details.</p>",
+      "refs" : { }
+    },
+    "UpdateApiInput" : {
+      "base" : "<p>Represents the input parameters for an UpdateApi request.</p>",
+      "refs" : { }
+    },
+    "UpdateApiMappingInput" : {
+      "base" : "<p>Represents the input parameters for an UpdateApiMapping request.</p>",
+      "refs" : { }
+    },
+    "UpdateAuthorizerInput" : {
+      "base" : "<p>The input parameters for an UpdateAuthorizer request.</p>",
+      "refs" : { }
+    },
+    "UpdateDeploymentInput" : {
+      "base" : "<p>Represents the input parameters for an UpdateDeployment request.</p>",
+      "refs" : { }
+    },
+    "UpdateDomainNameInput" : {
+      "base" : "<p>Represents the input parameters for an UpdateDomainName request.</p>",
+      "refs" : { }
+    },
+    "UpdateIntegrationInput" : {
+      "base" : "<p>Represents the input parameters for an UpdateIntegration request.</p>",
+      "refs" : { }
+    },
+    "UpdateIntegrationResponseInput" : {
+      "base" : "<p>Represents the input parameters for an UpdateIntegrationResponse request.</p>",
+      "refs" : { }
+    },
+    "UpdateModelInput" : {
+      "base" : "<p>Represents the input parameters for an UpdateModel request. Supported only for WebSocket APIs.</p>",
+      "refs" : { }
+    },
+    "UpdateRouteInput" : {
+      "base" : "<p>Represents the input parameters for an UpdateRoute request.</p>",
+      "refs" : { }
+    },
+    "UpdateRouteResponseInput" : {
+      "base" : "<p>Represents the input parameters for an UpdateRouteResponse request.</p>",
+      "refs" : { }
+    },
+    "UpdateStageInput" : {
+      "base" : "<p>Represents the input parameters for an UpdateStage request.</p>",
+      "refs" : { }
+    },
+    "UpdateVpcLinkInput" : {
+      "base" : "<p>Represents the input parameters for an UpdateVpcLink request.</p>",
+      "refs" : { }
+    },
+    "UriWithLengthBetween1And2048" : {
+      "base" : "<p>A string representation of a URI with a length between [1-2048].</p>",
+      "refs" : {
+        "Authorizer$AuthorizerUri" : "<p>The authorizer's Uniform Resource Identifier (URI). ForREQUEST authorizers, this must be a well-formed Lambda function URI, for example, arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:<replaceable>{account_id}</replaceable>:function:<replaceable>{lambda_function_name}</replaceable>/invocations. In general, the URI has this form: arn:aws:apigateway:<replaceable>{region}</replaceable>:lambda:path/<replaceable>{service_api}</replaceable>\n               , where <replaceable></replaceable>{region} is the same as the region hosting the Lambda function, path indicates that the remaining substring in the URI should be treated as the path to the resource, including the initial /. For Lambda functions, this is usually of the form /2015-03-31/functions/[FunctionARN]/invocations. Supported only for REQUEST authorizers.</p>",
+        "CreateApiInput$Target" : "<p>This property is part of quick create. Quick create produces an API with an integration, a default catch-all route, and a default stage which is configured to automatically deploy changes. For HTTP integrations, specify a fully qualified URL. For Lambda integrations, specify a function ARN. The type of the integration will be HTTP_PROXY or AWS_PROXY, respectively. Supported only for HTTP APIs.</p>",
+        "CreateAuthorizerInput$AuthorizerUri" : "<p>The authorizer's Uniform Resource Identifier (URI). For REQUEST authorizers, this must be a well-formed Lambda function URI, for example, arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:<replaceable>{account_id}</replaceable>:function:<replaceable>{lambda_function_name}</replaceable>/invocations. In general, the URI has this form: arn:aws:apigateway:<replaceable>{region}</replaceable>:lambda:path/<replaceable>{service_api}</replaceable>\n               , where <replaceable></replaceable>{region} is the same as the region hosting the Lambda function, path indicates that the remaining substring in the URI should be treated as the path to the resource, including the initial /. For Lambda functions, this is usually of the form /2015-03-31/functions/[FunctionARN]/invocations. Supported only for REQUEST authorizers.</p>",
+        "CreateIntegrationInput$IntegrationUri" : "<p>For a Lambda integration, specify the URI of a Lambda function.</p> <p>For an HTTP integration, specify a fully-qualified URL.</p> <p>For an HTTP API private integration, specify the ARN of an Application Load Balancer listener, Network Load Balancer listener, or AWS Cloud Map service. If you specify the ARN of an AWS Cloud Map service, API Gateway uses DiscoverInstances to identify resources. You can use query parameters to target specific resources. To learn more, see <a href=\"https://docs.aws.amazon.com/cloud-map/latest/api/API_DiscoverInstances.html\">DiscoverInstances</a>. For private integrations, all resources must be owned by the same AWS account.</p>",
+        "Integration$IntegrationUri" : "<p>For a Lambda integration, specify the URI of a Lambda function.</p> <p>For an HTTP integration, specify a fully-qualified URL.</p> <p>For an HTTP API private integration, specify the ARN of an Application Load Balancer listener, Network Load Balancer listener, or AWS Cloud Map service. If you specify the ARN of an AWS Cloud Map service, API Gateway uses DiscoverInstances to identify resources. You can use query parameters to target specific resources. To learn more, see <a href=\"https://docs.aws.amazon.com/cloud-map/latest/api/API_DiscoverInstances.html\">DiscoverInstances</a>. For private integrations, all resources must be owned by the same AWS account.</p>",
+        "JWTConfiguration$Issuer" : "<p>The base domain of the identity provider that issues JSON Web Tokens. For example, an Amazon Cognito user pool has the following format: https://cognito-idp.<replaceable>{region}</replaceable>.amazonaws.com/<replaceable>{userPoolId}</replaceable>\n               . Required for the JWT authorizer type. Supported only for HTTP APIs.</p>",
+        "UpdateApiInput$Target" : "<p>This property is part of quick create. For HTTP integrations, specify a fully qualified URL. For Lambda integrations, specify a function ARN. The type of the integration will be HTTP_PROXY or AWS_PROXY, respectively. The value provided updates the integration URI and integration type. You can update a quick-created target, but you can't remove it from an API. Supported only for HTTP APIs.</p>",
+        "UpdateAuthorizerInput$AuthorizerUri" : "<p>The authorizer's Uniform Resource Identifier (URI). For REQUEST authorizers, this must be a well-formed Lambda function URI, for example, arn:aws:apigateway:us-west-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-west-2:<replaceable>{account_id}</replaceable>:function:<replaceable>{lambda_function_name}</replaceable>/invocations. In general, the URI has this form: arn:aws:apigateway:<replaceable>{region}</replaceable>:lambda:path/<replaceable>{service_api}</replaceable>\n               , where <replaceable></replaceable>{region} is the same as the region hosting the Lambda function, path indicates that the remaining substring in the URI should be treated as the path to the resource, including the initial /. For Lambda functions, this is usually of the form /2015-03-31/functions/[FunctionARN]/invocations. Supported only for REQUEST authorizers.</p>",
+        "UpdateIntegrationInput$IntegrationUri" : "<p>For a Lambda integration, specify the URI of a Lambda function.</p> <p>For an HTTP integration, specify a fully-qualified URL.</p> <p>For an HTTP API private integration, specify the ARN of an Application Load Balancer listener, Network Load Balancer listener, or AWS Cloud Map service. If you specify the ARN of an AWS Cloud Map service, API Gateway uses DiscoverInstances to identify resources. You can use query parameters to target specific resources. To learn more, see <a href=\"https://docs.aws.amazon.com/cloud-map/latest/api/API_DiscoverInstances.html\">DiscoverInstances</a>. For private integrations, all resources must be owned by the same AWS account.</p>"
+      }
+    },
+    "VpcLink" : {
+      "base" : "<p>Represents a VPC link.</p>",
+      "refs" : {
+        "__listOfVpcLink$member" : null
+      }
+    },
+    "VpcLinkStatus" : {
+      "base" : "<p>The status of the VPC link.</p>",
+      "refs" : {
+        "VpcLink$VpcLinkStatus" : "<p>The status of the VPC link.</p>"
+      }
+    },
+    "VpcLinkVersion" : {
+      "base" : "<p>The version of the VPC link.</p>",
+      "refs" : {
+        "VpcLink$VpcLinkVersion" : "<p>The version of the VPC link.</p>"
+      }
+    },
+    "VpcLinks" : {
+      "base" : "<p>Represents a collection of VPCLinks.</p>",
+      "refs" : { }
+    },
+    "__boolean" : {
+      "base" : null,
+      "refs" : {
+        "Api$DisableSchemaValidation" : "<p>Avoid validating models when creating a deployment. Supported only for WebSocket APIs.</p>",
+        "Cors$AllowCredentials" : "<p>Specifies whether credentials are included in the CORS request. Supported only for HTTP APIs.</p>",
+        "CreateApiInput$DisableSchemaValidation" : "<p>Avoid validating models when creating a deployment. Supported only for WebSocket APIs.</p>",
+        "CreateRouteInput$ApiKeyRequired" : "<p>Specifies whether an API key is required for the route. Supported only for WebSocket APIs.</p>",
+        "CreateStageInput$AutoDeploy" : "<p>Specifies whether updates to an API automatically trigger a new deployment. The default value is false.</p>",
+        "Deployment$AutoDeployed" : "<p>Specifies whether a deployment was automatically released.</p>",
+        "Integration$ApiGatewayManaged" : "<p>Specifies whether an integration is managed by API Gateway. If you created an API using using quick create, the resulting integration is managed by API Gateway. You can update a managed integration, but you can't delete it.</p>",
+        "ParameterConstraints$Required" : "<p>Whether or not the parameter is required.</p>",
+        "Route$ApiGatewayManaged" : "<p>Specifies whether a route is managed by API Gateway. If you created an API using quick create, the $default route is managed by API Gateway. You can't modify the $default route key.</p>",
+        "Route$ApiKeyRequired" : "<p>Specifies whether an API key is required for this route. Supported only for WebSocket APIs.</p>",
+        "RouteSettings$DataTraceEnabled" : "<p>Specifies whether (true) or not (false) data trace logging is enabled for this route. This property affects the log entries pushed to Amazon CloudWatch Logs. Supported only for WebSocket APIs.</p>",
+        "RouteSettings$DetailedMetricsEnabled" : "<p>Specifies whether detailed metrics are enabled.</p>",
+        "Stage$ApiGatewayManaged" : "<p>Specifies whether a stage is managed by API Gateway. If you created an API using quick create, the $default stage is managed by API Gateway. You can't modify the $default stage.</p>",
+        "Stage$AutoDeploy" : "<p>Specifies whether updates to an API automatically trigger a new deployment. The default value is false.</p>",
+        "UpdateApiInput$DisableSchemaValidation" : "<p>Avoid validating models when creating a deployment. Supported only for WebSocket APIs.</p>",
+        "UpdateRouteInput$ApiKeyRequired" : "<p>Specifies whether an API key is required for the route. Supported only for WebSocket APIs.</p>",
+        "UpdateStageInput$AutoDeploy" : "<p>Specifies whether updates to an API automatically trigger a new deployment. The default value is false.</p>"
+      }
+    },
+    "__double" : {
+      "base" : null,
+      "refs" : {
+        "RouteSettings$ThrottlingRateLimit" : "<p>Specifies the throttling rate limit.</p>"
+      }
+    },
+    "__integer" : {
+      "base" : null,
+      "refs" : {
+        "RouteSettings$ThrottlingBurstLimit" : "<p>Specifies the throttling burst limit.</p>"
+      }
+    },
+    "__listOfApi" : {
+      "base" : null,
+      "refs" : {
+        "Apis$Items" : "<p>The elements from this collection.</p>"
+      }
+    },
+    "__listOfApiMapping" : {
+      "base" : null,
+      "refs" : {
+        "ApiMappings$Items" : "<p>The elements from this collection.</p>"
+      }
+    },
+    "__listOfAuthorizer" : {
+      "base" : null,
+      "refs" : {
+        "Authorizers$Items" : "<p>The elements from this collection.</p>"
+      }
+    },
+    "__listOfDeployment" : {
+      "base" : null,
+      "refs" : {
+        "Deployments$Items" : "<p>The elements from this collection.</p>"
+      }
+    },
+    "__listOfDomainName" : {
+      "base" : null,
+      "refs" : {
+        "DomainNames$Items" : "<p>The elements from this collection.</p>"
+      }
+    },
+    "__listOfIntegration" : {
+      "base" : null,
+      "refs" : {
+        "Integrations$Items" : "<p>The elements from this collection.</p>"
+      }
+    },
+    "__listOfIntegrationResponse" : {
+      "base" : null,
+      "refs" : {
+        "IntegrationResponses$Items" : "<p>The elements from this collection.</p>"
+      }
+    },
+    "__listOfModel" : {
+      "base" : null,
+      "refs" : {
+        "Models$Items" : "<p>The elements from this collection.</p>"
+      }
+    },
+    "__listOfRoute" : {
+      "base" : null,
+      "refs" : {
+        "Routes$Items" : "<p>The elements from this collection.</p>"
+      }
+    },
+    "__listOfRouteResponse" : {
+      "base" : null,
+      "refs" : {
+        "RouteResponses$Items" : "<p>The elements from this collection.</p>"
+      }
+    },
+    "__listOfStage" : {
+      "base" : null,
+      "refs" : {
+        "Stages$Items" : "<p>The elements from this collection.</p>"
+      }
+    },
+    "__listOfVpcLink" : {
+      "base" : null,
+      "refs" : {
+        "VpcLinks$Items" : "<p>A collection of VPC links.</p>"
+      }
+    },
+    "__listOf__string" : {
+      "base" : null,
+      "refs" : {
+        "Api$ImportInfo" : "<p>The validation information during API import. This may include particular properties of your OpenAPI definition which are ignored during import. Supported only for HTTP APIs.</p>",
+        "Api$Warnings" : "<p>The warning messages reported when failonwarnings is turned on during API import.</p>",
+        "JWTConfiguration$Audience" : "<p>A list of the intended recipients of the JWT. A valid JWT must provide an aud that matches at least one entry in this list. See <a href=\"https://tools.ietf.org/html/rfc7519#section-4.1.3\">RFC 7519</a>. Supported only for HTTP APIs.</p>"
+      }
+    },
+    "__string" : {
+      "base" : null,
+      "refs" : {
+        "AccessDeniedException$Message" : null,
+        "Api$ApiEndpoint" : "<p>The URI of the API, of the form {api-id}.execute-api.{region}.amazonaws.com. The stage name is typically appended to this URI to form a complete path to a deployed API stage.</p>",
+        "BadRequestException$Message" : "<p>Describes the error encountered.</p>",
+        "ConflictException$Message" : "<p>Describes the error encountered.</p>",
+        "CorsHeaderList$member" : null,
+        "CorsOriginList$member" : null,
+        "Deployment$DeploymentStatusMessage" : "<p>May contain additional feedback on the status of an API deployment.</p>",
+        "DomainNameConfiguration$ApiGatewayDomainName" : "<p>A domain name for the API.</p>",
+        "DomainNameConfiguration$DomainNameStatusMessage" : "<p>An optional text message containing detailed information about status of the domain name migration.</p>",
+        "DomainNameConfiguration$HostedZoneId" : "<p>The Amazon Route 53 Hosted Zone ID of the endpoint.</p>",
+        "IdentitySourceList$member" : null,
+        "ImportApiInput$Body" : "<p>The OpenAPI definition. Supported only for HTTP APIs.</p>",
+        "LimitExceededException$LimitType" : "<p>The limit type.</p>",
+        "LimitExceededException$Message" : "<p>Describes the error encountered.</p>",
+        "NotFoundException$Message" : "<p>Describes the error encountered.</p>",
+        "NotFoundException$ResourceType" : "<p>The resource type.</p>",
+        "ReimportApiInput$Body" : "<p>The OpenAPI definition. Supported only for HTTP APIs.</p>",
+        "SecurityGroupIdList$member" : null,
+        "Stage$LastDeploymentStatusMessage" : "<p>Describes the status of the last deployment of a stage. Supported only for stages with autoDeploy enabled.</p>",
+        "SubnetIdList$member" : null,
+        "Template$Value" : "<p>The template value.</p>",
+        "__listOf__string$member" : null
+      }
+    },
+    "__timestampIso8601" : {
+      "base" : null,
+      "refs" : {
+        "Api$CreatedDate" : "<p>The timestamp when the API was created.</p>",
+        "Deployment$CreatedDate" : "<p>The date and time when the Deployment resource was created.</p>",
+        "DomainNameConfiguration$CertificateUploadDate" : "<p>The timestamp when the certificate that was used by edge-optimized endpoint for this domain name was uploaded.</p>",
+        "Stage$CreatedDate" : "<p>The timestamp when the stage was created.</p>",
+        "Stage$LastUpdatedDate" : "<p>The timestamp when the stage was last updated.</p>",
+        "VpcLink$CreatedDate" : "<p>The timestamp when the VPC link was created.</p>"
+      }
+    }
+  }
+}

--- a/pkg/model/type_def.go
+++ b/pkg/model/type_def.go
@@ -66,6 +66,9 @@ func (h *Helper) GetTypeDefs() ([]*TypeDef, map[string]string, error) {
 	// Map, keyed by package import path, with the values being an alias to use
 	// for the package
 	timports := map[string]string{}
+	// Map, keyed by original Shape GoTypeElem(), with the values being a
+	// renamed type name (due to conflicting names)
+	trenames := map[string]string{}
 
 	payloads := h.getPayloads()
 
@@ -84,6 +87,7 @@ func (h *Helper) GetTypeDefs() ([]*TypeDef, map[string]string, error) {
 		tdefNames := names.New(shapeName)
 		if h.HasConflictingTypeName(shapeName) {
 			tdefNames.Camel += ConflictingNameSuffix
+			trenames[shapeName] = tdefNames.Camel
 		}
 
 		attrs := map[string]*Attr{}

--- a/pkg/model/type_def_test.go
+++ b/pkg/model/type_def_test.go
@@ -1,0 +1,59 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package model_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/aws/aws-controllers-k8s/pkg/model"
+	"github.com/aws/aws-controllers-k8s/pkg/testutil"
+)
+
+func getTypeDefByName(name string, tdefs []*model.TypeDef) *model.TypeDef {
+	for _, td := range tdefs {
+		if td.Names.Original == name {
+			return td
+		}
+	}
+	return nil
+}
+
+func TestAPIGatewayV2_GetTypeDefs(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	sh := testutil.NewSchemaHelperForService(t, "apigatewayv2")
+
+	tdefs, timports, err := sh.GetTypeDefs()
+	require.Nil(err)
+
+	// APIGatewayV2 shapes have time.Time ("timestamp") types and so
+	// GetTypeDefs() should return the special-cased with apimachinery/metav1
+	// import, aliased as "metav1"
+	expImports := map[string]string{"k8s.io/apimachinery/pkg/apis/meta/v1": "metav1"}
+	assert.Equal(expImports, timports)
+
+	// There is an "Api" Shape that is a struct that is an element of the
+	// GetApis Operation. Its name conflicts with the CRD called API and thus
+	// we need to check that its cleaned name is set to API_SDK (the _SDK
+	// suffix is appended to the type name to avoid the conflict with
+	// CRD-specific structs.
+	tdef := getTypeDefByName("Api", tdefs)
+	require.NotNil(tdef)
+
+	assert.Equal("API_SDK", tdef.Names.Camel)
+}

--- a/scripts/lib/k8s.sh
+++ b/scripts/lib/k8s.sh
@@ -2,7 +2,9 @@
 
 ensure_controller_gen() {
   if ! is_installed controller-gen; then
-    go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0
+    # Need this version of controller-gen to allow dangerous types and float
+    # type support
+    go get sigs.k8s.io/controller-tools/cmd/controller-gen@4a903ddb7005459a7baf4777c67244a74c91083d
   fi
 }
 

--- a/templates/pkg/crd_sdk.go.tpl
+++ b/templates/pkg/crd_sdk.go.tpl
@@ -70,7 +70,7 @@ func (rm *resourceManager) newDescribeRequestPayload(
 	r *resource,
 ) (*svcsdk.{{ .CRD.Ops.ReadOne.InputRef.Shape.ShapeName }}, error) {
 	res := &svcsdk.{{ .CRD.Ops.ReadOne.InputRef.Shape.ShapeName }}{}
-{{ GoCodeSetReadOneInput .CRD "res" "r.ko.Spec" 1 }}
+{{ GoCodeSetReadOneInput .CRD "r.ko.Spec" "res" 1 }}
 	return res, nil
 }
 {{- else }}
@@ -104,7 +104,7 @@ func (rm *resourceManager) newCreateRequestPayload(
 	r *resource,
 ) (*svcsdk.{{ .CRD.Ops.Create.InputRef.Shape.ShapeName }}, error) {
 	res := &svcsdk.{{ .CRD.Ops.Create.InputRef.Shape.ShapeName }}{}
-{{ GoCodeSetCreateInput .CRD "res" "r.ko.Spec" 1 }}
+{{ GoCodeSetCreateInput .CRD "r.ko.Spec" "res" 1 }}
 	return res, nil
 }
 
@@ -141,7 +141,7 @@ func (rm *resourceManager) newUpdateRequestPayload(
 	r *resource,
 ) (*svcsdk.{{ .CRD.Ops.Update.InputRef.Shape.ShapeName }}, error) {
 	res := &svcsdk.{{ .CRD.Ops.Update.InputRef.Shape.ShapeName }}{}
-{{ GoCodeSetUpdateInput .CRD "res" "r.ko.Spec" 1 }}
+{{ GoCodeSetUpdateInput .CRD "r.ko.Spec" "res" 1 }}
 	return res, nil
 }
 {{ end }}
@@ -171,7 +171,7 @@ func (rm *resourceManager) newDeleteRequestPayload(
 	r *resource,
 ) (*svcsdk.{{ .CRD.Ops.Delete.InputRef.Shape.ShapeName }}, error) {
 	res := &svcsdk.{{ .CRD.Ops.Delete.InputRef.Shape.ShapeName }}{}
-{{ GoCodeSetDeleteInput .CRD "res" "r.ko.Spec" 1 }}
+{{ GoCodeSetDeleteInput .CRD "r.ko.Spec" "res" 1 }}
 	return res, nil
 }
 {{- end -}}

--- a/templates/pkg/crd_sdk.go.tpl
+++ b/templates/pkg/crd_sdk.go.tpl
@@ -5,6 +5,9 @@ package {{ .CRD.Names.Snake }}
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServiceAlias }}"
+
 {{- if .CRD.TypeImports }}
 {{- range $packagePath, $alias := .CRD.TypeImports }}
     {{ if $alias }}{{ $alias }} {{ end }}"{{ $packagePath }}"
@@ -19,11 +22,11 @@ import (
 {{- end }}
 
 	svcapitypes "github.com/aws/aws-controllers-k8s/services/{{ .ServiceAlias }}/apis/{{ .APIVersion }}"
-	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServiceAlias }}"
 )
 
 // Hack to avoid import errors during build...
 var (
+    _ = &metav1.Time{}
     _ = &svcsdk.{{ .SDKAPIInterfaceTypeName}}{}
     _ = &svcapitypes.{{ .CRD.Names.Camel }}{}
 )


### PR DESCRIPTION
Fixes a series of mistakes in the sdk.go generation of struct-fields and
array-fields for the Go code that constructs and initializes SDK Input
shapes as well as CRD Status structs.

we construct variables containing temporary storage for sub-elements
and sub-fields that are structs. Names of fields are "f" appended by
the 0-based index of the field within the set of a struct's set of
fields. Nested structs simply append another "f" and the field index
to the variable name.

This means you can tell what field a temporary fields variable
represents by the name.

For example, the field variable name "f0f5f2", it contains the third
field of the sixth field of the first field of the input shape being
constructed.

If we have two levels of nested struct fields, we will end
up with a targetVarName of "field0f0f0" and the generated code
might look something like this:

```go
res := &sdkapi.CreateBookInput{}
f0 := &sdkapi.BookData{}
f0f0 := &sdkapi.Author{}
f0f0f0 := &sdkapi.Address{}
f0f0f0.SetStreet(*ko.Spec.Author.Address.Street)
f0f0f0.SetCity(*ko.Spec.Author.Address.City)
f0f0f0.SetState(*ko.Spec.Author.Address.State)
f0f0.Address = field0f0f0
f0f0.SetName(*r.ko.Author.Name)
f0.Author = field0f0
res.Book = field0
```

It's ugly but at least consistent and mostly readable...

For populating list fields, we need an iterator and a temporary
element variable. We name these "{fieldName}iter" and
"{fieldName}elem" respectively. For nested levels, the names will be
progressively longer.

For list fields, we want to end up with something like this:

```
res := &sdkapi.CreateCustomAvailabilityZoneInput{}
f0 := []*sdkapi.VpnGroupMembership{}
for _, f0iter := ko.Spec.VPNGroupMemberships {
    f0elem := &sdkapi.VpnGroupMembership{}
    f0elem.SetVpnId(f0elem.VPNID)
    f0 := append(f0, f0elem)
}
res.VpnMemberships = f0
```

Issue #101

Code generated to set SDK shape and CRD struct field values for
"timestamp" types was not properly unwrapping the wrapped time.Time
value from the wrapper metav1.Time struct. This meant we were running
into build errors that looked like this:

```
cannot use resp.ReplicationGroup.AuthTokenLastModifiedDate (type *time.Time) as type *"k8s.io/apimachinery/pkg/apis/meta/v1".Time in assignment
cannot use resp.CacheCluster.AuthTokenLastModifiedDate (type *time.Time) as type *"k8s.io/apimachinery/pkg/apis/meta/v1".Time in assignment
```

This patch addresses that by special-casing the code generated for
setting CRD field or SDK type definition fields for timestamp types to
either pop the wrapped time.Time or wrapping a time.Time in a
metav1.Time.

Fixes Issue #98

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
