### PR TITLE
introduce framework for handling "special" APIs

### DIFF
--- a/cmd/ack-generate/command/apis.go
+++ b/cmd/ack-generate/command/apis.go
@@ -83,7 +83,10 @@ func generateAPIs(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	sh := model.NewHelper(sdkAPI)
+	sh, err := model.NewHelper(sdkAPI, optGeneratorConfigPath)
+	if err != nil {
+		return err
+	}
 
 	crds, err := sh.GetCRDs()
 	if err != nil {

--- a/cmd/ack-generate/command/controller.go
+++ b/cmd/ack-generate/command/controller.go
@@ -79,7 +79,10 @@ func generateController(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	sh := model.NewHelper(sdkAPI)
+	sh, err := model.NewHelper(sdkAPI, optGeneratorConfigPath)
+	if err != nil {
+		return err
+	}
 	latestAPIVersion, err = getLatestAPIVersion()
 	if err != nil {
 		return err

--- a/cmd/ack-generate/command/root.go
+++ b/cmd/ack-generate/command/root.go
@@ -31,17 +31,18 @@ A tool to generate AWS service controller code`
 )
 
 var (
-	version             string
-	buildHash           string
-	buildDate           string
-	defaultCacheDir     string
-	optCacheDir         string
-	defaultTemplatesDir string
-	optTemplatesDir     string
-	defaultServicesDir  string
-	optServicesDir      string
-	optDryRun           bool
-	sdkDir              string
+	version                string
+	buildHash              string
+	buildDate              string
+	defaultCacheDir        string
+	optCacheDir            string
+	defaultTemplatesDir    string
+	optTemplatesDir        string
+	defaultServicesDir     string
+	optServicesDir         string
+	optDryRun              bool
+	sdkDir                 string
+	optGeneratorConfigPath string
 )
 
 var rootCmd = &cobra.Command{
@@ -103,6 +104,9 @@ func init() {
 	)
 	rootCmd.PersistentFlags().StringVar(
 		&optCacheDir, "cache-dir", defaultCacheDir, "Path to directory to store cached files (including clone'd aws-sdk-go repo)",
+	)
+	rootCmd.PersistentFlags().StringVar(
+		&optGeneratorConfigPath, "generator-config-path", "", "Path to file containing instructions for code generation to use",
 	)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/dlclark/regexp2 v1.2.0
 	// pin to v0.1.1 due to release problem with v0.1.2
 	github.com/gertd/go-pluralize v0.1.1
+	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.1.0
 	github.com/google/go-cmp v0.3.0
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334

--- a/pkg/model/generator_config.go
+++ b/pkg/model/generator_config.go
@@ -1,0 +1,121 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package model
+
+import (
+	"io/ioutil"
+
+	"github.com/ghodss/yaml"
+)
+
+// GeneratorConfig represents instructions to the ACK code generator for a
+// particular AWS service API
+type GeneratorConfig struct {
+	// Resources contains generator instructions for individual CRDs within an
+	// API
+	Resources map[string]ResourceGeneratorConfig `json:"resources"`
+}
+
+// ResourceGeneratorConfig represents instructions to the ACK code generator
+// for a particular CRD/resource on an AWS service API
+type ResourceGeneratorConfig struct {
+	// UnpackAttributeMapConfig contains instructions for converting a raw
+	// `map[string]*string` into real fields on a CRD's Spec or Status object
+	UnpackAttributesMapConfig *UnpackAttributesMapConfig `json:"unpack_attributes_map,omitempty"`
+}
+
+// UnpackAttributesMapConfig informs the code generator that the API follows a
+// pattern or using an "Attributes" `map[string]*string` that contains real,
+// schema'd fields of the primary resource, and that those fields should be
+// "unpacked" from the raw map and into CRD's Spec and Status struct fields.
+//
+// AWS Simple Notification Service (SNS) and AWS Simple Queue Service (SQS) are
+// examples of APIs that use this pattern. For instance, the SNS CreateTopic
+// API accepts a parameter called "Attributes" that can contain one of four
+// keys:
+//
+// * DeliveryPolicy – The policy that defines how Amazon SNS retries failed
+//   deliveries to HTTP/S endpoints.
+// * DisplayName – The display name to use for a topic with SMS subscriptions
+// * Policy – The policy that defines who can access your topic.
+// * KmsMasterKeyId - The ID of an AWS-managed customer master key (CMK) for
+//   Amazon SNS or a custom CMK.
+//
+// The `CreateTopic` API call **returns** only a single field: the TopicARN.
+// But there is a separate `GetTopicAttributes` call that needs to be made that
+// returns the above attributes (that are ReadWrite) along with a set of
+// key/values that are ReadOnly:
+//
+// * Owner – The AWS account ID of the topic's owner.
+// * SubscriptionsConfirmed – The number of confirmed subscriptions for the
+//   topic.
+// * SubscriptionsDeleted – The number of deleted subscriptions for the topic.
+// * SubscriptionsPending – The number of subscriptions pending confirmation
+//   for the topic.
+// * TopicArn – The topic's ARN.
+// * EffectiveDeliveryPolicy – The JSON serialization of the effective delivery
+//   policy, taking system defaults into account.
+//
+// This structure instructs the code generator about the above real, schema'd
+// fields that are masquerading as raw key/value pairs.
+type UnpackAttributesMapConfig struct {
+	// Fields contains a map, keyed by the original Attribute Key, of
+	// FieldGeneratorConfig instructions for Attributes that should be
+	// considered actual CRD fields.
+	//
+	// Some fields are ReadWrite -- i.e. the Kubernetes user has the ability to
+	// set/update these fields on their CR -- and therefore go in the Spec
+	// struct of the CR
+	//
+	// Other fields are ReadeOnly -- i.e. the Kubernetes user cannot update the
+	// value of these fields.
+	//
+	// Note that any Attribute keys *not* listed here will be **excluded** from
+	// the representation of the CR's Status struct. If there is an Attribute
+	// -- e.g. an SNS Topic's `SubscriptionsDeleted` attribute -- that has
+	// information that is constantly changing and does not represent
+	// information to the ACK service controller that is useful for determining
+	// observed versus desired state -- then do NOT list that attribute here.
+	Fields map[string]FieldGeneratorConfig `json:"fields"`
+}
+
+// FieldGeneratorConfig contains instructions to the code generator about how
+// to interpret the value of an Attribute and how to map it to a CRD's Spec or
+// Status field
+type FieldGeneratorConfig struct {
+	// IsReadOnly indicates the field's value can not be set by a Kubernetes
+	// user; in other words, the field should go in the CR's Status struct
+	IsReadOnly bool `json:"is_read_only"`
+	// ContainsOwnerAccountID indicates the field contains the AWS Account ID
+	// that owns the resource. This is a special field that we direct to
+	// storage in the common `Status.ACKResourceMetadata.OwnerAccountID` field.
+	ContainsOwnerAccountID bool `json:"contains_owner_account_id"`
+}
+
+// NewGeneratorConfig returns a new GeneratorConfig object given a supplied
+// path to a config file and a pointer to an aws-sdk-go private/model/api.API
+// struct
+func NewGeneratorConfig(
+	configPath string,
+) (*GeneratorConfig, error) {
+	gc := GeneratorConfig{}
+	contents, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+	if err = yaml.Unmarshal(contents, &gc); err != nil {
+		return nil, err
+	}
+	return &gc, nil
+}

--- a/pkg/model/testdata/models/apis/sns/0000-00-00/generator.yaml
+++ b/pkg/model/testdata/models/apis/sns/0000-00-00/generator.yaml
@@ -1,0 +1,13 @@
+resources:
+  Topic:
+    unpack_attributes_map:
+      fields:
+        DeliveryPolicy:
+        DisplayName:
+        Policy:
+        KmsMasterKeyId:
+        Owner:
+          is_read_only: true
+          contains_owner_account_id: true
+        EffectiveDeliveryPolicy:
+          is_read_only: true

--- a/pkg/model/testdata/models/apis/sqs/0000-00-00/generator.yaml
+++ b/pkg/model/testdata/models/apis/sqs/0000-00-00/generator.yaml
@@ -1,0 +1,19 @@
+resources:
+  Queue:
+    unpack_attributes_map:
+      fields:
+        DelaySeconds:
+        MaximumMessageSize:
+        MessageRetentionPeriod:
+        KmsMasterKeyId:
+        KmsDataKeyReusePeriodSeconds:
+        Policy:
+        ReceiveMessageWaitTimeSeconds:
+        VisibilityTimeout:
+        FifoQueue:
+        ContentBasedDeduplication:
+        RedrivePolicy:
+        CreatedTimestamp:
+          is_read_only: true
+        LastModifiedTimestamp:
+          is_read_only: true

--- a/pkg/testutil/schema_helper.go
+++ b/pkg/testutil/schema_helper.go
@@ -14,6 +14,7 @@
 package testutil
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -27,5 +28,13 @@ func NewSchemaHelperForService(t *testing.T, serviceAlias string) *model.Helper 
 	if err != nil {
 		t.Fatal(err)
 	}
-	return model.NewHelper(sdkAPI)
+	generatorConfigPath := filepath.Join(path, "models", "apis", serviceAlias, "0000-00-00", "generator.yaml")
+	if _, err := os.Stat(generatorConfigPath); os.IsNotExist(err) {
+		generatorConfigPath = ""
+	}
+	h, err := model.NewHelper(sdkAPI, generatorConfigPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
 }


### PR DESCRIPTION
We needed a way of informing the code generator that certain APIs use
"special" handling of certain fields for resources by using an
"Attributes" `map[string]*string` that contains actual, schema'd fields
for the resource.

An example of this type of special API is SNS API which has a
CreateTopic call that defines a Topic resource. The CreateTopic call has
an "Attributes" parameter that contains a set of key/value pairs for
fields such as "DeliveryPolicy" or "DisplayName".

We want to inform the code generator that these fields are contained in
the Attributes parameter and should be "unpacked" into the CRD
definition as top-level fields on the resource.

This patch introduces this functionality by creating a GeneratorConfig
struct that is represented as a YAML file that contains instructions to
the code generator on how to handle these kinds of
special/inconsistent/idiosyncratic API behaviours.

Issue #109

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
