### PR TITLE
Adding import for CRD packages to register resource-manager-factories

### DIFF
--- a/cmd/ack-generate/command/controller.go
+++ b/cmd/ack-generate/command/controller.go
@@ -104,11 +104,18 @@ func writeControllerMainGo(sh *model.Helper) error {
 		return error
 	}
 
-	vars := &cmdtemplate.ControllerMainTemplateVars{
-		APIVersion:   latestAPIVersion,
-		ServiceAlias: strings.ToLower(sh.GetServiceAlias()),
-		CRDNames:     crdsNames,
+	// convert CRD names into snake_case to use for package import
+	snakeCasedCRDNames := make([]string, 0)
+	for _, crdName := range crdsNames {
+		snakeCasedCRDNames = append(snakeCasedCRDNames, crdName.Snake)
 	}
+
+	vars := &cmdtemplate.ControllerMainTemplateVars{
+		APIVersion:         latestAPIVersion,
+		ServiceAlias:       strings.ToLower(sh.GetServiceAlias()),
+		SnakeCasedCRDNames: snakeCasedCRDNames,
+	}
+
 	tpl, err := cmdtemplate.NewControllerMainTemplate(optTemplatesDir)
 	if err != nil {
 		return err

--- a/cmd/ack-generate/command/controller.go
+++ b/cmd/ack-generate/command/controller.go
@@ -99,9 +99,15 @@ func generateController(cmd *cobra.Command, args []string) error {
 
 func writeControllerMainGo(sh *model.Helper) error {
 	var b bytes.Buffer
+	crdsNames, error := sh.GetCRDNames()
+	if error != nil {
+		return error
+	}
+
 	vars := &cmdtemplate.ControllerMainTemplateVars{
 		APIVersion:   latestAPIVersion,
 		ServiceAlias: strings.ToLower(sh.GetServiceAlias()),
+		CRDNames:     crdsNames,
 	}
 	tpl, err := cmdtemplate.NewControllerMainTemplate(optTemplatesDir)
 	if err != nil {

--- a/pkg/model/helper.go
+++ b/pkg/model/helper.go
@@ -15,6 +15,7 @@ package model
 
 import (
 	"fmt"
+	"github.com/aws/aws-controllers-k8s/pkg/names"
 	"strings"
 
 	awssdkmodel "github.com/aws/aws-sdk-go/private/model/api"
@@ -50,21 +51,20 @@ func (h *Helper) GetAPIGroup() string {
 	return fmt.Sprintf("%s.services.k8s.aws", serviceAlias)
 }
 
-func (h *Helper) GetCRDNames() ([]string, error) {
-
+func (h *Helper) GetCRDNames() ([]names.Names, error) {
 	crds, error := h.GetCRDs()
 	if error != nil {
 		return nil, error
 	}
 
-	crdNames := make([]string, 0)
+	crdNames := make([]names.Names, 0)
 
 	if crds == nil {
 		return crdNames, nil
 	}
 
 	for _, crd := range h.crds {
-		crdNames = append(crdNames, crd.Names.Snake)
+		crdNames = append(crdNames, crd.Names)
 	}
 
 	return crdNames, nil

--- a/pkg/model/helper.go
+++ b/pkg/model/helper.go
@@ -50,6 +50,26 @@ func (h *Helper) GetAPIGroup() string {
 	return fmt.Sprintf("%s.services.k8s.aws", serviceAlias)
 }
 
+func (h *Helper) GetCRDNames() ([]string, error) {
+
+	crds, error := h.GetCRDs()
+	if error != nil {
+		return nil, error
+	}
+
+	crdNames := make([]string, 0)
+
+	if crds == nil {
+		return crdNames, nil
+	}
+
+	for _, crd := range h.crds {
+		crdNames = append(crdNames, crd.Names.Snake)
+	}
+
+	return crdNames, nil
+}
+
 // GetTypeRenames returns a map of original type name to renamed name (some
 // type definition names conflict with generated names)
 func (h *Helper) GetTypeRenames() map[string]string {

--- a/pkg/template/cmd/controller_main.go
+++ b/pkg/template/cmd/controller_main.go
@@ -22,9 +22,9 @@ import (
 )
 
 type ControllerMainTemplateVars struct {
-	APIVersion   string
-	ServiceAlias string
-	CRDNames     []string
+	APIVersion         string
+	ServiceAlias       string
+	SnakeCasedCRDNames []string
 }
 
 func NewControllerMainTemplate(tplDir string) (*ttpl.Template, error) {

--- a/pkg/template/cmd/controller_main.go
+++ b/pkg/template/cmd/controller_main.go
@@ -24,6 +24,7 @@ import (
 type ControllerMainTemplateVars struct {
 	APIVersion   string
 	ServiceAlias string
+	CRDNames     []string
 }
 
 func NewControllerMainTemplate(tplDir string) (*ttpl.Template, error) {

--- a/pkg/template/pkg/resource_registry.go
+++ b/pkg/template/pkg/resource_registry.go
@@ -14,10 +14,11 @@
 package pkg
 
 import (
-	"github.com/aws/aws-controllers-k8s/pkg/template"
 	"io/ioutil"
 	"path/filepath"
 	ttpl "text/template"
+
+	"github.com/aws/aws-controllers-k8s/pkg/template"
 )
 
 type ResourceRegistryGoTemplateVars struct {

--- a/pkg/template/pkg/resource_registry.go
+++ b/pkg/template/pkg/resource_registry.go
@@ -14,6 +14,7 @@
 package pkg
 
 import (
+	"github.com/aws/aws-controllers-k8s/pkg/template"
 	"io/ioutil"
 	"path/filepath"
 	ttpl "text/template"
@@ -31,5 +32,16 @@ func NewResourceRegistryGoTemplate(tplDir string) (*ttpl.Template, error) {
 		return nil, err
 	}
 	t := ttpl.New("resource_registry")
-	return t.Parse(string(tplContents))
+	if t, err = t.Parse(string(tplContents)); err != nil {
+		return nil, err
+	}
+	includes := []string{
+		"boilerplate",
+	}
+	for _, include := range includes {
+		if t, err = template.IncludeTemplate(t, tplDir, include); err != nil {
+			return nil, err
+		}
+	}
+	return t, nil
 }

--- a/templates/cmd/controller/main.go.tpl
+++ b/templates/cmd/controller/main.go.tpl
@@ -13,6 +13,9 @@ import (
 
 	svcresource "github.com/aws/aws-controllers-k8s/services/{{ .ServiceAlias }}/pkg/resource"
 	svctypes "github.com/aws/aws-controllers-k8s/services/{{ .ServiceAlias }}/apis/{{ .APIVersion }}"
+
+	{{ $serviceAlias := .ServiceAlias }} {{range $crdName := .CRDNames }}_ "github.com/aws/aws-controllers-k8s/services/{{ $serviceAlias }}/pkg/resource/{{ $crdName }}"
+    {{end}}
 )
 
 var (

--- a/templates/cmd/controller/main.go.tpl
+++ b/templates/cmd/controller/main.go.tpl
@@ -15,7 +15,7 @@ import (
 	svctypes "github.com/aws/aws-controllers-k8s/services/{{ .ServiceAlias }}/apis/{{ .APIVersion }}"
 
 	{{ $serviceAlias := .ServiceAlias }} {{range $crdName := .SnakeCasedCRDNames }}_ "github.com/aws/aws-controllers-k8s/services/{{ $serviceAlias }}/pkg/resource/{{ $crdName }}"
-    {{end}}
+	{{end}}
 )
 
 var (

--- a/templates/cmd/controller/main.go.tpl
+++ b/templates/cmd/controller/main.go.tpl
@@ -14,7 +14,7 @@ import (
 	svcresource "github.com/aws/aws-controllers-k8s/services/{{ .ServiceAlias }}/pkg/resource"
 	svctypes "github.com/aws/aws-controllers-k8s/services/{{ .ServiceAlias }}/apis/{{ .APIVersion }}"
 
-	{{ $serviceAlias := .ServiceAlias }} {{range $crdName := .CRDNames }}_ "github.com/aws/aws-controllers-k8s/services/{{ $serviceAlias }}/pkg/resource/{{ $crdName }}"
+	{{ $serviceAlias := .ServiceAlias }} {{range $crdName := .SnakeCasedCRDNames }}_ "github.com/aws/aws-controllers-k8s/services/{{ $serviceAlias }}/pkg/resource/{{ $crdName }}"
     {{end}}
 )
 

--- a/templates/pkg/resource_registry.go.tpl
+++ b/templates/pkg/resource_registry.go.tpl
@@ -1,15 +1,4 @@
-// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License"). You may
-// not use this file except in compliance with the License. A copy of the
-// License is located at
-//
-//     http://aws.amazon.com/apache2.0/
-//
-// or in the "license" file accompanying this file. This file is distributed
-// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-// express or implied. See the License for the specific language governing
-// permissions and limitations under the License.
+{{ template "boilerplate" }}
 
 package resource
 


### PR DESCRIPTION
Issue #110 , if available:

Description of changes:

* While adding import for each CRD in registry.go as per original suggestion, there were errors for circular imports.
    * resource package(registry) had dependency on CRD package
    * CRD package had dependency on resource to register the resource manager.

So I added the CRD specific imports in main.go and now controller is picking up all the CRD resource manager during build now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
