### PR TITLE
Fix name initalism for texts that contains 'Uri'

### DIFF
--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -103,7 +103,7 @@ var (
 		{"Tls", "TLS", "tls", nil},
 		{"Udp", "UDP", "udp", nil},
 		// Need to prevent "security" from becoming "SecURIty"
-		{"Uri", "URI", "uri", regexp.MustCompile("(?!sec)uri(?!ty)", regexp.None)},
+		{"Uri", "URI", "uri", regexp.MustCompile("(?!sec)uri(?!ty)|(Uri)", regexp.None)},
 		{"Url", "URL", "url", nil},
 		{"Vpc", "VPC", "vpc", nil},
 		{"Vpn", "VPN", "vpn", nil},

--- a/pkg/names/names_test.go
+++ b/pkg/names/names_test.go
@@ -45,6 +45,7 @@ func TestNames(t *testing.T) {
 		{"DBInstanceIdentifier", "DBInstanceIdentifier", "dbInstanceIdentifier", "db_instance_identifier"},
 		{"MaxIdleConnectionsPercent", "MaxIdleConnectionsPercent", "maxIdleConnectionsPercent", "max_idle_connections_percent"},
 		{"CacheSecurityGroup", "CacheSecurityGroup", "cacheSecurityGroup", "cache_security_group"},
+		{"RepositoryUriTest", "RepositoryURITest", "repositoryURITest", "repository_uri_test"},
 	}
 	for _, tc := range testCases {
 		n := names.New(tc.original)


### PR DESCRIPTION
Some tests were failing after #107 merge. The 'Uri' associated regex expression`(?!sec)uri(?!ty)` wasn't enough to catch text that contains camel cased `Uri`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
