### PR TITLE
generate code for GetAttributes input/output

### DIFF
--- a/pkg/model/testdata/models/apis/sns/0000-00-00/generator.yaml
+++ b/pkg/model/testdata/models/apis/sns/0000-00-00/generator.yaml
@@ -11,3 +11,5 @@ resources:
           contains_owner_account_id: true
         EffectiveDeliveryPolicy:
           is_read_only: true
+        TopicArn:
+          is_read_only: true

--- a/pkg/model/testdata/models/apis/sqs/0000-00-00/generator.yaml
+++ b/pkg/model/testdata/models/apis/sqs/0000-00-00/generator.yaml
@@ -17,3 +17,5 @@ resources:
           is_read_only: true
         LastModifiedTimestamp:
           is_read_only: true
+        QueueArn:
+          is_read_only: true

--- a/pkg/template/pkg/crd_sdk.go
+++ b/pkg/template/pkg/crd_sdk.go
@@ -38,26 +38,32 @@ func NewCRDSDKGoTemplate(tplDir string) (*ttpl.Template, error) {
 	}
 	t := ttpl.New("crd_sdk")
 	t = t.Funcs(ttpl.FuncMap{
-		"GoCodeSetReadOneOutput": func(r *model.CRD, outVarName string, koVarName string, indentLevel int) string {
-			return r.GoCodeSetOutput(model.OpTypeGet, outVarName, koVarName, indentLevel)
+		"GoCodeSetReadOneOutput": func(r *model.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
+			return r.GoCodeSetOutput(model.OpTypeGet, sourceVarName, targetVarName, indentLevel)
 		},
-		"GoCodeSetReadOneInput": func(r *model.CRD, inVarName string, koVarName string, indentLevel int) string {
-			return r.GoCodeSetInput(model.OpTypeGet, inVarName, koVarName, indentLevel)
+		"GoCodeSetReadOneInput": func(r *model.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
+			return r.GoCodeSetInput(model.OpTypeGet, sourceVarName, targetVarName, indentLevel)
 		},
-		"GoCodeSetCreateOutput": func(r *model.CRD, outVarName string, koVarName string, indentLevel int) string {
-			return r.GoCodeSetOutput(model.OpTypeCreate, outVarName, koVarName, indentLevel)
+		"GoCodeGetAttributesSetInput": func(r *model.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
+			return r.GoCodeGetAttributesSetInput(sourceVarName, targetVarName, indentLevel)
 		},
-		"GoCodeSetCreateInput": func(r *model.CRD, inVarName string, koVarName string, indentLevel int) string {
-			return r.GoCodeSetInput(model.OpTypeCreate, inVarName, koVarName, indentLevel)
+		"GoCodeGetAttributesSetOutput": func(r *model.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
+			return r.GoCodeGetAttributesSetOutput(sourceVarName, targetVarName, indentLevel)
 		},
-		"GoCodeSetUpdateOutput": func(r *model.CRD, outVarName string, koVarName string, indentLevel int) string {
-			return r.GoCodeSetOutput(model.OpTypeUpdate, outVarName, koVarName, indentLevel)
+		"GoCodeSetCreateOutput": func(r *model.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
+			return r.GoCodeSetOutput(model.OpTypeCreate, sourceVarName, targetVarName, indentLevel)
 		},
-		"GoCodeSetUpdateInput": func(r *model.CRD, inVarName string, koVarName string, indentLevel int) string {
-			return r.GoCodeSetInput(model.OpTypeUpdate, inVarName, koVarName, indentLevel)
+		"GoCodeSetCreateInput": func(r *model.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
+			return r.GoCodeSetInput(model.OpTypeCreate, sourceVarName, targetVarName, indentLevel)
 		},
-		"GoCodeSetDeleteInput": func(r *model.CRD, inVarName string, koVarName string, indentLevel int) string {
-			return r.GoCodeSetInput(model.OpTypeDelete, inVarName, koVarName, indentLevel)
+		"GoCodeSetUpdateOutput": func(r *model.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
+			return r.GoCodeSetOutput(model.OpTypeUpdate, sourceVarName, targetVarName, indentLevel)
+		},
+		"GoCodeSetUpdateInput": func(r *model.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
+			return r.GoCodeSetInput(model.OpTypeUpdate, sourceVarName, targetVarName, indentLevel)
+		},
+		"GoCodeSetDeleteInput": func(r *model.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
+			return r.GoCodeSetInput(model.OpTypeDelete, sourceVarName, targetVarName, indentLevel)
 		},
 	})
 	if t, err = t.Parse(string(tplContents)); err != nil {


### PR DESCRIPTION
Adds generation for Go code that sets the Input shape for GetAttributes
operations or sets CRD Status fields from the Output shape of a
GetAttributes operation.

We add special handling for the primary resource ARN and the AWS Owner
Account ID attribute keys, if found in the Attributes map. For these
special cases, we route the returned Output shape attribute key to the
`Status.ACKResourceMetadata.ARN` and
`Status.ACKResourceMetadata.OwnerAccountID` fields respectively.

Issue #109

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
