### PR TITLE
fix build errors from attribute-map sets

### DIFF
--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -15,6 +15,8 @@ package errors
 
 import (
 	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
 )
 
 var (
@@ -25,3 +27,10 @@ var (
 	)
 	AdoptedResourceNotFound = fmt.Errorf("adopted resource not found")
 )
+
+// AWSError returns the type conversion for the supplied error to an aws-sdk-go
+// Error interface
+func AWSError(err error) (awserr.Error, bool) {
+	awsErr, ok := err.(awserr.Error)
+	return awsErr, ok
+}

--- a/pkg/model/crd_test.go
+++ b/pkg/model/crd_test.go
@@ -140,7 +140,7 @@ func TestSNSTopic(t *testing.T) {
 	// itself) and should be set specially from the ACKResourceMetadata.ARN
 	// field in the TopicStatus struct
 	expGetAttrsInput := `
-	res.SetTopicArn(*r.ko.Status.ACKResourceMetadata.ARN)
+	res.SetTopicArn(string(*r.ko.Status.ACKResourceMetadata.ARN))
 `
 	assert.Equal(expGetAttrsInput, crd.GoCodeGetAttributesSetInput("r.ko", "res", 1))
 
@@ -151,8 +151,10 @@ func TestSNSTopic(t *testing.T) {
 	// AWS Owner account ID, both of which are handled specially.
 	expGetAttrsOutput := `
 	ko.Status.EffectiveDeliveryPolicy = resp.Attributes["EffectiveDeliveryPolicy"]
-	ko.Status.ACKResourceMetadata.OwnerAccountID = resp.Attributes["Owner"]
-	ko.Status.ACKResourceMetadata.ARN = resp.Attributes["TopicArn"]
+	tmpOwnerID := ackv1alpha1.AWSAccountID(*resp.Attributes["Owner"])
+	ko.Status.ACKResourceMetadata.OwnerAccountID = &tmpOwnerID
+	tmpARN := ackv1alpha1.AWSResourceName(*resp.Attributes["TopicArn"])
+	ko.Status.ACKResourceMetadata.ARN = &tmpARN
 `
 	assert.Equal(expGetAttrsOutput, crd.GoCodeGetAttributesSetOutput("resp", "ko.Status", 1))
 }
@@ -720,7 +722,8 @@ func TestSQSQueue(t *testing.T) {
 	expGetAttrsOutput := `
 	ko.Status.CreatedTimestamp = resp.Attributes["CreatedTimestamp"]
 	ko.Status.LastModifiedTimestamp = resp.Attributes["LastModifiedTimestamp"]
-	ko.Status.ACKResourceMetadata.ARN = resp.Attributes["QueueArn"]
+	tmpARN := ackv1alpha1.AWSResourceName(*resp.Attributes["QueueArn"])
+	ko.Status.ACKResourceMetadata.ARN = &tmpARN
 `
 	assert.Equal(expGetAttrsOutput, crd.GoCodeGetAttributesSetOutput("resp", "ko.Status", 1))
 }

--- a/pkg/model/testdata/models/apis/sns/0000-00-00/generator.yaml
+++ b/pkg/model/testdata/models/apis/sns/0000-00-00/generator.yaml
@@ -13,3 +13,21 @@ resources:
           is_read_only: true
         TopicArn:
           is_read_only: true
+  PlatformApplication:
+    unpack_attributes_map:
+      fields:
+        PlatformCredential:
+        PlatformPrincipal:
+        EventEndpointCreated:
+        EventEndpointDeleted:
+        EventEndpointUpdated:
+        EventDeliveryFailure:
+        SuccessFeedbackRoleArn:
+        FailureFeedbackRoleArn:
+        SuccessFeedbackSampleRate:
+  Endpoint:
+    unpack_attributes_map:
+      fields:
+        CustomUserData:
+        Enabled:
+        Token:

--- a/pkg/template/pkg/crd_sdk.go
+++ b/pkg/template/pkg/crd_sdk.go
@@ -16,6 +16,7 @@ package pkg
 import (
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	ttpl "text/template"
 
 	"github.com/aws/aws-controllers-k8s/pkg/model"
@@ -64,6 +65,9 @@ func NewCRDSDKGoTemplate(tplDir string) (*ttpl.Template, error) {
 		},
 		"GoCodeSetDeleteInput": func(r *model.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
 			return r.GoCodeSetInput(model.OpTypeDelete, sourceVarName, targetVarName, indentLevel)
+		},
+		"Empty": func(subject string) bool {
+			return strings.TrimSpace(subject) == ""
 		},
 	})
 	if t, err = t.Parse(string(tplContents)); err != nil {


### PR DESCRIPTION
When constructing the SNS and SQS controllers, ran into some build
failures, including type conversion issues to/from
string/ackv1alpha.AWSResourceName, unused variable errors when there
were no fields being set in an input or output shape, and import issues
with the aws-sdk-go/aws/errors package.

This patch fixes all the above issues and corrects the build of the SNS
and SQS generated service controllers.

You can test the SNS or SQS service controller build by calling:

```
make build-ack-generate
ACK_GENERATE_CONFIG_PATH=pkg/models/testdata/models/apis/sns/0000-00-00/generator.yaml \
./scripts/build-controller.sh sns
make test
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
