### PR TITLE
correct issues with Go code generation

### DIFF
--- a/pkg/model/crd_test.go
+++ b/pkg/model/crd_test.go
@@ -284,7 +284,7 @@ func TestEC2LaunchTemplate(t *testing.T) {
 	f2f12f1.SetInstanceInterruptionBehavior(*r.ko.Spec.LaunchTemplateData.InstanceMarketOptions.SpotOptions.InstanceInterruptionBehavior)
 	f2f12f1.SetMaxPrice(*r.ko.Spec.LaunchTemplateData.InstanceMarketOptions.SpotOptions.MaxPrice)
 	f2f12f1.SetSpotInstanceType(*r.ko.Spec.LaunchTemplateData.InstanceMarketOptions.SpotOptions.SpotInstanceType)
-	f2f12f1.SetValidUntil(*r.ko.Spec.LaunchTemplateData.InstanceMarketOptions.SpotOptions.ValidUntil.Time)
+	f2f12f1.SetValidUntil(r.ko.Spec.LaunchTemplateData.InstanceMarketOptions.SpotOptions.ValidUntil.Time)
 	f2f12.SetSpotOptions(f2f12f1)
 	f2.SetInstanceMarketOptions(f2f12)
 	f2.SetInstanceType(*r.ko.Spec.LaunchTemplateData.InstanceType)
@@ -697,7 +697,13 @@ func TestSQSQueue(t *testing.T) {
 	attrMap["VisibilityTimeout"] = r.ko.Spec.VisibilityTimeout
 	res.SetAttributes(attrMap)
 	res.SetQueueName(*r.ko.Spec.QueueName)
-	res.SetTags(r.ko.Spec.Tags)
+	f11 := map[string]*string{}
+	for f11key, f11valiter := range r.ko.Spec.Tags {
+		var f11val string
+		f11val = *f11valiter
+		f11[f11key] = &f11val
+	}
+	res.SetTags(f11)
 `
 	assert.Equal(expCreateInput, crd.GoCodeSetInput(model.OpTypeCreate, "r.ko.Spec", "res", 1))
 
@@ -805,8 +811,20 @@ func TestAPIGatewayV2_Route(t *testing.T) {
 	res.SetAuthorizerId(*r.ko.Spec.AuthorizerID)
 	res.SetModelSelectionExpression(*r.ko.Spec.ModelSelectionExpression)
 	res.SetOperationName(*r.ko.Spec.OperationName)
-	res.SetRequestModels(r.ko.Spec.RequestModels)
-	res.SetRequestParameters(r.ko.Spec.RequestParameters)
+	f7 := map[string]*string{}
+	for f7key, f7valiter := range r.ko.Spec.RequestModels {
+		var f7val string
+		f7val = *f7valiter
+		f7[f7key] = &f7val
+	}
+	res.SetRequestModels(f7)
+	f8 := map[string]*svcsdk.ParameterConstraints{}
+	for f8key, f8valiter := range r.ko.Spec.RequestParameters {
+		f8val := &svcsdk.ParameterConstraints{}
+		f8val.SetRequired(*f8valiter.Required)
+		f8[f8key] = f8val
+	}
+	res.SetRequestParameters(f8)
 	res.SetRouteKey(*r.ko.Spec.RouteKey)
 	res.SetRouteResponseSelectionExpression(*r.ko.Spec.RouteResponseSelectionExpression)
 	res.SetTarget(*r.ko.Spec.Target)


### PR DESCRIPTION
This PR contains fixes for three separate issues in the code generation.

The Go code being generated for scalar elements within a list field was
missing the constructor, so, for example, the generated code looked
something like this:

```go
	f7 := []*string{}
	for _, f7iter := range resp.MyListField {
		f7elem.f7 = f7iter
		f7 = append(f7, f7elem)
	}
```

which of course causes compilation failures to bubble up during `go
build`:

```
undefined: f7elem
```

This patch fixes the code generation for list elements that are scalar
types so that the correct code being output is this:

```go
	f7 := []*string{}
	for _, f7iter := range resp.MyListField {
                var f7elem string
		f7elem = *f7iter
		f7 = append(f7, &f7elem)
	}
```

We were not generating Go code for `map` types. This patch adds support
for outputting Go code similar to the slice types. So, for example, the
Go code now output for the API Gateway V2 API's
`CreateRouteInput.RequestParameters` (which is of type
`map[string]*apigatewayv2.ParameterConstraint`) looks like this:

```go
	f8 := map[string]*svcsdk.ParameterConstraints{}
	for f8key, f8valiter := range r.ko.Spec.RequestParameters {
		f8val := &svcsdk.ParameterConstraints{}
		f8val.SetRequired(*f8valiter.Required)
		f8[f8key] = f8val
	}
```

Fixes #101
Fixes #115

In addition to the map type support, this patch fixes scenarios where
`time.Time` was incorrectly being indirected into a target value
variable that wasn't a pointer type.

Fixes #98

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
