### PR TITLE
Kind local test cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .idea
 /docs/site
 bin
+/scripts/k8s-local-cluster-test/build/

--- a/go.mod
+++ b/go.mod
@@ -16,8 +16,6 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1
-	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b // indirect
-	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
 	k8s.io/api v0.18.2
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v0.18.2

--- a/scripts/k8s-local-cluster-test/delete-cluster.sh
+++ b/scripts/k8s-local-cluster-test/delete-cluster.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+USAGE=$(cat << 'EOM'
+  Usage: delete-cluster  [-c <CLUSTER_CONTEXT>] [-o]
+  Deletes a kind cluster and context dir
+
+  Example: delete-cluster -c build/tmp-cluster-1234
+
+          Required:
+            -c          Cluster context directory
+
+          Optional:
+            -o          Override path w/ your own kubectl and kind binaries
+EOM
+)
+
+# Process our input arguments
+while getopts "c:o" opt; do
+  case ${opt} in
+    c ) # Cluster context directory
+        TMP_DIR=$OPTARG
+        CLUSTER_NAME=$(cat $TMP_DIR/clustername)
+      ;;
+    o ) # Override path with your own kubectl and kind binaries
+	      OVERRIDE_PATH=1
+        export PATH=$PATH:$TMP_DIR
+      ;;
+    \? )
+        echoerr "$USAGE" 1>&2
+        exit
+      ;;
+  esac
+done
+
+echo "🥑 Deleting k8s cluster using \"kind\""
+kind delete cluster --name "$CLUSTER_NAME"
+rm -r $TMP_DIR

--- a/scripts/k8s-local-cluster-test/kind-two-node-cluster.yaml
+++ b/scripts/k8s-local-cluster-test/kind-two-node-cluster.yaml
@@ -1,0 +1,14 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        apiVersion: kubeadm.k8s.io/v1beta2
+        kind: ClusterConfiguration
+        metadata:
+          name: config
+        apiServer:
+          extraArgs:
+            "enable-admission-plugins": "NodeRestriction,PodSecurityPolicy"
+  - role: worker

--- a/scripts/k8s-local-cluster-test/provision-cluster.sh
+++ b/scripts/k8s-local-cluster-test/provision-cluster.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_PATH="$(cd "$(dirname "$0")" ; pwd -P )"
+PLATFORM=$(uname | tr '[:upper:]' '[:lower:]')
+CLUSTER_CREATION_TIMEOUT_IN_SEC=300
+TEST_ID=$(uuidgen | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
+CLUSTER_NAME_BASE=$(uuidgen | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
+OVERRIDE_PATH=0
+KIND_CONFIG_FILE=$SCRIPT_PATH/kind-two-node-cluster.yaml
+
+K8_1_18="kindest/node:v1.18.4@sha256:9ddbe5ba7dad96e83aec914feae9105ac1cffeb6ebd0d5aa42e820defe840fd4"
+K8_1_17="kindest/node:v1.17.5@sha256:ab3f9e6ec5ad8840eeb1f76c89bb7948c77bbf76bcebe1a8b59790b8ae9a283a"
+K8_1_16="kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765"
+K8_1_15="kindest/node:v1.15.11@sha256:6cc31f3533deb138792db2c7d1ffc36f7456a06f1db5556ad3b6927641016f50"
+K8_1_14="kindest/node:v1.14.10@sha256:6cd43ff41ae9f02bb46c8f455d5323819aec858b99534a290517ebc181b443c6"
+
+K8_VERSION="$K8_1_16"
+KUBECTL_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+KIND_VERSION="0.8.1"
+HELM_VERSION="3.2.4"
+
+echoerr() { echo "$@" 1>&2; }
+
+USAGE=$(cat << 'EOM'
+  Usage: provision-cluster  [-b <BASE_CLUSTER_NAME>] [-i <TEST_IDENTIFIER>] [-v K8s_VERSION] [-o]
+  Executes the spot termination integration test for the Node Termination Handler.
+  Outputs the cluster context directory to stdout on successful completion
+
+  Example: provision-cluster -b my-test -i 123 -v 1.16
+
+          Optional:
+            -b          Base Name of cluster
+            -i          Test Identifier to suffix Cluster Name and tmp dir
+            -v          K8s version to use in this test
+            -k          Kind cluster config file
+            -o          Override path w/ your own kubectl and kind binaries
+EOM
+)
+
+# Process our input arguments
+while getopts "b:i:v:k:o" opt; do
+  case ${opt} in
+    b ) # BASE CLUSTER NAME
+        CLUSTER_NAME_BASE=$OPTARG
+      ;;
+    i ) # Test ID
+        TEST_ID=$OPTARG
+        echoerr "👉 Test Run: $TEST_ID 👈"
+      ;;
+    v ) # K8s version to provision
+        OPTARG="K8_$(echo "${OPTARG}" | sed 's/\./\_/g')"
+        if [ ! -z ${OPTARG+x} ]; then
+            K8_VERSION=${!OPTARG}
+        else
+            echoerr "K8s version not supported"
+            exit 2
+        fi
+      ;;
+    k ) # Kind cluster config file
+        KIND_CONFIG_FILE="${OPTARG}"
+      ;;
+    o ) # Override path with your own kubectl and kind binaries
+	    OVERRIDE_PATH=1
+      ;;
+    \? )
+        echoerr "${USAGE}" 1>&2
+        exit
+      ;;
+  esac
+done
+
+CLUSTER_NAME="$CLUSTER_NAME_BASE"-"${TEST_ID}"
+TMP_DIR=$SCRIPT_PATH/build/tmp-$CLUSTER_NAME
+
+echoerr "🐳 Using Kubernetes $K8_VERSION"
+mkdir -p "${TMP_DIR}"
+
+deps=("docker")
+
+for dep in "${deps[@]}"; do
+    path_to_executable=$(which $dep)
+    if [ ! -x "$path_to_executable" ]; then
+        echoerr "You are required to have $dep installed on your system..."
+        echoerr "Please install $dep and try again. "
+        exit 3
+    fi
+done
+
+## Append to the end of PATH so that the user can override the executables if they want
+if [[ OVERRIDE_PATH -eq 1 ]]; then
+   export PATH=$PATH:$TMP_DIR
+else
+  if [ ! -x "$TMP_DIR/kubectl" ]; then
+      echoerr "🥑 Downloading the \"kubectl\" binary"
+      curl -Lo $TMP_DIR/kubectl "https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/$PLATFORM/amd64/kubectl"
+      chmod +x $TMP_DIR/kubectl
+      echoerr "👍 Downloaded the \"kubectl\" binary"
+  fi
+
+  if [ ! -x "$TMP_DIR/kind" ]; then
+      echoerr "🥑 Downloading the \"kind\" binary"
+      curl -Lo $TMP_DIR/kind https://github.com/kubernetes-sigs/kind/releases/download/v$KIND_VERSION/kind-$PLATFORM-amd64
+      chmod +x $TMP_DIR/kind
+      echoerr "👍 Downloaded the \"kind\" binary"
+  fi
+
+  if [ ! -x "$TMP_DIR/helm" ]; then
+      echoerr "🥑 Downloading the \"helm\" binary"
+      curl -L https://get.helm.sh/helm-v$HELM_VERSION-$PLATFORM-amd64.tar.gz | tar zxf - -C $TMP_DIR
+      mv $TMP_DIR/$PLATFORM-amd64/helm $TMP_DIR/.
+      chmod +x $TMP_DIR/helm
+      echoerr "👍 Downloaded the \"helm\" binary"
+  fi
+  export PATH=$TMP_DIR:$PATH
+fi
+
+echoerr "🥑 Creating k8s cluster using \"kind\""
+for i in $(seq 0 5); do
+  if [[ -z $(kind get clusters | grep $CLUSTER_NAME) ]]; then
+      kind create cluster -q --name "$CLUSTER_NAME" --image $K8_VERSION --config "$SCRIPT_PATH/kind-two-node-cluster.yaml" --kubeconfig $TMP_DIR/kubeconfig 1>&2 || :
+  else
+      break
+  fi
+done
+
+echo "$CLUSTER_NAME" > $TMP_DIR/clustername
+echoerr "👍 Created k8s cluster using \"kind\""
+
+kubectl apply -f "$SCRIPT_PATH/psp-default.yaml" --context kind-$CLUSTER_NAME --kubeconfig $TMP_DIR/kubeconfig 1>&2
+kubectl apply -f "$SCRIPT_PATH/psp-privileged.yaml" --context kind-$CLUSTER_NAME --kubeconfig $TMP_DIR/kubeconfig 1>&2
+
+echo $TMP_DIR

--- a/scripts/k8s-local-cluster-test/psp-default.yaml
+++ b/scripts/k8s-local-cluster-test/psp-default.yaml
@@ -1,0 +1,71 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+  name: default
+spec:
+  allowedCapabilities: []  # default set of capabilities are implicitly allowed
+  allowPrivilegeEscalation: false
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  hostIPC: false
+  hostNetwork: false
+  hostPID: false
+  privileged: false
+  readOnlyRootFilesystem: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  volumes:
+    - 'configMap'
+    - 'downwardAPI'
+    - 'emptyDir'
+    - 'persistentVolumeClaim'
+    - 'projected'
+    - 'secret'
+
+---
+
+# Cluster role which grants access to the default pod security policy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: default-psp
+rules:
+  - apiGroups:
+      - policy
+    resourceNames:
+      - default
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+
+---
+
+# Cluster role binding for default pod security policy granting all authenticated users access
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: default-psp
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: default-psp
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:authenticated

--- a/scripts/k8s-local-cluster-test/psp-privileged.yaml
+++ b/scripts/k8s-local-cluster-test/psp-privileged.yaml
@@ -1,0 +1,70 @@
+# Should grant access to very few pods, i.e. kube-system system pods and possibly CNI pods
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  annotations:
+    # See https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+  name: privileged
+spec:
+  allowedCapabilities:
+    - '*'
+  allowPrivilegeEscalation: true
+  fsGroup:
+    rule: 'RunAsAny'
+  hostIPC: true
+  hostNetwork: true
+  hostPID: true
+  hostPorts:
+    - min: 0
+      max: 65535
+  privileged: true
+  readOnlyRootFilesystem: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  volumes:
+    - '*'
+
+---
+
+# Cluster role which grants access to the privileged pod security policy
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: privileged-psp
+rules:
+  - apiGroups:
+      - policy
+    resourceNames:
+      - privileged
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+
+---
+
+# Role binding for kube-system - allow nodes and kube-system service accounts - should take care of CNI i.e. flannel running in the kube-system namespace
+# Assumes access to the kube-system is restricted
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kube-system-psp
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: privileged-psp
+subjects:
+  # For the kubeadm kube-system nodes
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:nodes
+  # For all service accounts in the kube-system namespace
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: system:serviceaccounts:kube-system

--- a/scripts/k8s-local-cluster-test/run.sh
+++ b/scripts/k8s-local-cluster-test/run.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+set -eo pipefail
+
+AEMM_URL="amazon-ec2-metadata-mock-service.default.svc.cluster.local"
+AEMM_VERSION="1.2.0"
+AEMM_DL_URL="https://github.com/aws/amazon-ec2-metadata-mock/releases/download/v${AEMM_VERSION}/amazon-ec2-metadata-mock-${AEMM_VERSION}.tgz"
+CLUSTER_NAME_BASE="nth-test"
+DELETE_CLUSTER_ARGS=""
+K8S_VERSION="1.16"
+OVERRIDE_PATH=0
+PRESERVE=false
+PROVISION_CLUSTER_ARGS=""
+START=$(date +%s)
+SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
+TMP_DIR=""
+# VERSION is the source revision that executables and images are built from.
+VERSION=$(git describe --tags --always --dirty || echo "unknown")
+
+function timeout() { perl -e 'alarm shift; exec @ARGV' "$@"; }
+
+function relpath() {
+  perl -e 'use File::Spec; print File::Spec->abs2rel(@ARGV) . "\n"' "${1}" "${2}"
+}
+
+function clean_up {
+    if [[ "$PRESERVE" == false ]]; then
+        "${SCRIPT_PATH}"/delete-cluster.sh $DELETE_CLUSTER_ARGS || :
+        return
+    fi
+    echo "To resume test with the same cluster use: \"-c $TMP_DIR\""""
+}
+
+function exit_and_fail {
+    local pod_id=$(get_nth_worker_pod || :)
+    kubectl logs "${pod_id}" --namespace kube-system || :
+    END=$(date +%s)
+    echo "⏰ Took $(expr "${END}" - "${START}")sec"
+    echo "❌ NTH Integration Test FAILED $CLUSTER_NAME! ❌"
+    exit 1
+}
+
+function get_nth_worker_pod {
+    kubectl get pods -n kube-system \
+      --selector 'app.kubernetes.io/name=aws-node-termination-handler' \
+      --field-selector="spec.nodeName=$CLUSTER_NAME-worker,status.phase=Running" \
+      --sort-by=.metadata.creationTimestamp \
+      --output jsonpath='{.items[-1].metadata.name}'
+}
+
+USAGE=$(cat << 'EOM'
+  Usage: bash run.sh [-p] [-s] [-o] [-b <TEST_BASE_NAME>] [-c <CLUSTER_CONTEXT_DIR>] [-i <AWS Docker image name>] [-s] [-v K8S_VERSION]
+  Executes a test within a provisioned kubernetes cluster with NTH and IMDS pre-loaded.
+
+  Example: bash run.sh -p -s petstore
+
+          Optional:
+            -b          Base name of test (will be used for cluster too)
+            -c          Cluster context directory, if operating on an existing cluster
+            -p          Preserve kind k8s cluster for inspection
+            -i          Provide AWS Service docker image
+            -s          Provide AWS Service name (ecr, sns, sqs, petstore, bookstore)
+            -o          Override path w/ your own kubectl and kind binaries
+            -v          Kubernetes Version (Default: 1.16) [1.14, 1.15, 1.16, 1.17, and 1.18]
+
+EOM
+)
+
+# Process our input arguments
+while getopts "ps:ioc:b:v:" opt; do
+  case ${opt} in
+    p ) # PRESERVE K8s Cluster
+        echo "❄️  This run will preserve the cluster as you requested"
+        PRESERVE=true
+      ;;
+    s ) # AWS Service name
+        echo "Running Docker build as you requested for ${OPTARG} service"
+        AWS_SERVICE=$(echo "${OPTARG}" | tr '[:upper:]' '[:lower:]')
+        echo $AWS_SERVICE
+      ;;
+    i ) # AWS Service Docker Image
+        AWS_SERVICE_DOCKER_IMG="${OPTARG}"
+      ;;
+    o ) # Override path with your own kubectl and kind binaries
+        DELETE_CLUSTER_ARGS="${DELETE_CLUSTER_ARGS} -o"
+        PROVISION_CLUSTER_ARGS="${PROVISION_CLUSTER_ARGS} -o"
+        OVERRIDE_PATH=1
+      ;;
+    c ) # Cluster context directory to operate on existing cluster
+        TMP_DIR="${OPTARG}"
+      ;;
+    b ) # Base cluster name
+        CLUSTER_NAME_BASE="${OPTARG}"
+      ;;
+    v ) # K8s VERSION
+        K8S_VERSION="${OPTARG}"
+      ;;
+    \? )
+        echo "${USAGE}" 1>&2
+        exit
+      ;;
+  esac
+done
+
+if [ -z $TMP_DIR ]; then
+    TMP_DIR=$("${SCRIPT_PATH}"/../k8s-local-cluster-test/provision-cluster.sh -b "${CLUSTER_NAME_BASE}" -v "${K8S_VERSION}" "${PROVISION_CLUSTER_ARGS}")
+fi
+
+if [ $OVERRIDE_PATH == 0 ]; then
+  export PATH=$TMP_DIR:$PATH
+else
+  export PATH=$PATH:$TMP_DIR
+fi
+
+CLUSTER_NAME=$(cat $TMP_DIR/clustername)
+
+## Build and Load Docker Images
+
+if [ -z "$AWS_SERVICE_DOCKER_IMG" ]; then
+    echo "🥑 Building ${AWS_SERVICE} docker image"
+    DEFAULT_AWS_SERVICE_DOCKER_IMG="${AWS_SERVICE}:${VERSION}"
+    docker build -f services/"${AWS_SERVICE}"/Dockerfile -t "${DEFAULT_AWS_SERVICE_DOCKER_IMG}" .
+    AWS_SERVICE_DOCKER_IMG="${DEFAULT_AWS_SERVICE_DOCKER_IMG}"
+    echo "👍 Built the ${AWS_SERVICE} docker image"
+else
+    echo "🥑 Skipping building the ${AWS_SERVICE} docker image, since one was specified ${AWS_SERVICE_DOCKER_IMG}"
+fi
+echo "$AWS_SERVICE_DOCKER_IMG" > "${TMP_DIR}"/nth-docker-img
+
+echo "🥑 Loading the images into the cluster"
+kind load docker-image --name "${CLUSTER_NAME}" --nodes="${CLUSTER_NAME}"-worker,"${CLUSTER_NAME}"-control-plane "${AWS_SERVICE_DOCKER_IMG}"
+echo "👍 Loaded image(s) into the cluster"
+
+export KUBECONFIG="${TMP_DIR}/kubeconfig"
+
+trap "exit_and_fail" INT TERM ERR
+trap "clean_up" EXIT
+
+echo "======================================================================================================"
+echo "To poke around your test manually:"
+echo "export KUBECONFIG=$TMP_DIR/kubeconfig"
+echo "export PATH=$TMP_DIR:\$PATH"
+echo "kubectl get pods -A"
+echo "======================================================================================================"
+
+
+### exported vars and funcs that tests can use
+export TMP_DIR
+export CLUSTER_NAME
+export AEMM_URL
+export AEMM_VERSION
+export AEMM_DL_URL
+export -f timeout
+export -f relpath
+export -f get_nth_worker_pod
+export NTH_WORKER_LABEL="kubernetes\.io/hostname=${CLUSTER_NAME}-worker"
+###
+
+echo "======================================================================================================"
+echo "✅ All tests passed! ✅"
+echo "======================================================================================================"


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: This PR will cover part of #111
```
a483e7384446:aws-controllers-k8s nithmu$ bash scripts/k8s-local-cluster-test/run.sh -s ecr
Running Docker build as you requested for ecr service
ecr
🐳 Using Kubernetes kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765
🥑 Downloading the "kubectl" binary
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 47.8M  100 47.8M    0     0  18.3M      0  0:00:02  0:00:02 --:--:-- 18.3M
👍 Downloaded the "kubectl" binary
🥑 Downloading the "kind" binary
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   630  100   630    0     0   1698      0 --:--:-- --:--:-- --:--:--  1702
100 9771k  100 9771k    0     0  2788k      0  0:00:03  0:00:03 --:--:-- 3230k
👍 Downloaded the "kind" binary
🥑 Downloading the "helm" binary
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 12.9M  100 12.9M    0     0  4524k      0  0:00:02  0:00:02 --:--:-- 4525k
👍 Downloaded the "helm" binary
🥑 Creating k8s cluster using "kind"
No kind clusters found.
👍 Created k8s cluster using "kind"
podsecuritypolicy.policy/default created
clusterrole.rbac.authorization.k8s.io/default-psp created
clusterrolebinding.rbac.authorization.k8s.io/default-psp created
podsecuritypolicy.policy/privileged created
clusterrole.rbac.authorization.k8s.io/privileged-psp created
rolebinding.rbac.authorization.k8s.io/kube-system-psp created
🥑 Building ecr docker image
Sending build context to Docker daemon  281.9MB
Step 1/18 : FROM golang:1.14.1 as builder
 ---> b022a9b82d88
Step 2/18 : ARG work_dir=/github.com/aws/aws-controllers-k8s
 ---> Using cache
 ---> 3400bec262c7
Step 3/18 : WORKDIR $work_dir
 ---> Using cache
 ---> 90cc2c9fbb84
Step 4/18 : ENV GOPROXY=direct
 ---> Using cache
 ---> 40fc667e058e
Step 5/18 : ENV GO111MODULE=on
 ---> Using cache
 ---> 1a0a942f5b7d
Step 6/18 : ENV GOARCH=amd64
 ---> Using cache
 ---> 9f407aeec171
Step 7/18 : ENV GOOS=linux
 ---> Using cache
 ---> 4badc93a7516
Step 8/18 : ENV CGO_ENABLED=0
 ---> Using cache
 ---> 42236b98e2da
Step 9/18 : COPY go.mod go.mod
 ---> Using cache
 ---> 7780c792bab8
Step 10/18 : COPY go.sum go.sum
 ---> Using cache
 ---> 3f9c0d624f45
Step 11/18 : RUN  go mod download
 ---> Using cache
 ---> 36292125372d
Step 12/18 : COPY . $work_dir/
 ---> fac6544b4e33
Step 13/18 : RUN  go build -a -o $work_dir/bin/controller $work_dir/services/ecr/cmd/controller/main.go
 ---> Running in 7a9c24535bba
Removing intermediate container 7a9c24535bba
 ---> cb022d4400e3
Step 14/18 : FROM amazonlinux:2
 ---> fa0a6a710ca7
Step 15/18 : ARG work_dir=/github.com/aws/aws-controllers-k8s
 ---> Using cache
 ---> ec511c6aee2c
Step 16/18 : WORKDIR /
 ---> Using cache
 ---> 62fc5855e569
Step 17/18 : COPY --from=builder $work_dir/bin/controller /bin/.
 ---> Using cache
 ---> bd893de6f5b1
Step 18/18 : ENTRYPOINT ["/bin/controller"]
 ---> Using cache
 ---> bc69fc6c2922
Successfully built bc69fc6c2922
Successfully tagged ecr:88d7396-dirty
👍 Built the ecr docker image
🥑 Loading the images into the cluster
Image: "ecr:88d7396-dirty" with ID "sha256:bc69fc6c2922672e294182ea5acade18034ab78df5d1c0bc493c9d6c2ffb6403" not yet present on node "nth-test-96b85053-worker", loading...
Image: "ecr:88d7396-dirty" with ID "sha256:bc69fc6c2922672e294182ea5acade18034ab78df5d1c0bc493c9d6c2ffb6403" not yet present on node "nth-test-96b85053-control-plane", loading...
👍 Loaded image(s) into the cluster
======================================================================================================
To poke around your test manually:
export KUBECONFIG=/Users/nithmu/go/src/github.com/aws/aws-controllers-k8s/scripts/k8s-local-cluster-test/build/tmp-nth-test-96b85053/kubeconfig
export PATH=/Users/nithmu/go/src/github.com/aws/aws-controllers-k8s/scripts/k8s-local-cluster-test/build/tmp-nth-test-96b85053:$PATH
kubectl get pods -A
======================================================================================================
======================================================================================================
✅ All tests passed! ✅
======================================================================================================
scripts/k8s-local-cluster-test/run.sh: line 27: /Users/nithmu/go/src/github.com/aws/aws-controllers-k8s/scripts/k8s-local-cluster-test/delete-cluster.sh: Permission denied
a483e7384446:aws-controllers-k8s nithmu$ chmod +x scripts/k8s-local-cluster-test/delete-cluster.sh 
a483e7384446:aws-controllers-k8s nithmu$ 
a483e7384446:aws-controllers-k8s nithmu$ clear
a483e7384446:aws-controllers-k8s nithmu$ bash scripts/k8s-local-cluster-test/run.sh -s ecr
Running Docker build as you requested for ecr service
ecr
🐳 Using Kubernetes kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765
🥑 Downloading the "kubectl" binary
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 47.8M  100 47.8M    0     0  17.5M      0  0:00:02  0:00:02 --:--:-- 17.5M
👍 Downloaded the "kubectl" binary
🥑 Downloading the "kind" binary
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   630  100   630    0     0   1429      0 --:--:-- --:--:-- --:--:--  1428
100 9771k  100 9771k    0     0  2637k      0  0:00:03  0:00:03 --:--:-- 3802k
👍 Downloaded the "kind" binary
🥑 Downloading the "helm" binary
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 12.9M  100 12.9M    0     0  6497k      0  0:00:02  0:00:02 --:--:-- 6500k
👍 Downloaded the "helm" binary
🥑 Creating k8s cluster using "kind"
👍 Created k8s cluster using "kind"
podsecuritypolicy.policy/default created
clusterrole.rbac.authorization.k8s.io/default-psp created
clusterrolebinding.rbac.authorization.k8s.io/default-psp created
podsecuritypolicy.policy/privileged created
clusterrole.rbac.authorization.k8s.io/privileged-psp created
rolebinding.rbac.authorization.k8s.io/kube-system-psp created
🥑 Building ecr docker image
Sending build context to Docker daemon  387.1MB
Step 1/18 : FROM golang:1.14.1 as builder
 ---> b022a9b82d88
Step 2/18 : ARG work_dir=/github.com/aws/aws-controllers-k8s
 ---> Using cache
 ---> 3400bec262c7
Step 3/18 : WORKDIR $work_dir
 ---> Using cache
 ---> 90cc2c9fbb84
Step 4/18 : ENV GOPROXY=direct
 ---> Using cache
 ---> 40fc667e058e
Step 5/18 : ENV GO111MODULE=on
 ---> Using cache
 ---> 1a0a942f5b7d
Step 6/18 : ENV GOARCH=amd64
 ---> Using cache
 ---> 9f407aeec171
Step 7/18 : ENV GOOS=linux
 ---> Using cache
 ---> 4badc93a7516
Step 8/18 : ENV CGO_ENABLED=0
 ---> Using cache
 ---> 42236b98e2da
Step 9/18 : COPY go.mod go.mod
 ---> Using cache
 ---> 7780c792bab8
Step 10/18 : COPY go.sum go.sum
 ---> Using cache
 ---> 3f9c0d624f45
Step 11/18 : RUN  go mod download
 ---> Using cache
 ---> 36292125372d
Step 12/18 : COPY . $work_dir/
 ---> e5b4c8c89e05
Step 13/18 : RUN  go build -a -o $work_dir/bin/controller $work_dir/services/ecr/cmd/controller/main.go
 ---> Running in c9937fd0db7a
Removing intermediate container c9937fd0db7a
 ---> 999221be5262
Step 14/18 : FROM amazonlinux:2
 ---> fa0a6a710ca7
Step 15/18 : ARG work_dir=/github.com/aws/aws-controllers-k8s
 ---> Using cache
 ---> ec511c6aee2c
Step 16/18 : WORKDIR /
 ---> Using cache
 ---> 62fc5855e569
Step 17/18 : COPY --from=builder $work_dir/bin/controller /bin/.
 ---> Using cache
 ---> bd893de6f5b1
Step 18/18 : ENTRYPOINT ["/bin/controller"]
 ---> Using cache
 ---> bc69fc6c2922
Successfully built bc69fc6c2922
Successfully tagged ecr:88d7396-dirty
👍 Built the ecr docker image
🥑 Loading the images into the cluster
Image: "ecr:88d7396-dirty" with ID "sha256:bc69fc6c2922672e294182ea5acade18034ab78df5d1c0bc493c9d6c2ffb6403" not yet present on node "nth-test-e1da04e3-worker", loading...
Image: "ecr:88d7396-dirty" with ID "sha256:bc69fc6c2922672e294182ea5acade18034ab78df5d1c0bc493c9d6c2ffb6403" not yet present on node "nth-test-e1da04e3-control-plane", loading...
👍 Loaded image(s) into the cluster
======================================================================================================
To poke around your test manually:
export KUBECONFIG=/Users/nithmu/go/src/github.com/aws/aws-controllers-k8s/scripts/k8s-local-cluster-test/build/tmp-nth-test-e1da04e3/kubeconfig
export PATH=/Users/nithmu/go/src/github.com/aws/aws-controllers-k8s/scripts/k8s-local-cluster-test/build/tmp-nth-test-e1da04e3:$PATH
kubectl get pods -A
======================================================================================================
======================================================================================================
✅ All tests passed! ✅
======================================================================================================
🥑 Deleting k8s cluster using "kind"
Deleting cluster "nth-test-e1da04e3" ...
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
