### PR TITLE
cleanup and make build/test scripts consistent

### DIFF
--- a/docs/contents/dev-docs/setup.md
+++ b/docs/contents/dev-docs/setup.md
@@ -10,9 +10,9 @@ Then, on your workstation, run:
 
 ```bash
 cd go/src/github.com/aws
-git clone git@github.com:$GITHUB_ID/aws-service-operator-k8s
-cd aws-service-operator-k8s
-git remote add upstream git@github.com:aws/aws-service-operator-k8s
+git clone git@github.com:$GITHUB_ID/aws-controllers-k8s
+cd aws-controllers-k8s
+git remote add upstream git@github.com:aws/aws-controllers-k8s
 ```
 
 ## Create your local branch
@@ -41,12 +41,12 @@ Writing objects: 100% (4/4), 710 bytes | 710.00 KiB/s, done.
 Total 4 (delta 2), reused 0 (delta 0)
 remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
 remote: This repository moved. Please use the new location:
-remote:   git@github.com:$GITHUB_ID/aws-service-operator-k8s.git
+remote:   git@github.com:$GITHUB_ID/aws-controllers-k8s.git
 remote: 
 remote: Create a pull request for 'docs' on GitHub by visiting:
-remote:      https://github.com/$GITHUB_ID/aws-service-operator-k8s/pull/new/docs
+remote:      https://github.com/$GITHUB_ID/aws-controllers-k8s/pull/new/docs
 remote: 
-To github.com:a-hilaly/aws-service-operator-k8s
+To github.com:a-hilaly/aws-controllers-k8s
  * [new branch]      docs -> docs
 ```
 

--- a/docs/contents/dev-docs/testing.md
+++ b/docs/contents/dev-docs/testing.md
@@ -1,8 +1,36 @@
 # Testing
 
-Testing is tracked in the umbrella [Issue 6](https://github.com/aws/aws-controllers-k8s/issues/6).
+**NOTE**: Testing is tracked in the umbrella [Issue 6](https://github.com/aws/aws-controllers-k8s/issues/6).
 
-The current plan is to modify the [e2e integration test setup](https://github.com/aws/amazon-vpc-cni-k8s/blob/bc04604397889430f0a3d5f6e4766b399c1d5fcc/scripts/run-integration-tests.sh) of the AWS VPC CNI plugin repository, which uses [aws-k8s-tester](https://github.com/aws/aws-k8s-tester) for the initial setup of the Kubernetes cluster.
+For local development and/or testing we use [kind](https://kind.sigs.k8s.io/).
 
-For local development and/or testing we use [kind](https://kind.sigs.k8s.io/),
-integration tests run against an EKS cluster.
+To build and test an ACK controller against a KinD cluster, execute the
+following from the root directory of your checked-out source repository:
+
+```
+make build-ack-generate
+# Replace with the service you want to build and test an ACK controller for...
+SERVICE_TO_BUILD="ecr"
+./scripts/build-controller.sh $SERVICE_TO_BUILD
+./scripts/kind-build-test.sh -s $SERVICE_TO_BUILD
+```
+
+The above does the following:
+
+* Builds the latest `ack-generate` binary
+* Generates the ACK service controller for the AWS ECR API and output the
+  generated code to the `services/$SERVICE_TO_BUILD` directory
+* Generates the custom resource definition (CRD) manifests for resources
+  managed by that ACK service controller
+* Generates the Helm chart that can be used to install those CRD manifests and
+  a Deployment manifest that runs the ACK service controller in a Pod on a
+  Kubernetes cluster (still TODO)
+* Provisions a KinD Kubernetes cluster
+* Builds a Docker image containing the ACK service controller
+* Loads the Docker image for the ACK service controller into the KinD cluster
+* Installs the ACK service controller and related Kubernetes manifests into the
+  KinD cluster using `helm install` (still TODO)
+* Runs a series of Bash test scripts that call `kubectl` and the `aws` CLI
+  tools to verify that custom resources (CRs) of the type managed by the ACK
+  service controller are created, updated and deleted appropriately (still
+  TODO)

--- a/scripts/build-controller.sh
+++ b/scripts/build-controller.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 
-# A script that builds a single ACK service controllers an AWS API
+# A script that builds a single ACK service controller for an AWS service API
 
-set -Eou pipefail
+set -Eo pipefail
 
-SOURCE_REPO=github.com/aws/aws-controllers-k8s
 SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
-BIN_DIR=$SCRIPTS_DIR/../bin
-TEMPLATES_DIR=$SCRIPTS_DIR/../templates
+ROOT_DIR="$SCRIPTS_DIR/.."
+BIN_DIR="$ROOT_DIR/bin"
+TEMPLATES_DIR="$ROOT_DIR/templates"
 
-source "$SCRIPTS_DIR"/lib/common.sh
-source "$SCRIPTS_DIR"/lib/k8s.sh
+source "$SCRIPTS_DIR/lib/common.sh"
+source "$SCRIPTS_DIR/lib/k8s.sh"
 
 : "${ACK_GENERATE_CACHE_DIR:=~/.cache/aws-controllers-k8s}"
 : "${ACK_GENERATE_BIN_PATH:=$BIN_DIR/ack-generate}"

--- a/scripts/delete-kind-cluster.sh
+++ b/scripts/delete-kind-cluster.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -eo pipefail
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 

--- a/scripts/lib/helm.sh
+++ b/scripts/lib/helm.sh
@@ -1,5 +1,29 @@
 #!/usr/bin/env bash
 
+DEFAULT_HELM_VERSION="3.2.4"
+
+# ensure_helm [<helm version>]
+#
+# Installs the helm binary if it isn't present on the system.  Takes an
+# optional parameter for the version of helm to install. Defaults to the value
+# of the HELM_VERSION environment variable and then the value of the
+# DEFAULT_HELM_VERSION variable.  Uses `sudo mv` to place the downloaded binary
+# into your PATH.
+ensure_helm() {
+    local __helm_version="$1"
+    if [ "x$__helm_version" == "x" ]; then
+        __helm_version=${HELM_VERSION:-$DEFAULT_HELM_VERSION}
+    fi
+    if ! is_installed helm; then
+        __platform=$(uname | tr '[:upper:]' '[:lower:]')
+        __tmp_install_dir=$(mktemp -d -t install-helm-XXX)
+        curl -L https://get.helm.sh/helm-v$__helm_version-$__platform-amd64.tar.gz | tar zxf - -C $__tmp_install_dir
+        mv $__tmp_install_dir/$__platform-amd64/helm $__tmp_install_dir/.
+        chmod +x $__tmp_install_dir/helm
+        sudo mv $__tmp_install_dir/helm /usr/local/bin/helm
+    fi
+}
+
 add_helm_repo() {
    if ! should_execute add_helm_repo; then
      return 1
@@ -21,21 +45,6 @@ add_helm_repo() {
     echo "'$HELM_REPO_CHART_NAME' chart is NOT present in local helm repo '$HELM_LOCAL_REPO_NAME'."
     TEST_PASS=1
   fi
-}
-
-install_helm() {
-  # install helm in /tmp directory
-  pushd /tmp
-  # clone the source
-  git clone https://github.com/helm/helm.git
-  # checkout stable release and build the source
-  cd helm
-  git fetch --tags
-  git checkout $(git tag -l | tail -1)
-  make
-  #Update the path
-  export PATH=/tmp/helm/bin/:$PATH
-  popd
 }
 
 uninstall_helm_chart() {

--- a/scripts/lib/k8s.sh
+++ b/scripts/lib/k8s.sh
@@ -8,6 +8,19 @@ ensure_controller_gen() {
   fi
 }
 
+# ensure_kubectl installs the kubectl binary if it isn't present on the system.
+# It installs the kubectl binary for the latest stable release of Kubernetes
+# and uses `sudo mv` to place the downloaded binary into your PATH.
+ensure_kubectl() {
+    if ! is_installed kubectl ; then
+        __platform=$(uname | tr '[:upper:]' '[:lower:]')
+        __stable_k8s_version=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
+        curl -Lo "https://storage.googleapis.com/kubernetes-release/release/$__stable_k8s_version/bin/$__platform/amd64/kubectl"
+        chmod +x kubectl
+        sudo mv ./kubectl /usr/local/bin/kubectl
+    fi
+}
+
 ensure_service_controller_running() {
 
   __service_path=$1

--- a/scripts/lib/kind.sh
+++ b/scripts/lib/kind.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+DEFAULT_KIND_VERSION="0.8.1"
+
+# ensure_kind [<kind version>]
+#
+# Ensures that KinD is installed. Optional parameter specifies the version of
+# KinD to install. Defaults to the value of the environment variable
+# "KIND_VERSION" and if that is not set, the value of the DEFAULT_KIND_VERSION
+# variable.
+ensure_kind() {
+    local __kind_version="$1"
+    if [ "x$__kind_version" == "x" ]; then
+        __kind_version=${KIND_VERSION:-$DEFAULT_KIND_VERSION}
+    fi
+    if ! is_installed kind; then
+        go get "sigs.k8s.io/kind@v$__kind_version"
+    fi
+}

--- a/scripts/provision-kind-cluster.sh
+++ b/scripts/provision-kind-cluster.sh
@@ -1,8 +1,19 @@
-#!/bin/bash
-set -euo pipefail
+#!/usr/bin/env bash
+
+# A script that provisions a KinD Kubernetes cluster for local development and
+# testing
+
+set -Eo pipefail
+
+SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
+ROOT_DIR="$SCRIPTS_DIR/.."
+
+source "$SCRIPTS_DIR"/lib/common.sh
+source "$SCRIPTS_DIR"/lib/kind.sh
+source "$SCRIPTS_DIR"/lib/k8s.sh
+source "$SCRIPTS_DIR"/lib/helm.sh
 
 SCRIPT_PATH="$(cd "$(dirname "$0")" ; pwd -P )"
-ROOT_DIR="$SCRIPT_PATH/../"
 PLATFORM=$(uname | tr '[:upper:]' '[:lower:]')
 CLUSTER_CREATION_TIMEOUT_IN_SEC=300
 TEST_ID=$(uuidgen | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
@@ -17,27 +28,25 @@ K8_1_15="kindest/node:v1.15.11@sha256:6cc31f3533deb138792db2c7d1ffc36f7456a06f1d
 K8_1_14="kindest/node:v1.14.10@sha256:6cd43ff41ae9f02bb46c8f455d5323819aec858b99534a290517ebc181b443c6"
 
 K8_VERSION="$K8_1_16"
-KUBECTL_VERSION=$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)
-KIND_VERSION="0.8.1"
-HELM_VERSION="3.2.4"
 
 echoerr() { echo "$@" 1>&2; }
 
-USAGE=$(cat << 'EOM'
-  Usage: provision-cluster  [-b <BASE_CLUSTER_NAME>] [-i <TEST_IDENTIFIER>] [-v K8s_VERSION] [-o]
-  Executes the spot termination integration test for the Node Termination Handler.
-  Outputs the cluster context directory to stdout on successful completion
+USAGE="
+Usage:
+  $(basename "$0") [-b <BASE_CLUSTER_NAME>] [-i <TEST_IDENTIFIER>] [-v K8s_VERSION]
 
-  Example: provision-cluster -b my-test -i 123 -v 1.16
+Provisions a KinD cluster for local development and testing. Outputs the
+directory containing the KinD/kubectl cluster context to stdout on successful
+completion
 
-          Optional:
-            -b          Base Name of cluster
-            -i          Test Identifier to suffix Cluster Name and tmp dir
-            -v          K8s version to use in this test
-            -k          Kind cluster config file
-            -o          Override path w/ your own kubectl and kind binaries
-EOM
-)
+Example: $(basename "$0") -b my-test -i 123 -v 1.16
+
+      Optional:
+        -b          Base Name of cluster
+        -i          Test Identifier to suffix Cluster Name and tmp dir
+        -v          K8s version to use in this test
+        -k          Kind cluster config file
+"
 
 # Process our input arguments
 while getopts "b:i:v:k:o" opt; do
@@ -61,9 +70,6 @@ while getopts "b:i:v:k:o" opt; do
     k ) # Kind cluster config file
         KIND_CONFIG_FILE="${OPTARG}"
       ;;
-    o ) # Override path with your own kubectl and kind binaries
-	    OVERRIDE_PATH=1
-      ;;
     \? )
         echoerr "${USAGE}" 1>&2
         exit
@@ -71,55 +77,22 @@ while getopts "b:i:v:k:o" opt; do
   esac
 done
 
+check_is_installed docker
+
+ensure_kind
+ensure_kubectl
+ensure_helm
+
 CLUSTER_NAME="$CLUSTER_NAME_BASE"-"${TEST_ID}"
 TMP_DIR=$ROOT_DIR/build/tmp-$CLUSTER_NAME
 
 echoerr "🐳 Using Kubernetes $K8_VERSION"
 mkdir -p "${TMP_DIR}"
 
-deps=("docker")
-
-for dep in "${deps[@]}"; do
-    path_to_executable=$(which $dep)
-    if [ ! -x "$path_to_executable" ]; then
-        echoerr "You are required to have $dep installed on your system..."
-        echoerr "Please install $dep and try again. "
-        exit 3
-    fi
-done
-
-## Append to the end of PATH so that the user can override the executables if they want
-if [[ OVERRIDE_PATH -eq 1 ]]; then
-   export PATH=$PATH:$TMP_DIR
-else
-  if [ ! -x "$TMP_DIR/kubectl" ]; then
-      echoerr "🥑 Downloading the \"kubectl\" binary"
-      curl -Lo $TMP_DIR/kubectl "https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/$PLATFORM/amd64/kubectl"
-      chmod +x $TMP_DIR/kubectl
-      echoerr "👍 Downloaded the \"kubectl\" binary"
-  fi
-
-  if [ ! -x "$TMP_DIR/kind" ]; then
-      echoerr "🥑 Downloading the \"kind\" binary"
-      curl -Lo $TMP_DIR/kind https://github.com/kubernetes-sigs/kind/releases/download/v$KIND_VERSION/kind-$PLATFORM-amd64
-      chmod +x $TMP_DIR/kind
-      echoerr "👍 Downloaded the \"kind\" binary"
-  fi
-
-  if [ ! -x "$TMP_DIR/helm" ]; then
-      echoerr "🥑 Downloading the \"helm\" binary"
-      curl -L https://get.helm.sh/helm-v$HELM_VERSION-$PLATFORM-amd64.tar.gz | tar zxf - -C $TMP_DIR
-      mv $TMP_DIR/$PLATFORM-amd64/helm $TMP_DIR/.
-      chmod +x $TMP_DIR/helm
-      echoerr "👍 Downloaded the \"helm\" binary"
-  fi
-  export PATH=$TMP_DIR:$PATH
-fi
-
 echoerr "🥑 Creating k8s cluster using \"kind\""
 for i in $(seq 0 5); do
   if [[ -z $(kind get clusters | grep $CLUSTER_NAME) ]]; then
-      kind create cluster -q --name "$CLUSTER_NAME" --image $K8_VERSION --config "$SCRIPT_PATH/kind-two-node-cluster.yaml" --kubeconfig $TMP_DIR/kubeconfig 1>&2 || :
+      kind create cluster --name "$CLUSTER_NAME" --image $K8_VERSION --config "$SCRIPT_PATH/kind-two-node-cluster.yaml" --kubeconfig $TMP_DIR/kubeconfig 1>&2 || :
   else
       break
   fi


### PR DESCRIPTION
* Makes the use of variables at top of each script consistent
* Uses ensure_XXX functions to ensure that required binaries are present
  on the system
* Removes the "OVERRIDE" functionality in the
  `scripts/kind-build-test.sh`, `scripts/provision-kind-cluster.sh` and
  `scripts/delete-kind-cluster.sh` script. Instead, uses ensure_XXX
  functions and just makes sure the required dependencies are available on
  the host system
* Removes unused variables and extraneous echo statements
* Update dev-docs appropriately

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
