### PR TITLE
generate all config files needed for deployment

### DIFF
--- a/docs/contents/dev-docs/testing.md
+++ b/docs/contents/dev-docs/testing.md
@@ -29,8 +29,26 @@ The above does the following:
 * Builds a Docker image containing the ACK service controller
 * Loads the Docker image for the ACK service controller into the KinD cluster
 * Installs the ACK service controller and related Kubernetes manifests into the
-  KinD cluster using `helm install` (still TODO)
+  KinD cluster using `kustomize build | kubectl apply -f -`
 * Runs a series of Bash test scripts that call `kubectl` and the `aws` CLI
   tools to verify that custom resources (CRs) of the type managed by the ACK
   service controller are created, updated and deleted appropriately (still
   TODO)
+* Deletes the Kubernetes cluster created by KinD. You can prevent this last
+  step from happening by passing the `-p` (for "preserve") flag to the
+  `scripts/kind-build-test.sh` script
+
+**IMPORTANT NOTE**: The first time you run the `scripts/kind-build-test.sh`
+script, the step that builds the Docker image for the target ACK service
+controller can take a LONG time (40+ minutes). This is because a Docker image
+layer contains a lot of dependencies. Once you successfully build the target
+Docker image, that base Docker image layer is cached by Docker and the build
+takes a much shorter amount of time.
+
+# Cleaning up test runs
+
+If you run `scripts/kind-build-test.sh` with the `-p` (for "preserve") flag,
+the Kubernetes cluster created by KinD is not destroyed at the end of the test.
+To cleanup a Kubernetes cluster created by KinD (which will include all the
+configuration files created by the script specifically for your test cluster),
+call `kind delete cluster --name $CLUSTER_NAME`

--- a/pkg/template/config/controller/deployment_yaml.go
+++ b/pkg/template/config/controller/deployment_yaml.go
@@ -11,36 +11,27 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package pkg
+package config
 
 import (
 	"io/ioutil"
 	"path/filepath"
-	"strings"
 	ttpl "text/template"
 
-	"github.com/aws/aws-controllers-k8s/pkg/model"
 	"github.com/aws/aws-controllers-k8s/pkg/template"
 )
 
-type CRDManagerGoTemplateVars struct {
-	APIVersion              string
-	APIGroup                string
-	ServiceAlias            string
-	SDKAPIInterfaceTypeName string
-	CRD                     *model.CRD
+type ConfigControllerDeploymentYAMLTemplateVars struct {
+	ServiceAlias string
 }
 
-func NewCRDManagerGoTemplate(tplDir string) (*ttpl.Template, error) {
-	tplPath := filepath.Join(tplDir, "pkg", "crd_manager.go.tpl")
+func NewConfigControllerDeploymentYAMLTemplate(tplDir string) (*ttpl.Template, error) {
+	tplPath := filepath.Join(tplDir, "config", "controller", "deployment.yaml.tpl")
 	tplContents, err := ioutil.ReadFile(tplPath)
 	if err != nil {
 		return nil, err
 	}
-	t := ttpl.New("crd_manager")
-	t = t.Funcs(ttpl.FuncMap{
-		"ToLower": strings.ToLower,
-	})
+	t := ttpl.New("deployment_yaml")
 	if t, err = t.Parse(string(tplContents)); err != nil {
 		return nil, err
 	}

--- a/pkg/template/config/controller/kustomization_yaml.go
+++ b/pkg/template/config/controller/kustomization_yaml.go
@@ -11,36 +11,27 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package pkg
+package config
 
 import (
 	"io/ioutil"
 	"path/filepath"
-	"strings"
 	ttpl "text/template"
 
-	"github.com/aws/aws-controllers-k8s/pkg/model"
 	"github.com/aws/aws-controllers-k8s/pkg/template"
 )
 
-type CRDManagerGoTemplateVars struct {
-	APIVersion              string
-	APIGroup                string
-	ServiceAlias            string
-	SDKAPIInterfaceTypeName string
-	CRD                     *model.CRD
+type ConfigControllerKustomizationYAMLTemplateVars struct {
+	ServiceAlias string
 }
 
-func NewCRDManagerGoTemplate(tplDir string) (*ttpl.Template, error) {
-	tplPath := filepath.Join(tplDir, "pkg", "crd_manager.go.tpl")
+func NewConfigControllerKustomizationYAMLTemplate(tplDir string) (*ttpl.Template, error) {
+	tplPath := filepath.Join(tplDir, "config", "controller", "kustomization.yaml.tpl")
 	tplContents, err := ioutil.ReadFile(tplPath)
 	if err != nil {
 		return nil, err
 	}
-	t := ttpl.New("crd_manager")
-	t = t.Funcs(ttpl.FuncMap{
-		"ToLower": strings.ToLower,
-	})
+	t := ttpl.New("kustomization_yaml")
 	if t, err = t.Parse(string(tplContents)); err != nil {
 		return nil, err
 	}

--- a/pkg/template/config/default/kustomization_yaml.go
+++ b/pkg/template/config/default/kustomization_yaml.go
@@ -11,36 +11,27 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package pkg
+package config
 
 import (
 	"io/ioutil"
 	"path/filepath"
-	"strings"
 	ttpl "text/template"
 
-	"github.com/aws/aws-controllers-k8s/pkg/model"
 	"github.com/aws/aws-controllers-k8s/pkg/template"
 )
 
-type CRDManagerGoTemplateVars struct {
-	APIVersion              string
-	APIGroup                string
-	ServiceAlias            string
-	SDKAPIInterfaceTypeName string
-	CRD                     *model.CRD
+type ConfigDefaultKustomizationYAMLTemplateVars struct {
+	ServiceAlias string
 }
 
-func NewCRDManagerGoTemplate(tplDir string) (*ttpl.Template, error) {
-	tplPath := filepath.Join(tplDir, "pkg", "crd_manager.go.tpl")
+func NewConfigDefaultKustomizationYAMLTemplate(tplDir string) (*ttpl.Template, error) {
+	tplPath := filepath.Join(tplDir, "config", "default", "kustomization.yaml.tpl")
 	tplContents, err := ioutil.ReadFile(tplPath)
 	if err != nil {
 		return nil, err
 	}
-	t := ttpl.New("crd_manager")
-	t = t.Funcs(ttpl.FuncMap{
-		"ToLower": strings.ToLower,
-	})
+	t := ttpl.New("kustomization_yaml")
 	if t, err = t.Parse(string(tplContents)); err != nil {
 		return nil, err
 	}

--- a/pkg/template/config/rbac/cluster_role_binding_yaml.go
+++ b/pkg/template/config/rbac/cluster_role_binding_yaml.go
@@ -11,36 +11,27 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package pkg
+package config
 
 import (
 	"io/ioutil"
 	"path/filepath"
-	"strings"
 	ttpl "text/template"
 
-	"github.com/aws/aws-controllers-k8s/pkg/model"
 	"github.com/aws/aws-controllers-k8s/pkg/template"
 )
 
-type CRDManagerGoTemplateVars struct {
-	APIVersion              string
-	APIGroup                string
-	ServiceAlias            string
-	SDKAPIInterfaceTypeName string
-	CRD                     *model.CRD
+type ConfigRBACClusterRoleBindingYAMLTemplateVars struct {
+	ServiceAlias string
 }
 
-func NewCRDManagerGoTemplate(tplDir string) (*ttpl.Template, error) {
-	tplPath := filepath.Join(tplDir, "pkg", "crd_manager.go.tpl")
+func NewConfigRBACClusterRoleBindingYAMLTemplate(tplDir string) (*ttpl.Template, error) {
+	tplPath := filepath.Join(tplDir, "config", "rbac", "cluster-role-binding.yaml.tpl")
 	tplContents, err := ioutil.ReadFile(tplPath)
 	if err != nil {
 		return nil, err
 	}
-	t := ttpl.New("crd_manager")
-	t = t.Funcs(ttpl.FuncMap{
-		"ToLower": strings.ToLower,
-	})
+	t := ttpl.New("cluster_role_binding_yaml")
 	if t, err = t.Parse(string(tplContents)); err != nil {
 		return nil, err
 	}

--- a/pkg/template/config/rbac/kustomization_yaml.go
+++ b/pkg/template/config/rbac/kustomization_yaml.go
@@ -11,36 +11,27 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package pkg
+package config
 
 import (
 	"io/ioutil"
 	"path/filepath"
-	"strings"
 	ttpl "text/template"
 
-	"github.com/aws/aws-controllers-k8s/pkg/model"
 	"github.com/aws/aws-controllers-k8s/pkg/template"
 )
 
-type CRDManagerGoTemplateVars struct {
-	APIVersion              string
-	APIGroup                string
-	ServiceAlias            string
-	SDKAPIInterfaceTypeName string
-	CRD                     *model.CRD
+type ConfigRBACKustomizationYAMLTemplateVars struct {
+	ServiceAlias string
 }
 
-func NewCRDManagerGoTemplate(tplDir string) (*ttpl.Template, error) {
-	tplPath := filepath.Join(tplDir, "pkg", "crd_manager.go.tpl")
+func NewConfigRBACKustomizationYAMLTemplate(tplDir string) (*ttpl.Template, error) {
+	tplPath := filepath.Join(tplDir, "config", "rbac", "kustomization.yaml.tpl")
 	tplContents, err := ioutil.ReadFile(tplPath)
 	if err != nil {
 		return nil, err
 	}
-	t := ttpl.New("crd_manager")
-	t = t.Funcs(ttpl.FuncMap{
-		"ToLower": strings.ToLower,
-	})
+	t := ttpl.New("kustomization_yaml")
 	if t, err = t.Parse(string(tplContents)); err != nil {
 		return nil, err
 	}

--- a/scripts/lib/k8s.sh
+++ b/scripts/lib/k8s.sh
@@ -21,6 +21,16 @@ ensure_kubectl() {
     fi
 }
 
+# ensure_kustomize installs the kustomize binary if it isn't present on the
+# system and uses `sudo mv` to place the downloaded binary into your PATH.
+ensure_kustomize() {
+    if ! is_installed kustomize ; then
+        curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+        chmod +x kustomize
+        sudo mv kustomize /usr/local/bin/kustomize
+    fi
+}
+
 ensure_service_controller_running() {
 
   __service_path=$1

--- a/scripts/provision-kind-cluster.sh
+++ b/scripts/provision-kind-cluster.sh
@@ -86,18 +86,18 @@ ensure_helm
 CLUSTER_NAME="$CLUSTER_NAME_BASE"-"${TEST_ID}"
 TMP_DIR=$ROOT_DIR/build/tmp-$CLUSTER_NAME
 
-echoerr "🐳 Using Kubernetes $K8_VERSION"
+echoerr "Using Kubernetes $K8_VERSION"
 mkdir -p "${TMP_DIR}"
 
-echoerr "🥑 Creating k8s cluster using \"kind\""
+echoerr "Creating k8s cluster using \"kind\" ..."
 for i in $(seq 0 5); do
   if [[ -z $(kind get clusters | grep $CLUSTER_NAME) ]]; then
-      kind create cluster --name "$CLUSTER_NAME" --image $K8_VERSION --config "$SCRIPT_PATH/kind-two-node-cluster.yaml" --kubeconfig $TMP_DIR/kubeconfig 1>&2 || :
+      kind create cluster -q --name "$CLUSTER_NAME" --image $K8_VERSION --config "$SCRIPT_PATH/kind-two-node-cluster.yaml" --kubeconfig $TMP_DIR/kubeconfig 1>&2 || :
   else
       break
   fi
 done
 
 echo "$CLUSTER_NAME" > $TMP_DIR/clustername
-echoerr "👍 Created k8s cluster using \"kind\""
+echoerr "Created k8s cluster using \"kind\""
 echo $TMP_DIR

--- a/templates/config/controller/deployment.yaml.tpl
+++ b/templates/config/controller/deployment.yaml.tpl
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    control-plane: controller
+  name: ack-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ack-{{ .ServiceAlias}}-controller
+  namespace: ack-system
+  labels:
+    control-plane: controller
+spec:
+  selector:
+    matchLabels:
+      control-plane: controller
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        control-plane: controller
+    spec:
+      containers:
+      - command:
+        - ./bin/controller
+        args:
+        # Obviously this needs to change...
+        - --aws-account-id
+        - "123456"
+        image: controller:latest
+        name: controller
+        resources:
+          limits:
+            cpu: 100m
+            memory: 300Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+      terminationGracePeriodSeconds: 10

--- a/templates/config/controller/kustomization.yaml.tpl
+++ b/templates/config/controller/kustomization.yaml.tpl
@@ -1,0 +1,8 @@
+resources:
+- deployment.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: ack-{{ .ServiceAlias }}-controller
+  newTag: latest

--- a/templates/config/default/kustomization.yaml.tpl
+++ b/templates/config/default/kustomization.yaml.tpl
@@ -1,0 +1,20 @@
+# Adds namespace to all resources.
+# namespace:
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+# namePrefix: 
+
+# Labels to add to all resources and selectors.
+#commonLabels:
+#  someName: someValue
+
+bases:
+# - ../crd
+- ../rbac
+- ../controller
+
+patchesStrategicMerge:

--- a/templates/config/rbac/cluster-role-binding.yaml.tpl
+++ b/templates/config/rbac/cluster-role-binding.yaml.tpl
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ack-controller-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ack-controller-role
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: ack-system

--- a/templates/config/rbac/kustomization.yaml.tpl
+++ b/templates/config/rbac/kustomization.yaml.tpl
@@ -1,0 +1,3 @@
+resources:
+- role.yaml
+- cluster-role-binding.yaml

--- a/templates/pkg/crd_manager.go.tpl
+++ b/templates/pkg/crd_manager.go.tpl
@@ -14,6 +14,9 @@ import (
 	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServiceAlias }}"
 )
 
+// +kubebuilder:rbac:groups={{ .ServiceAlias }}.services.k8s.aws,resources={{ ToLower .CRD.Plural }},verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups={{ .ServiceAlias }}.services.k8s.aws,resources={{ ToLower .CRD.Plural }}/status,verbs=get;update;patch
+
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {


### PR DESCRIPTION
Adds all the RBAC, Deployment, Namespace and other config file
requisites into the generation of an ACK service controller. This moves
the generated config files into a `services/$SERVICE/config` directory
(out of the `services/$SERVICE/apis/v1alpha1/config/crd` directory)
along with a set of kustomize overlay directories and kustomization.yaml
files.

The `scripts/kind-build-test.sh` has been updated to use kustomize to
generate a templatized overlay directory during testing which points to
the Docker image for the ACK service controller built during the test
run. All configs are then `kubectl apply`'d to the k8s cluster running
in KinD:

```
jaypipes@thelio:~/go/src/github.com/aws/aws-controllers-k8s$ rm -rf services/ecr/
jaypipes@thelio:~/go/src/github.com/aws/aws-controllers-k8s$ ./scripts/build-controller.sh ecr
Building Kubernetes API objects for ecr
Generating deepcopy code for ecr
Generating custom resource definitions for ecr
Building service controller for ecr
Generating RBAC manifests for ecr
jaypipes@thelio:~/go/src/github.com/aws/aws-controllers-k8s$ tree services/ecr/
services/ecr/
├── apis
│   └── v1alpha1
│       ├── doc.go
│       ├── enums.go
│       ├── groupversion_info.go
│       ├── repository.go
│       ├── types.go
│       └── zz_generated.deepcopy.go
├── cmd
│   └── controller
│       └── main.go
├── config
│   ├── controller
│   │   ├── deployment.yaml
│   │   └── kustomization.yaml
│   ├── crd
│   │   └── bases
│   │       └── ecr.services.k8s.aws_repositories.yaml
│   ├── default
│   │   └── kustomization.yaml
│   └── rbac
│       ├── cluster-role-binding.yaml
│       ├── kustomization.yaml
│       └── role.yaml
├── Dockerfile
└── pkg
    └── resource
        ├── registry.go
        └── repository
            ├── descriptor.go
            ├── identifiers.go
            ├── manager_factory.go
            ├── manager.go
            ├── resource.go
            └── sdk.go

13 directories, 22 files
jaypipes@thelio:~/go/src/github.com/aws/aws-controllers-k8s$ ./scripts/kind-build-test.sh -s ecr -p
Using Kubernetes kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765
Creating k8s cluster using "kind" ...
No kind clusters found.
Created k8s cluster using "kind"
Building ecr docker image
sha256:bb3aa98009c9f797affb58e23f85131f46ae5c92bd318a0451c5beff0bec118c
Loading the images into the cluster
Image: "ack-ecr-controller:ca5184a-dirty" with ID "sha256:bb3aa98009c9f797affb58e23f85131f46ae5c92bd318a0451c5beff0bec118c" not yet present on node "test-17ff52cd-worker", loading...
Image: "ack-ecr-controller:ca5184a-dirty" with ID "sha256:bb3aa98009c9f797affb58e23f85131f46ae5c92bd318a0451c5beff0bec118c" not yet present on node "test-17ff52cd-control-plane", loading...
Loading CRD manifests for ecr into the cluster
customresourcedefinition.apiextensions.k8s.io/repositories.ecr.services.k8s.aws created
Loading RBAC manifests for ecr into the cluster
clusterrole.rbac.authorization.k8s.io/ack-controller-role created
clusterrolebinding.rbac.authorization.k8s.io/ack-controller-rolebinding created
Loading service controller Deployment for ecr into the cluster
namespace/ack-system created
deployment.apps/ack-ecr-controller created
======================================================================================================
To poke around your test manually:
export KUBECONFIG=/home/jaypipes/go/src/github.com/aws/aws-controllers-k8s/scripts/../build/tmp-test-17ff52cd/kubeconfig
kubectl get pods -A
======================================================================================================
To resume test with the same cluster use: "-c /home/jaypipes/go/src/github.com/aws/aws-controllers-k8s/scripts/../build/tmp-test-17ff52cd"
jaypipes@thelio:~/go/src/github.com/aws/aws-controllers-k8s$ export KUBECONFIG=/home/jaypipes/go/src/github.com/aws/aws-controllers-k8s/scripts/../build/tmp-test-17ff52cd/kubeconfig
jaypipes@thelio:~/go/src/github.com/aws/aws-controllers-k8s$ kubectl get pods -A
NAMESPACE            NAME                                                  READY   STATUS    RESTARTS   AGE
ack-system           ack-ecr-controller-5b66b74bd8-2mbsw                   1/1     Running   0          107s
kube-system          coredns-5644d7b6d9-248ng                              1/1     Running   0          2m33s
kube-system          coredns-5644d7b6d9-fmkbg                              1/1     Running   0          2m33s
kube-system          etcd-test-17ff52cd-control-plane                      1/1     Running   0          90s
kube-system          kindnet-dxqfx                                         1/1     Running   0          2m33s
kube-system          kindnet-fc7jd                                         1/1     Running   0          2m16s
kube-system          kube-apiserver-test-17ff52cd-control-plane            1/1     Running   0          92s
kube-system          kube-controller-manager-test-17ff52cd-control-plane   1/1     Running   0          97s
kube-system          kube-proxy-lqjk8                                      1/1     Running   0          2m33s
kube-system          kube-proxy-plcc8                                      1/1     Running   0          2m16s
kube-system          kube-scheduler-test-17ff52cd-control-plane            1/1     Running   0          107s
local-path-storage   local-path-provisioner-58f6947c7-vc8cd                1/1     Running   0          2m33s
jaypipes@thelio:~/go/src/github.com/aws/aws-controllers-k8s$ kubectl describe pod ack-ecr-controller-5b66b74bd8-2mbsw -n ack-system
Name:         ack-ecr-controller-5b66b74bd8-2mbsw
Namespace:    ack-system
Priority:     0
Node:         test-17ff52cd-worker/172.18.0.2
Start Time:   Tue, 04 Aug 2020 19:55:39 -0400
Labels:       control-plane=controller
              pod-template-hash=5b66b74bd8
Annotations:  <none>
Status:       Running
IP:           10.244.1.2
IPs:
  IP:           10.244.1.2
Controlled By:  ReplicaSet/ack-ecr-controller-5b66b74bd8
Containers:
  controller:
    Container ID:  containerd://ae33c1a2b32d2709b0fcff7632f33f931041a5d59b08894918cdcc18f76be01d
    Image:         ack-ecr-controller:ca5184a-dirty
    Image ID:      sha256:bb3aa98009c9f797affb58e23f85131f46ae5c92bd318a0451c5beff0bec118c
    Port:          <none>
    Host Port:     <none>
    Command:
      ./bin/controller
    State:          Running
      Started:      Tue, 04 Aug 2020 19:55:41 -0400
    Ready:          True
    Restart Count:  0
    Limits:
      cpu:     100m
      memory:  300Mi
    Requests:
      cpu:        100m
      memory:     200Mi
    Environment:  <none>
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from default-token-hh4wg (ro)
Conditions:
  Type              Status
  Initialized       True
  Ready             True
  ContainersReady   True
  PodScheduled      True
Volumes:
  default-token-hh4wg:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  default-token-hh4wg
    Optional:    false
QoS Class:       Burstable
Node-Selectors:  <none>
Tolerations:     node.kubernetes.io/not-ready:NoExecute for 300s
                 node.kubernetes.io/unreachable:NoExecute for 300s
Events:
  Type    Reason     Age    From                           Message
  ----    ------     ----   ----                           -------
  Normal  Scheduled  2m35s  default-scheduler              Successfully assigned ack-system/ack-ecr-controller-5b66b74bd8-2mbsw to test-17ff52cd-worker
  Normal  Pulled     2m34s  kubelet, test-17ff52cd-worker  Container image "ack-ecr-controller:ca5184a-dirty" already present on machine
  Normal  Created    2m33s  kubelet, test-17ff52cd-worker  Created container controller
  Normal  Started    2m33s  kubelet, test-17ff52cd-worker  Started container controller
jaypipes@thelio:~/go/src/github.com/aws/aws-controllers-k8s$ kubectl logs ack-ecr-controller-5b66b74bd8-2mbsw -n ack-system
{"level":"info","ts":1596585341.9561605,"logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":"0.0.0.0:8080"}
{"level":"info","ts":1596585341.9665308,"logger":"setup","msg":"initializing service controller","aws.service":"ecr"}
{"level":"info","ts":1596585341.966627,"logger":"setup","msg":"starting manager","aws.service":"ecr"}
{"level":"info","ts":1596585341.9667215,"logger":"controller-runtime.manager","msg":"starting metrics server","path":"/metrics"}
{"level":"info","ts":1596585341.9667659,"logger":"controller-runtime.controller","msg":"Starting EventSource","controller":"repository","source":"kind source: /, Kind="}
{"level":"info","ts":1596585342.0670905,"logger":"controller-runtime.controller","msg":"Starting Controller","controller":"repository"}
{"level":"info","ts":1596585342.0671284,"logger":"controller-runtime.controller","msg":"Starting workers","controller":"repository","worker count":1}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
