### PR TITLE
construct Input shape from both Spec and Status

### DIFF
--- a/pkg/model/crd_test.go
+++ b/pkg/model/crd_test.go
@@ -116,16 +116,16 @@ func TestSNSTopic(t *testing.T) {
 	attrMap["Policy"] = r.ko.Spec.Policy
 	res.SetAttributes(attrMap)
 	res.SetName(*r.ko.Spec.Name)
-	f5 := []*svcsdk.Tag{}
-	for _, f5iter := range r.ko.Spec.Tags {
-		f5elem := &svcsdk.Tag{}
-		f5elem.SetKey(*f5iter.Key)
-		f5elem.SetValue(*f5iter.Value)
-		f5 = append(f5, f5elem)
+	f2 := []*svcsdk.Tag{}
+	for _, f2iter := range r.ko.Spec.Tags {
+		f2elem := &svcsdk.Tag{}
+		f2elem.SetKey(*f2iter.Key)
+		f2elem.SetValue(*f2iter.Value)
+		f2 = append(f2, f2elem)
 	}
-	res.SetTags(f5)
+	res.SetTags(f2)
 `
-	assert.Equal(expCreateInput, crd.GoCodeSetInput(model.OpTypeCreate, "r.ko.Spec", "res", 1))
+	assert.Equal(expCreateInput, crd.GoCodeSetInput(model.OpTypeCreate, "r.ko", "res", 1))
 
 	// None of the fields in the Topic resource's CreateTopicInput shape are
 	// returned in the CreateTopicOutput shape, so none of them return any Go
@@ -403,7 +403,7 @@ func TestEC2LaunchTemplate(t *testing.T) {
 	res.SetTagSpecifications(f4)
 	res.SetVersionDescription(*r.ko.Spec.VersionDescription)
 `
-	assert.Equal(expCreateInput, crd.GoCodeSetInput(model.OpTypeCreate, "r.ko.Spec", "res", 1))
+	assert.Equal(expCreateInput, crd.GoCodeSetInput(model.OpTypeCreate, "r.ko", "res", 1))
 
 	// Check that we properly determined how to find the CreatedBy attribute
 	// within the CreateLaunchTemplateResult shape, which has a single field called
@@ -502,7 +502,7 @@ func TestECRRepository(t *testing.T) {
 	}
 	res.SetTags(f3)
 `
-	assert.Equal(expCreateInput, crd.GoCodeSetInput(model.OpTypeCreate, "r.ko.Spec", "res", 1))
+	assert.Equal(expCreateInput, crd.GoCodeSetInput(model.OpTypeCreate, "r.ko", "res", 1))
 
 	expStatusFieldCamel := []string{
 		"CreatedAt",
@@ -697,15 +697,15 @@ func TestSQSQueue(t *testing.T) {
 	attrMap["VisibilityTimeout"] = r.ko.Spec.VisibilityTimeout
 	res.SetAttributes(attrMap)
 	res.SetQueueName(*r.ko.Spec.QueueName)
-	f11 := map[string]*string{}
-	for f11key, f11valiter := range r.ko.Spec.Tags {
-		var f11val string
-		f11val = *f11valiter
-		f11[f11key] = &f11val
+	f2 := map[string]*string{}
+	for f2key, f2valiter := range r.ko.Spec.Tags {
+		var f2val string
+		f2val = *f2valiter
+		f2[f2key] = &f2val
 	}
-	res.SetTags(f11)
+	res.SetTags(f2)
 `
-	assert.Equal(expCreateInput, crd.GoCodeSetInput(model.OpTypeCreate, "r.ko.Spec", "res", 1))
+	assert.Equal(expCreateInput, crd.GoCodeSetInput(model.OpTypeCreate, "r.ko", "res", 1))
 
 	// There are no fields other than QueueID in the returned CreateQueueResult
 	// shape
@@ -829,7 +829,7 @@ func TestAPIGatewayV2_Route(t *testing.T) {
 	res.SetRouteResponseSelectionExpression(*r.ko.Spec.RouteResponseSelectionExpression)
 	res.SetTarget(*r.ko.Spec.Target)
 `
-	assert.Equal(expCreateInput, crd.GoCodeSetInput(model.OpTypeCreate, "r.ko.Spec", "res", 1))
+	assert.Equal(expCreateInput, crd.GoCodeSetInput(model.OpTypeCreate, "r.ko", "res", 1))
 
 	expCreateOutput := `
 	ko.Status.APIGatewayManaged = resp.ApiGatewayManaged

--- a/templates/pkg/crd_sdk.go.tpl
+++ b/templates/pkg/crd_sdk.go.tpl
@@ -86,7 +86,7 @@ func (rm *resourceManager) newDescribeRequestPayload(
 	r *resource,
 ) (*svcsdk.{{ .CRD.Ops.ReadOne.InputRef.Shape.ShapeName }}, error) {
 	res := &svcsdk.{{ .CRD.Ops.ReadOne.InputRef.Shape.ShapeName }}{}
-{{ GoCodeSetReadOneInput .CRD "r.ko.Spec" "res" 1 }}
+{{ GoCodeSetReadOneInput .CRD "r.ko" "res" 1 }}
 	return res, nil
 }
 {{- end }}
@@ -131,7 +131,7 @@ func (rm *resourceManager) newCreateRequestPayload(
 	r *resource,
 ) (*svcsdk.{{ .CRD.Ops.Create.InputRef.Shape.ShapeName }}, error) {
 	res := &svcsdk.{{ .CRD.Ops.Create.InputRef.Shape.ShapeName }}{}
-{{ GoCodeSetCreateInput .CRD "r.ko.Spec" "res" 1 }}
+{{ GoCodeSetCreateInput .CRD "r.ko" "res" 1 }}
 	return res, nil
 }
 
@@ -168,7 +168,7 @@ func (rm *resourceManager) newUpdateRequestPayload(
 	r *resource,
 ) (*svcsdk.{{ .CRD.Ops.Update.InputRef.Shape.ShapeName }}, error) {
 	res := &svcsdk.{{ .CRD.Ops.Update.InputRef.Shape.ShapeName }}{}
-{{ GoCodeSetUpdateInput .CRD "r.ko.Spec" "res" 1 }}
+{{ GoCodeSetUpdateInput .CRD "r.ko" "res" 1 }}
 	return res, nil
 }
 {{ end }}
@@ -198,7 +198,7 @@ func (rm *resourceManager) newDeleteRequestPayload(
 	r *resource,
 ) (*svcsdk.{{ .CRD.Ops.Delete.InputRef.Shape.ShapeName }}, error) {
 	res := &svcsdk.{{ .CRD.Ops.Delete.InputRef.Shape.ShapeName }}{}
-{{ GoCodeSetDeleteInput .CRD "r.ko.Spec" "res" 1 }}
+{{ GoCodeSetDeleteInput .CRD "r.ko" "res" 1 }}
 	return res, nil
 }
 {{- end -}}


### PR DESCRIPTION
We were only attempting to set the fields on an Input shape by looking
for a corresponding field in the CRD's Spec struct. This makes sense in
a way, since constructing, for example, the CreateBookInput shape would
by nature only take fields from the Book's desired state (i.e. the
BookSpec) struct.

However when constructing Input shapes like that used for ReadOne
operations, we need to look in the CRD's Status fields as well as the
Spec fields.

For example, consider the API Gateway V2 API's GetApiInput shape:

```go
type GetApiInput struct {
	_ struct{} `type:"structure"`

	// ApiId is a required field
	ApiId *string `location:"uri" locationName:"apiId" type:"string" required:"true"`
}
```

The Go code we were outputting for the `newDescribeRequestPayload()`
method in that generated service controller's `pkg/resource/api/sdk.go`
file looked like this:

```go
func (rm *resourceManager) newDescribeRequestPayload(
	r *resource,
) (*svcsdk.GetApiInput, error) {
	res := &svcsdk.GetApiInput{}

	return res, nil
}
```

There is a `GetApiInput.ApiId` field that isn't being set because the
`ApiId` value is stored in the `API.Status.APIID` field, not the
`API.Spec.APIID` field.

With this patch, we now output the proper Go code to populate the Input
shape with values from both Spec and Status fields in the CR:

```go

// newDescribeRequestPayload returns SDK-specific struct for the HTTP request
// payload of the Describe API call for the resource
func (rm *resourceManager) newDescribeRequestPayload(
	r *resource,
) (*svcsdk.GetApiInput, error) {
	res := &svcsdk.GetApiInput{}

	res.SetApiId(*r.ko.Status.APIID)

	return res, nil
}
```

Issue #127

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
