### PR TITLE
Ability to filter service APIs for controller auto generation #133

### DIFF
--- a/pkg/model/crd_test.go
+++ b/pkg/model/crd_test.go
@@ -1056,6 +1056,33 @@ func TestElasticache_CacheCluster(t *testing.T) {
 	assert.Equal(expCreateOutput, crd.GoCodeSetOutput(model.OpTypeCreate, "resp", "ko.Status", 1))
 }
 
+
+func TestElasticache_Ignored_Operations(t *testing.T) {
+	require := require.New(t)
+
+	sh := testutil.NewSchemaHelperForService(t, "elasticache")
+
+	crds, err := sh.GetCRDs()
+	require.Nil(err)
+
+	crd := getCRDByName("Snapshot", crds)
+	require.NotNil(crd)
+	require.NotNil(crd.Ops.Create)
+	require.Nil(crd.Ops.Delete)
+}
+
+func TestElasticache_Ignored_Resources(t *testing.T) {
+	require := require.New(t)
+
+	sh := testutil.NewSchemaHelperForService(t, "elasticache")
+
+	crds, err := sh.GetCRDs()
+	require.Nil(err)
+
+	crd := getCRDByName("GlobalReplicationGroup", crds)
+	require.Nil(crd)
+}
+
 func TestDynamoDB_Table(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/pkg/model/generator_config.go
+++ b/pkg/model/generator_config.go
@@ -25,6 +25,19 @@ type GeneratorConfig struct {
 	// Resources contains generator instructions for individual CRDs within an
 	// API
 	Resources map[string]ResourceGeneratorConfig `json:"resources"`
+	// CRDs to ignore. ACK generator would skip these resources.
+	Ignore IgnoreSpec `json:"ignore"`
+}
+
+// IgnoreSpec represents instructions to the ACK code generator to
+// ignore operations, resources on an AWS service API
+type IgnoreSpec struct {
+	// Set of operation IDs/names that should be ignored by the
+	// generator when constructing SDK linkage
+	Operations []string `json:"operations"`
+	// Set of resource names that should be ignored by the
+	// generator
+	ResourceNames []string `json:"resource_names"`
 }
 
 // ResourceGeneratorConfig represents instructions to the ACK code generator
@@ -104,8 +117,7 @@ type FieldGeneratorConfig struct {
 }
 
 // NewGeneratorConfig returns a new GeneratorConfig object given a supplied
-// path to a config file and a pointer to an aws-sdk-go private/model/api.API
-// struct
+// path to a config file
 func NewGeneratorConfig(
 	configPath string,
 ) (*GeneratorConfig, error) {

--- a/pkg/model/testdata/models/apis/elasticache/0000-00-00/generator.yaml
+++ b/pkg/model/testdata/models/apis/elasticache/0000-00-00/generator.yaml
@@ -1,0 +1,6 @@
+resources:
+ignore:
+  operations:
+    - DeleteSnapshot
+  resource_names:
+    - GlobalReplicationGroup


### PR DESCRIPTION
Issue #, if available: #133 

Description of changes: Added support to ignore resources, operations for AWS Service API controller generation via generator config YAML file

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
