### PR TITLE
s/aws-service-operators-k8s/aws-controllers-k8s/g

### DIFF
--- a/docs/contents/user-docs/install.md
+++ b/docs/contents/user-docs/install.md
@@ -11,7 +11,7 @@ Before installing an AWS service controller, ensure you have added the
 AWS Controllers for Kubernetes Helm repository:
 
 ```
-helm repo add ack https://aws.github.io/aws-service-operator-k8s
+helm repo add ack https://aws.github.io/aws-controllers-k8s
 ```
 
 Each AWS service controller is packaged into a separate container image, published on a public AWS Elastic Container Registry repository. Likewise,

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -28,7 +28,7 @@ GO111MODULE=on
 : "${RUN_CONFORMANCE:=false}"
 : "${HELM_LOCAL_REPO_NAME:=ack}"
 # TODO: HELM_REPO_SOURCE will change to aws org.
-: "${HELM_REPO_SOURCE:=https://varun1524.github.io/aws-service-operator-k8s/helm/charts/}"
+: "${HELM_REPO_SOURCE:=https://aws.github.io/aws-controllers-k8s/helm/charts/}"
 : "${HELM_REPO_CHART_NAME:=start-service-controller}"
 : "${HELM_CONTROLLER_NAME_PREFIX:=aws-k8s}"
 : "${HELM_LOCAL_CHART_NAME:=ack}"


### PR DESCRIPTION
Small renames from old repo name.

I didn't touch any of the go templates because I'm not familiar with the tests so I could verify it doesn't break anything.
