### PR TITLE
local functional testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash # Use bash syntax
 GO111MODULE=on
 
 PKGS=$(sort $(dir $(wildcard pkg/*/*/)))
@@ -7,7 +8,8 @@ MOCKS=$(foreach x, $(PKGS), mocks/$(x))
 # aws-sdk-go/private/model/api package is gated behind a build tag "codegen"...
 GO_TAGS=-tags codegen
 
-.PHONY: all build-ack-generate test clean-mocks mocks
+.PHONY: all build-ack-generate test clean-mocks mocks build-controller build-kind-cluster build-kind-cluster-preserve \
+        build-kind-cluster-functional kind-get-cluster-names delete-all-kind-clusters
 
 all: test
 
@@ -19,6 +21,27 @@ test: | mocks
 
 clean-mocks:
 	rm -rf mocks
+
+build-controller:
+	./scripts/build-controller.sh $(SERVICE)
+
+kind-cluster: test
+	./scripts/kind-build-test.sh -s $(SERVICE)
+
+kind-cluster-preserve: test
+	./scripts/kind-build-test.sh -s $(SERVICE) -p
+
+kind-cluster-functional: test
+	./scripts/kind-build-test.sh -s $(SERVICE) -p -r $(ROLE_ARN)
+
+kind-get-cluster-names:
+	@kind get clusters
+
+delete-all-kind-clusters:
+	@kind get clusters | \
+	while read name ; do \
+	kind delete cluster --name $$name; \
+	done
 
 mocks: ensure-mockery $(MOCKS)
 

--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -6,7 +6,7 @@
 
 set -Eo pipefail
 
-SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
+SCRIPTS_DIR=$(cd "$(dirname "$0")" || exit 1; pwd)
 ROOT_DIR="$SCRIPTS_DIR/.."
 
 source "$SCRIPTS_DIR/lib/common.sh"
@@ -14,6 +14,7 @@ source "$SCRIPTS_DIR/lib/k8s.sh"
 
 OPTIND=1
 CLUSTER_NAME_BASE="test"
+AWS_ROLE_ARN=""
 DELETE_CLUSTER_ARGS=""
 K8S_VERSION="1.16"
 OVERRIDE_PATH=0
@@ -23,12 +24,6 @@ START=$(date +%s)
 TMP_DIR=""
 # VERSION is the source revision that executables and images are built from.
 VERSION=$(git describe --tags --always --dirty || echo "unknown")
-
-function timeout() { perl -e 'alarm shift; exec @ARGV' "$@"; }
-
-function relpath() {
-  perl -e 'use File::Spec; print File::Spec->abs2rel(@ARGV) . "\n"' "${1}" "${2}"
-}
 
 function clean_up {
     if [[ "$PRESERVE" == false ]]; then
@@ -47,7 +42,7 @@ function exit_and_fail {
 
 USAGE="
 Usage:
-  $(basename "$0") [-p] [-s] [-o] [-b <TEST_BASE_NAME>] [-c <CLUSTER_CONTEXT_DIR>] [-i <AWS Docker image name>] [-s] [-v K8S_VERSION]
+  $(basename "$0") [-p] [-s] [-o] [-b <TEST_BASE_NAME>] [-c <CLUSTER_CONTEXT_DIR>] [-i <AWS Docker image name>] [-r] [-s] [-v K8S_VERSION]
 
 Builds the Docker image for an ACK service controller, loads the Docker image
 into a KinD Kubernetes cluster, creates the Deployment artifact for the ACK
@@ -60,18 +55,22 @@ Options:
   -c          Cluster context directory, if operating on an existing cluster
   -p          Preserve kind k8s cluster for inspection
   -i          Provide AWS Service docker image
+  -r          Provide AWS Role ARN for functional testing on local KinD Cluster
   -s          Provide AWS Service name (ecr, sns, sqs, petstore, bookstore)
   -v          Kubernetes Version (Default: 1.16) [1.14, 1.15, 1.16, 1.17, and 1.18]
 "
 
 # Process our input arguments
-while getopts "ps:ioc:b:v:" opt; do
+while getopts "ps:r:ic:b:v" opt; do
   case ${opt} in
     p ) # PRESERVE K8s Cluster
         PRESERVE=true
       ;;
     s ) # AWS Service name
         AWS_SERVICE=$(echo "${OPTARG}" | tr '[:upper:]' '[:lower:]')
+      ;;
+    r ) # AWS ROLE ARN
+        AWS_ROLE_ARN="${OPTARG}"
       ;;
     i ) # AWS Service Docker Image
         AWS_SERVICE_DOCKER_IMG="${OPTARG}"
@@ -92,26 +91,32 @@ while getopts "ps:ioc:b:v:" opt; do
   esac
 done
 
+if [ -z "$AWS_SERVICE" ]; then
+    echo "AWS_SERVICE is not defined. Use flag -s <AWS_SERVICE> to build that docker images of that service and load into Kind"
+    echo "(Example: $(basename "$0") -p -s ecr)"
+    exit  1
+fi
+
 ensure_kustomize
 
-if [ -z $TMP_DIR ]; then
+if [ -z "$TMP_DIR" ]; then
     TMP_DIR=$("${SCRIPTS_DIR}"/provision-kind-cluster.sh -b "${CLUSTER_NAME_BASE}" -v "${K8S_VERSION}")
 fi
 
-if [ $OVERRIDE_PATH == 0 ]; then
+if [ "$OVERRIDE_PATH" == 0 ]; then
   export PATH=$TMP_DIR:$PATH
 else
   export PATH=$PATH:$TMP_DIR
 fi
 
-CLUSTER_NAME=$(cat $TMP_DIR/clustername)
+CLUSTER_NAME=$(cat "$TMP_DIR"/clustername)
 
 ## Build and Load Docker Images
 
 if [ -z "$AWS_SERVICE_DOCKER_IMG" ]; then
     echo "Building ${AWS_SERVICE} docker image"
     DEFAULT_AWS_SERVICE_DOCKER_IMG="ack-${AWS_SERVICE}-controller:${VERSION}"
-    docker build --quiet -f ${ROOT_DIR}/services/${AWS_SERVICE}/Dockerfile -t "${DEFAULT_AWS_SERVICE_DOCKER_IMG}" .
+    docker build --quiet -f "${ROOT_DIR}"/services/"${AWS_SERVICE}"/Dockerfile -t "${DEFAULT_AWS_SERVICE_DOCKER_IMG}" .
     AWS_SERVICE_DOCKER_IMG="${DEFAULT_AWS_SERVICE_DOCKER_IMG}"
 else
     echo "Skipping building the ${AWS_SERVICE} docker image, since one was specified ${AWS_SERVICE_DOCKER_IMG}"
@@ -135,27 +140,40 @@ service_config_dir="$ROOT_DIR/services/$AWS_SERVICE/config"
 # TODO(jaypipes): Eventually use kubebuilder:scaffold:crdkustomizeresource?
 echo "Loading CRD manifests for $AWS_SERVICE into the cluster"
 for crd_file in $service_config_dir/crd/bases; do
-    kubectl apply -f $crd_file --validate=false
+    kubectl apply -f "$crd_file" --validate=false
 done
 
 echo "Loading RBAC manifests for $AWS_SERVICE into the cluster"
-kustomize build $service_config_dir/rbac | kubectl apply -f -
+kustomize build "$service_config_dir"/rbac | kubectl apply -f -
 
 ## Create the ACK service controller Deployment in the target k8s cluster
 test_config_dir=$TMP_DIR/config/test
-mkdir -p $test_config_dir
+mkdir -p "$test_config_dir"
 
-cp $service_config_dir/controller/deployment.yaml $test_config_dir/deployment.yaml
+cp "$service_config_dir"/controller/deployment.yaml "$test_config_dir"/deployment.yaml
 
-cat <<EOF >$test_config_dir/kustomization.yaml
+cat <<EOF >"$test_config_dir"/kustomization.yaml
 resources:
 - deployment.yaml
 EOF
 
 echo "Loading service controller Deployment for $AWS_SERVICE into the cluster"
-cd $test_config_dir
-kustomize edit set image controller=$AWS_SERVICE_DOCKER_IMG
-kustomize build $test_config_dir | kubectl apply -f -
+cd "$test_config_dir"
+kustomize edit set image controller="$AWS_SERVICE_DOCKER_IMG"
+
+kustomize build "$test_config_dir" | kubectl apply -f -
+
+## Functional tests where we assume role and pass aws temporary credentials as env vars to deployment
+if [ -n "$AWS_ROLE_ARN" ]; then
+   export AWS_ROLE_ARN
+   generate_aws_temp_creds
+   kubectl -n ack-system set env deployment/ack-"$AWS_SERVICE"-controller \
+   AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+   AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+   AWS_SESSION_TOKEN="$AWS_SESSION_TOKEN"
+   echo "Added AWS Credentials to env vars map"
+fi
+
 
 echo "======================================================================================================"
 echo "To poke around your test manually:"

--- a/scripts/provision-kind-cluster.sh
+++ b/scripts/provision-kind-cluster.sh
@@ -49,7 +49,7 @@ Example: $(basename "$0") -b my-test -i 123 -v 1.16
 "
 
 # Process our input arguments
-while getopts "b:i:v:k:o" opt; do
+while getopts "b:i:v:k:" opt; do
   case ${opt} in
     b ) # BASE CLUSTER NAME
         CLUSTER_NAME_BASE=$OPTARG


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

- [x] Added sts-assume-role.sh to create temporary credentials for functional testing
- [x] Updated kind-build-test.sh script to include `-r` flag which will users to pass `--role-arn` for functional testing where we make `aws sts assume-role` API call to fetch temp creds and set as environment variable to deployment. This way, we can create AWS resources by leverage the same local KinD cluster. 
- [x] Updated kind-build-test.sh script to fail fast if service name to build parameter is not passed 
- [x] Added makefile config to invoke all these scripts instead of navigating to script dir. Now you can just run `make build-controller SERVICE_TO_BUILD=ecr` commands


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
