### PR TITLE
add NotImplemented for ReadMany code path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ GO111MODULE=on
 PKGS=$(sort $(dir $(wildcard pkg/*/*/)))
 MOCKS=$(foreach x, $(PKGS), mocks/$(x))
 
+MOCKERY_BIN=$(shell which mockery || "./bin/mockery")
+
 # We need to use the codegen tag when building and testing because the
 # aws-sdk-go/private/model/api package is gated behind a build tag "codegen"...
 GO_TAGS=-tags codegen
@@ -46,4 +48,4 @@ delete-all-kind-clusters:
 mocks: $(MOCKS)
 
 $(MOCKS): mocks/% : %
-	./bin/mockery --tags=codegen --case=underscore --output=$@ --dir=$^ --all
+	${MOCKERY_BIN} --tags=codegen --case=underscore --output=$@ --dir=$^ --all

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -20,11 +20,19 @@ import (
 )
 
 var (
-	NotFound                  = fmt.Errorf("resource not found")
+	// NotImplemented is returned when a code path isn't implemented yet
+	NotImplemented = fmt.Errorf("not implemented")
+	// NotFound is returned when an expected resource was not found
+	NotFound = fmt.Errorf("resource not found")
+	// NilResourceManagerFactory is returned when a resource manager factory
+	// that has not been properly initialized is bound to a controller manager
 	NilResourceManagerFactory = fmt.Errorf(
 		"error binding controller manager to reconciler before " +
 			"setting resource manager factory",
 	)
+	// AdoptedResourceNotFound is like NotFound but provides the caller with
+	// information that the resource being checked for existence was
+	// previously-created out of band from ACK
 	AdoptedResourceNotFound = fmt.Errorf("adopted resource not found")
 )
 

--- a/templates/pkg/crd_sdk.go.tpl
+++ b/templates/pkg/crd_sdk.go.tpl
@@ -53,6 +53,7 @@ func (rm *resourceManager) sdkFind(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 {{ $setCode }}
+	return &resource{ko}, nil
 {{- else if .CRD.Ops.GetAttributes }}
 	input, err := rm.newGetAttributesRequestPayload(r)
 	if err != nil {
@@ -71,14 +72,11 @@ func (rm *resourceManager) sdkFind(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 {{ $setCode }}
+	return &resource{ko}, nil
 {{- else }}
 	// TODO(jaypipes): Map out the ReadMany codepath
-
-	// Merge in the information we read from the API call above to the copy of
-	// the original Kubernetes object we passed to the function
-	ko := r.ko.DeepCopy()
+    return nil, ackerr.NotImplemented
 {{- end }}
-	return &resource{ko}, nil
 }
 
 {{- if .CRD.Ops.ReadOne }}


### PR DESCRIPTION
Adds a NotImplemented error return for the ReadMany code path in the
sdk.go generated code. This will at least allow the create code path to
properly error out (issue #152) instead of returning an empty result and
nil error.

Issue #152

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
