### PR TITLE
implement ReadMany code path

### DIFF
--- a/pkg/model/crd_test.go
+++ b/pkg/model/crd_test.go
@@ -1496,6 +1496,216 @@ func TestElasticache_CacheCluster(t *testing.T) {
 	}
 `
 	assert.Equal(expCreateOutput, crd.GoCodeSetOutput(model.OpTypeCreate, "resp", "ko.Status", 1))
+
+	// Elasticache doesn't have a ReadOne operation; only a List/ReadMany
+	// operation. Let's verify that the construction of the
+	// DescribeCacheClustersInput and processing of the
+	// DescribeCacheClustersOutput shapes is correct.
+	expReadManyInput := `
+	if r.ko.Spec.CacheClusterID != nil {
+		res.SetCacheClusterId(*r.ko.Spec.CacheClusterID)
+	}
+`
+	assert.Equal(expReadManyInput, crd.GoCodeSetInput(model.OpTypeList, "r.ko", "res", 1))
+
+	expReadManyOutput := `
+	if len(resp.CacheClusters) == 1 {
+		elem := resp.CacheClusters[0]
+		if elem.ARN != nil {
+			if ko.Status.ACKResourceMetadata == nil {
+				ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+			}
+			tmpARN := ackv1alpha1.AWSResourceName(*elem.ARN)
+			ko.Status.ACKResourceMetadata.ARN = &tmpARN
+		}
+		if elem.AtRestEncryptionEnabled != nil {
+			ko.Status.AtRestEncryptionEnabled = elem.AtRestEncryptionEnabled
+		}
+		if elem.AuthTokenEnabled != nil {
+			ko.Status.AuthTokenEnabled = elem.AuthTokenEnabled
+		}
+		if elem.AuthTokenLastModifiedDate != nil {
+			ko.Status.AuthTokenLastModifiedDate = &metav1.Time{*elem.AuthTokenLastModifiedDate}
+		}
+		if elem.AutoMinorVersionUpgrade != nil {
+			ko.Spec.AutoMinorVersionUpgrade = elem.AutoMinorVersionUpgrade
+		}
+		if elem.CacheClusterCreateTime != nil {
+			ko.Status.CacheClusterCreateTime = &metav1.Time{*elem.CacheClusterCreateTime}
+		}
+		if elem.CacheClusterId != nil {
+			ko.Spec.CacheClusterID = elem.CacheClusterId
+		}
+		if elem.CacheClusterStatus != nil {
+			ko.Status.CacheClusterStatus = elem.CacheClusterStatus
+		}
+		if elem.CacheNodeType != nil {
+			ko.Spec.CacheNodeType = elem.CacheNodeType
+		}
+		if elem.CacheNodes != nil {
+			f9 := []*svcapitypes.CacheNode{}
+			for _, f9iter := range elem.CacheNodes {
+				f9elem := &svcapitypes.CacheNode{}
+				if f9iter.CacheNodeCreateTime != nil {
+					f9elem.CacheNodeCreateTime = &metav1.Time{*f9iter.CacheNodeCreateTime}
+				}
+				if f9iter.CacheNodeId != nil {
+					f9elem.CacheNodeID = f9iter.CacheNodeId
+				}
+				if f9iter.CacheNodeStatus != nil {
+					f9elem.CacheNodeStatus = f9iter.CacheNodeStatus
+				}
+				if f9iter.CustomerAvailabilityZone != nil {
+					f9elem.CustomerAvailabilityZone = f9iter.CustomerAvailabilityZone
+				}
+				if f9iter.Endpoint != nil {
+					f9elemf4 := &svcapitypes.Endpoint{}
+					if f9iter.Endpoint.Address != nil {
+						f9elemf4.Address = f9iter.Endpoint.Address
+					}
+					if f9iter.Endpoint.Port != nil {
+						f9elemf4.Port = f9iter.Endpoint.Port
+					}
+					f9elem.Endpoint = f9elemf4
+				}
+				if f9iter.ParameterGroupStatus != nil {
+					f9elem.ParameterGroupStatus = f9iter.ParameterGroupStatus
+				}
+				if f9iter.SourceCacheNodeId != nil {
+					f9elem.SourceCacheNodeID = f9iter.SourceCacheNodeId
+				}
+				f9 = append(f9, f9elem)
+			}
+			ko.Status.CacheNodes = f9
+		}
+		if elem.CacheParameterGroup != nil {
+			f10 := &svcapitypes.CacheParameterGroupStatus_SDK{}
+			if elem.CacheParameterGroup.CacheNodeIdsToReboot != nil {
+				f10f0 := []*string{}
+				for _, f10f0iter := range elem.CacheParameterGroup.CacheNodeIdsToReboot {
+					var f10f0elem string
+					f10f0elem = *f10f0iter
+					f10f0 = append(f10f0, &f10f0elem)
+				}
+				f10.CacheNodeIDsToReboot = f10f0
+			}
+			if elem.CacheParameterGroup.CacheParameterGroupName != nil {
+				f10.CacheParameterGroupName = elem.CacheParameterGroup.CacheParameterGroupName
+			}
+			if elem.CacheParameterGroup.ParameterApplyStatus != nil {
+				f10.ParameterApplyStatus = elem.CacheParameterGroup.ParameterApplyStatus
+			}
+			ko.Status.CacheParameterGroup = f10
+		}
+		if elem.CacheSecurityGroups != nil {
+			f11 := []*svcapitypes.CacheSecurityGroupMembership{}
+			for _, f11iter := range elem.CacheSecurityGroups {
+				f11elem := &svcapitypes.CacheSecurityGroupMembership{}
+				if f11iter.CacheSecurityGroupName != nil {
+					f11elem.CacheSecurityGroupName = f11iter.CacheSecurityGroupName
+				}
+				if f11iter.Status != nil {
+					f11elem.Status = f11iter.Status
+				}
+				f11 = append(f11, f11elem)
+			}
+			ko.Status.CacheSecurityGroups = f11
+		}
+		if elem.CacheSubnetGroupName != nil {
+			ko.Spec.CacheSubnetGroupName = elem.CacheSubnetGroupName
+		}
+		if elem.ClientDownloadLandingPage != nil {
+			ko.Status.ClientDownloadLandingPage = elem.ClientDownloadLandingPage
+		}
+		if elem.ConfigurationEndpoint != nil {
+			f14 := &svcapitypes.Endpoint{}
+			if elem.ConfigurationEndpoint.Address != nil {
+				f14.Address = elem.ConfigurationEndpoint.Address
+			}
+			if elem.ConfigurationEndpoint.Port != nil {
+				f14.Port = elem.ConfigurationEndpoint.Port
+			}
+			ko.Status.ConfigurationEndpoint = f14
+		}
+		if elem.Engine != nil {
+			ko.Spec.Engine = elem.Engine
+		}
+		if elem.EngineVersion != nil {
+			ko.Spec.EngineVersion = elem.EngineVersion
+		}
+		if elem.NotificationConfiguration != nil {
+			f17 := &svcapitypes.NotificationConfiguration{}
+			if elem.NotificationConfiguration.TopicArn != nil {
+				f17.TopicARN = elem.NotificationConfiguration.TopicArn
+			}
+			if elem.NotificationConfiguration.TopicStatus != nil {
+				f17.TopicStatus = elem.NotificationConfiguration.TopicStatus
+			}
+			ko.Status.NotificationConfiguration = f17
+		}
+		if elem.NumCacheNodes != nil {
+			ko.Spec.NumCacheNodes = elem.NumCacheNodes
+		}
+		if elem.PendingModifiedValues != nil {
+			f19 := &svcapitypes.PendingModifiedValues{}
+			if elem.PendingModifiedValues.AuthTokenStatus != nil {
+				f19.AuthTokenStatus = elem.PendingModifiedValues.AuthTokenStatus
+			}
+			if elem.PendingModifiedValues.CacheNodeIdsToRemove != nil {
+				f19f1 := []*string{}
+				for _, f19f1iter := range elem.PendingModifiedValues.CacheNodeIdsToRemove {
+					var f19f1elem string
+					f19f1elem = *f19f1iter
+					f19f1 = append(f19f1, &f19f1elem)
+				}
+				f19.CacheNodeIDsToRemove = f19f1
+			}
+			if elem.PendingModifiedValues.CacheNodeType != nil {
+				f19.CacheNodeType = elem.PendingModifiedValues.CacheNodeType
+			}
+			if elem.PendingModifiedValues.EngineVersion != nil {
+				f19.EngineVersion = elem.PendingModifiedValues.EngineVersion
+			}
+			if elem.PendingModifiedValues.NumCacheNodes != nil {
+				f19.NumCacheNodes = elem.PendingModifiedValues.NumCacheNodes
+			}
+			ko.Status.PendingModifiedValues = f19
+		}
+		if elem.PreferredAvailabilityZone != nil {
+			ko.Spec.PreferredAvailabilityZone = elem.PreferredAvailabilityZone
+		}
+		if elem.PreferredMaintenanceWindow != nil {
+			ko.Spec.PreferredMaintenanceWindow = elem.PreferredMaintenanceWindow
+		}
+		if elem.ReplicationGroupId != nil {
+			ko.Spec.ReplicationGroupID = elem.ReplicationGroupId
+		}
+		if elem.SecurityGroups != nil {
+			f23 := []*svcapitypes.SecurityGroupMembership{}
+			for _, f23iter := range elem.SecurityGroups {
+				f23elem := &svcapitypes.SecurityGroupMembership{}
+				if f23iter.SecurityGroupId != nil {
+					f23elem.SecurityGroupID = f23iter.SecurityGroupId
+				}
+				if f23iter.Status != nil {
+					f23elem.Status = f23iter.Status
+				}
+				f23 = append(f23, f23elem)
+			}
+			ko.Status.SecurityGroups = f23
+		}
+		if elem.SnapshotRetentionLimit != nil {
+			ko.Spec.SnapshotRetentionLimit = elem.SnapshotRetentionLimit
+		}
+		if elem.SnapshotWindow != nil {
+			ko.Spec.SnapshotWindow = elem.SnapshotWindow
+		}
+		if elem.TransitEncryptionEnabled != nil {
+			ko.Status.TransitEncryptionEnabled = elem.TransitEncryptionEnabled
+		}
+	}
+`
+	assert.Equal(expReadManyOutput, crd.GoCodeSetOutput(model.OpTypeList, "resp", "ko", 1))
 }
 
 func TestElasticache_Ignored_Operations(t *testing.T) {

--- a/pkg/template/pkg/crd_sdk.go
+++ b/pkg/template/pkg/crd_sdk.go
@@ -45,6 +45,12 @@ func NewCRDSDKGoTemplate(tplDir string) (*ttpl.Template, error) {
 		"GoCodeSetReadOneInput": func(r *model.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
 			return r.GoCodeSetInput(model.OpTypeGet, sourceVarName, targetVarName, indentLevel)
 		},
+		"GoCodeSetReadManyOutput": func(r *model.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
+			return r.GoCodeSetOutput(model.OpTypeList, sourceVarName, targetVarName, indentLevel)
+		},
+		"GoCodeSetReadManyInput": func(r *model.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
+			return r.GoCodeSetInput(model.OpTypeList, sourceVarName, targetVarName, indentLevel)
+		},
 		"GoCodeGetAttributesSetInput": func(r *model.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
 			return r.GoCodeGetAttributesSetInput(sourceVarName, targetVarName, indentLevel)
 		},


### PR DESCRIPTION
Generate the Go code that constructs the Input shapes for List/ReadMany
operations and processes the Output shapes of those ReadMany operations
into the Spec and Status structs of the target CRs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
