### PR TITLE
Missing source lib/aws.sh

### DIFF
--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -10,6 +10,7 @@ SCRIPTS_DIR=$(cd "$(dirname "$0")" || exit 1; pwd)
 ROOT_DIR="$SCRIPTS_DIR/.."
 
 source "$SCRIPTS_DIR/lib/common.sh"
+source "$SCRIPTS_DIR/lib/aws.sh"
 source "$SCRIPTS_DIR/lib/k8s.sh"
 
 OPTIND=1


### PR DESCRIPTION
Script was failing because we forgot to import lib/aws.sh

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
