### PR TITLE
plumb reconciler into resource manager

### DIFF
--- a/mocks/pkg/types/aws_resource_manager_factory.go
+++ b/mocks/pkg/types/aws_resource_manager_factory.go
@@ -14,13 +14,13 @@ type AWSResourceManagerFactory struct {
 	mock.Mock
 }
 
-// ManagerFor provides a mock function with given fields: _a0
-func (_m *AWSResourceManagerFactory) ManagerFor(_a0 v1alpha1.AWSAccountID) (types.AWSResourceManager, error) {
-	ret := _m.Called(_a0)
+// ManagerFor provides a mock function with given fields: _a0, _a1
+func (_m *AWSResourceManagerFactory) ManagerFor(_a0 types.AWSResourceReconciler, _a1 v1alpha1.AWSAccountID) (types.AWSResourceManager, error) {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 types.AWSResourceManager
-	if rf, ok := ret.Get(0).(func(v1alpha1.AWSAccountID) types.AWSResourceManager); ok {
-		r0 = rf(_a0)
+	if rf, ok := ret.Get(0).(func(types.AWSResourceReconciler, v1alpha1.AWSAccountID) types.AWSResourceManager); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(types.AWSResourceManager)
@@ -28,8 +28,8 @@ func (_m *AWSResourceManagerFactory) ManagerFor(_a0 v1alpha1.AWSAccountID) (type
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(v1alpha1.AWSAccountID) error); ok {
-		r1 = rf(_a0)
+	if rf, ok := ret.Get(1).(func(types.AWSResourceReconciler, v1alpha1.AWSAccountID) error); ok {
+		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/mocks/pkg/types/aws_resource_reconciler.go
+++ b/mocks/pkg/types/aws_resource_reconciler.go
@@ -4,6 +4,7 @@ package mocks
 
 import (
 	mock "github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
 	manager "sigs.k8s.io/controller-runtime/pkg/manager"
 
 	reconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -59,6 +60,27 @@ func (_m *AWSResourceReconciler) Reconcile(_a0 reconcile.Request) (reconcile.Res
 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(reconcile.Request) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// SecretValueFromReference provides a mock function with given fields: _a0
+func (_m *AWSResourceReconciler) SecretValueFromReference(_a0 *corev1.SecretReference) (string, error) {
+	ret := _m.Called(_a0)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(*corev1.SecretReference) string); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*corev1.SecretReference) error); ok {
 		r1 = rf(_a0)
 	} else {
 		r1 = ret.Error(1)

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlrt "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -67,6 +68,15 @@ func (r *reconciler) BindControllerManager(mgr ctrlrt.Manager) error {
 	).Complete(r)
 }
 
+// SecretValueFromReference fetches the value of a Secret given a
+// SecretReference
+func (r *reconciler) SecretValueFromReference(
+	ref *corev1.SecretReference,
+) (string, error) {
+	// TODO(alina-kim): Implement this method :)
+	return "", ackerr.NotImplemented
+}
+
 // Reconcile implements `controller-runtime.Reconciler` and handles reconciling
 // a CR CRUD request
 func (r *reconciler) Reconcile(req ctrlrt.Request) (ctrlrt.Result, error) {
@@ -87,7 +97,7 @@ func (r *reconciler) reconcile(req ctrlrt.Request) error {
 		"kind", r.rd.GroupKind().String(),
 	)
 
-	rm, err := r.rmf.ManagerFor(acctID)
+	rm, err := r.rmf.ManagerFor(r, acctID)
 	if err != nil {
 		return err
 	}

--- a/pkg/types/aws_resource_manager.go
+++ b/pkg/types/aws_resource_manager.go
@@ -60,5 +60,5 @@ type AWSResourceManagerFactory interface {
 	ResourceDescriptor() AWSResourceDescriptor
 	// ManagerFor returns an AWSResourceManager that manages AWS resources on
 	// behalf of a particular AWS account
-	ManagerFor(ackv1alpha1.AWSAccountID) (AWSResourceManager, error)
+	ManagerFor(AWSResourceReconciler, ackv1alpha1.AWSAccountID) (AWSResourceManager, error)
 }

--- a/pkg/types/aws_resource_reconciler.go
+++ b/pkg/types/aws_resource_reconciler.go
@@ -14,6 +14,7 @@
 package types
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlrt "sigs.k8s.io/controller-runtime"
 	ctrlreconcile "sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -37,4 +38,7 @@ type AWSResourceReconciler interface {
 	// BindControllerManager sets up the AWSResourceReconciler with an instance
 	// of an upstream controller-runtime.Manager
 	BindControllerManager(ctrlrt.Manager) error
+	// SecretValueFromReference fetches the value of a Secret given a
+	// SecretReference
+	SecretValueFromReference(*corev1.SecretReference) (string, error)
 }

--- a/services/bookstore/pkg/resource/book/manager.go
+++ b/services/bookstore/pkg/resource/book/manager.go
@@ -16,10 +16,10 @@ package book
 import (
 	"context"
 
-	"github.com/aws/aws-sdk-go/aws/session"
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
+	"github.com/aws/aws-sdk-go/aws/session"
 
 	// svcsdkapi "github.com/aws/aws-sdk-go/service/{{ .AWSServiceAlias }}/{{ .AWSServiceAlias }}iface"
 	svcsdkapi "github.com/aws/aws-controllers-k8s/services/bookstore/sdk/service/bookstore/bookstoreiface"
@@ -30,6 +30,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// rr is the AWSResourceReconciler which can be used for various utility
+	// functions such as querying for Secret values given a SecretReference
+	rr acktypes.AWSResourceReconciler
 	// awsAccountID is the AWS account identifier that contains the resources
 	// managed by this resource manager
 	awsAccountID ackv1alpha1.AWSAccountID
@@ -127,6 +130,7 @@ func (rm *resourceManager) Delete(
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	rr acktypes.AWSResourceReconciler,
 	id ackv1alpha1.AWSAccountID,
 ) (*resourceManager, error) {
 	sess, err := ackrt.NewSession()
@@ -134,6 +138,7 @@ func newResourceManager(
 		return nil, err
 	}
 	return &resourceManager{
+		rr:           rr,
 		awsAccountID: id,
 		sess:         sess,
 		sdkapi:       svcsdk.New(sess),

--- a/services/bookstore/pkg/resource/book/manager_factory.go
+++ b/services/bookstore/pkg/resource/book/manager_factory.go
@@ -39,6 +39,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	rr acktypes.AWSResourceReconciler,
 	id ackv1alpha1.AWSAccountID,
 ) (acktypes.AWSResourceManager, error) {
 	f.RLock()
@@ -52,7 +53,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(id)
+	rm, err := newResourceManager(rr, id)
 	if err != nil {
 		return nil, err
 	}

--- a/services/bookstore/pkg/resource/book/manager_factory_test.go
+++ b/services/bookstore/pkg/resource/book/manager_factory_test.go
@@ -43,14 +43,14 @@ func TestManagerFor(t *testing.T) {
 	require.NotNil(bookRMF)
 
 	acctID := ackv1alpha1.AWSAccountID("aws-account-id")
-	bookRM, err := bookRMF.ManagerFor(acctID)
+	bookRM, err := bookRMF.ManagerFor(nil, acctID)
 	require.Nil(err)
 	require.NotNil(bookRM)
 	require.Implements((*acktypes.AWSResourceManager)(nil), bookRM)
 
 	// The resource manager factory should keep a cache of resource manager
 	// objects, keyed by account ID.
-	otherBookRM, err := bookRMF.ManagerFor(acctID)
+	otherBookRM, err := bookRMF.ManagerFor(nil, acctID)
 	require.Nil(err)
 	require.Exactly(bookRM, otherBookRM)
 }

--- a/services/petstore/pkg/resource/pet/manager.go
+++ b/services/petstore/pkg/resource/pet/manager.go
@@ -35,6 +35,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Pet custom resources.
 type resourceManager struct {
+	// rr is the AWSResourceReconciler which can be used for various utility
+	// functions such as querying for Secret values given a SecretReference
+	rr acktypes.AWSResourceReconciler
 	// awsAccountID is the AWS account identifier that contains the resources
 	// managed by this resource manager
 	awsAccountID ackv1alpha1.AWSAccountID
@@ -204,6 +207,7 @@ func (rm *resourceManager) newDeleteRequestPayload(
 }
 
 func newResourceManager(
+	rr acktypes.AWSResourceReconciler,
 	id ackv1alpha1.AWSAccountID,
 ) (*resourceManager, error) {
 	sess, err := ackrt.NewSession()
@@ -211,6 +215,7 @@ func newResourceManager(
 		return nil, err
 	}
 	return &resourceManager{
+		rr:           rr,
 		awsAccountID: id,
 		sess:         sess,
 	}, nil

--- a/services/petstore/pkg/resource/pet/manager_factory.go
+++ b/services/petstore/pkg/resource/pet/manager_factory.go
@@ -44,6 +44,7 @@ func (f *resourceManagerFactory) GroupKind() string {
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	rr acktypes.AWSResourceReconciler,
 	id ackv1alpha1.AWSAccountID,
 ) (acktypes.AWSResourceManager, error) {
 	f.RLock()
@@ -57,7 +58,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(id)
+	rm, err := newResourceManager(rr, id)
 	if err != nil {
 		return nil, err
 	}

--- a/services/petstore/pkg/resource/pet/manager_factory_test.go
+++ b/services/petstore/pkg/resource/pet/manager_factory_test.go
@@ -43,14 +43,14 @@ func TestManagerFor(t *testing.T) {
 	require.NotNil(petRMF)
 
 	acctID := ackv1alpha1.AWSAccountID("aws-account-id")
-	petRM, err := petRMF.ManagerFor(acctID)
+	petRM, err := petRMF.ManagerFor(nil, acctID)
 	require.Nil(err)
 	require.NotNil(petRM)
 	require.Implements((*acktypes.AWSResourceManager)(nil), petRM)
 
 	// The resource manager factory should keep a cache of resource manager
 	// objects, keyed by account ID.
-	otherPetRM, err := petRMF.ManagerFor(acctID)
+	otherPetRM, err := petRMF.ManagerFor(nil, acctID)
 	require.Nil(err)
 	require.Exactly(petRM, otherPetRM)
 }

--- a/templates/pkg/crd_manager.go.tpl
+++ b/templates/pkg/crd_manager.go.tpl
@@ -20,6 +20,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// rr is the AWSResourceReconciler which can be used for various utility
+	// functions such as querying for Secret values given a SecretReference
+	rr acktypes.AWSResourceReconciler
 	// awsAccountID is the AWS account identifier that contains the resources
 	// managed by this resource manager
 	awsAccountID ackv1alpha1.AWSAccountID
@@ -117,6 +120,7 @@ func (rm *resourceManager) Delete(
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	rr acktypes.AWSResourceReconciler,
 	id ackv1alpha1.AWSAccountID,
 ) (*resourceManager, error) {
 	sess, err := ackrt.NewSession()
@@ -124,8 +128,9 @@ func newResourceManager(
 		return nil, err
 	}
 	return &resourceManager{
+		rr: rr,
 		awsAccountID: id,
-		sess:         sess,
-		sdkapi:       svcsdk.New(sess),
+		sess:		 sess,
+		sdkapi:	   svcsdk.New(sess),
 	}, nil
 }

--- a/templates/pkg/crd_manager_factory.go.tpl
+++ b/templates/pkg/crd_manager_factory.go.tpl
@@ -28,6 +28,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	rr acktypes.AWSResourceReconciler,
 	id ackv1alpha1.AWSAccountID,
 ) (acktypes.AWSResourceManager, error) {
 	f.RLock()
@@ -41,7 +42,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(id)
+	rm, err := newResourceManager(rr, id)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We need a way of allowing the resource manager to get Kubernetes object
information for things like Kubernetes Secrets. However, I deliberately
did not want to pass the Kubernetes client objects into the resource
managers (since their job is to handle the SDK linkage, not to query
Kubernetes API).

However, the resource manager will need at least the ability to grab a
value for a SecretReference, and in order to facilitate this, I changed
the `AWSResourceManagerFactory.ManagerFor` interface method to pass in
an object that implements the `AWSResourceReconciler` interface. I then
added a stub `AWSResourceReconciler.SecretValueFromReference()`
interface method (for Alina to implement) into the runtime's Reconciler
concrete struct. The resource managers now have an `rr` field that
points to the Reconciler for the runtime and will allow the resource
managers to call utility methods like `SecretValueFromReference` and not
have to handle calls to the Kubernetes API directly themselves.

Related: #106

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
