### PR TITLE
properly handle NotFoundException in reads

### DIFF
--- a/pkg/model/crd_test.go
+++ b/pkg/model/crd_test.go
@@ -1703,6 +1703,8 @@ func TestElasticache_CacheCluster(t *testing.T) {
 		if elem.TransitEncryptionEnabled != nil {
 			ko.Status.TransitEncryptionEnabled = elem.TransitEncryptionEnabled
 		}
+	} else {
+		return nil, ackerr.NotFound
 	}
 `
 	assert.Equal(expReadManyOutput, crd.GoCodeSetOutput(model.OpTypeList, "resp", "ko", 1))

--- a/pkg/template/pkg/crd_sdk.go
+++ b/pkg/template/pkg/crd_sdk.go
@@ -39,6 +39,9 @@ func NewCRDSDKGoTemplate(tplDir string) (*ttpl.Template, error) {
 	}
 	t := ttpl.New("crd_sdk")
 	t = t.Funcs(ttpl.FuncMap{
+		"ResourceNotFoundException": func(r *model.CRD) string {
+			return r.NotFoundException()
+		},
 		"GoCodeSetReadOneOutput": func(r *model.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
 			return r.GoCodeSetOutput(model.OpTypeGet, sourceVarName, targetVarName, indentLevel)
 		},

--- a/scripts/build-controller-image.sh
+++ b/scripts/build-controller-image.sh
@@ -63,7 +63,7 @@ docker build \
   --quiet=${QUIET} \
   -t ${AWS_SERVICE_DOCKER_IMG} \
   -f ${DOCKERFILE} \
-  --build-arg service_alias=${SERVICE} \
+  --build-arg service_alias=${AWS_SERVICE} \
   ${BUILD_CONTEXT}
 
 if [ $? -ne 0 ]; then

--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -15,7 +15,10 @@ source "$SCRIPTS_DIR/lib/k8s.sh"
 
 OPTIND=1
 CLUSTER_NAME_BASE="test"
+AWS_ACCOUNT_ID=${AWS_ACCOUNT_ID:-"123456789012"}
+AWS_REGION=${AWS_REGION_ID:-"us-west-2"}
 AWS_ROLE_ARN=""
+ACK_ENABLE_DEVELOPMENT_LOGGING="true"
 DELETE_CLUSTER_ARGS=""
 K8S_VERSION="1.16"
 OVERRIDE_PATH=0
@@ -132,6 +135,11 @@ export KUBECONFIG="${TMP_DIR}/kubeconfig"
 trap "exit_and_fail" INT TERM ERR
 trap "clean_up" EXIT
 
+export AWS_ACCOUNT_ID
+export AWS_REGION
+export AWS_ROLE_ARN
+export ACK_ENABLE_DEVELOPMENT_LOGGING
+
 service_config_dir="$ROOT_DIR/services/$AWS_SERVICE/config"
 
 ## Register the ACK service controller's CRDs in the target k8s cluster
@@ -171,7 +179,8 @@ if [ -n "$AWS_ROLE_ARN" ]; then
    kubectl -n ack-system set env deployment/ack-"$AWS_SERVICE"-controller \
    AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
    AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
-   AWS_SESSION_TOKEN="$AWS_SESSION_TOKEN"
+   AWS_SESSION_TOKEN="$AWS_SESSION_TOKEN" \
+   AWS_REGION="$AWS_REGION"
    echo "Added AWS Credentials to env vars map"
 fi
 

--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -60,7 +60,8 @@ generate_aws_temp_creds() {
   JSON=$(aws sts assume-role \
            --role-arn "$AWS_ROLE_ARN"  \
            --role-session-name tmp-role-"$__uuid" \
-           --duration-seconds 900 || exit 1)
+           --duration-seconds 900 \
+           --output json || exit 1)
 
       AWS_ACCESS_KEY_ID=$(echo "${JSON}" | jq --raw-output ".Credentials[\"AccessKeyId\"]")
       AWS_SECRET_ACCESS_KEY=$(echo "${JSON}" | jq --raw-output ".Credentials[\"SecretAccessKey\"]")

--- a/templates/config/controller/deployment.yaml.tpl
+++ b/templates/config/controller/deployment.yaml.tpl
@@ -26,9 +26,12 @@ spec:
       - command:
         - ./bin/controller
         args:
-        # Obviously this needs to change...
         - --aws-account-id
-        - "123456"
+        - "${AWS_ACCOUNT_ID}"
+        - --aws-region
+        - "${AWS_REGION}"
+        - --enable-development-logging
+        - "${ACK_ENABLE_DEVELOPMENT_LOGGING}"
         image: controller:latest
         name: controller
         resources:

--- a/templates/pkg/crd_sdk.go.tpl
+++ b/templates/pkg/crd_sdk.go.tpl
@@ -42,8 +42,8 @@ func (rm *resourceManager) sdkFind(
 	}
 {{ $setCode := GoCodeSetReadOneOutput .CRD "resp" "ko.Status" 1 }}
 	{{ if and .CRD.StatusFields ( not ( Empty $setCode ) ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.ReadOne.Name }}WithContext(ctx, input)
-	if err != nil {
-		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
+	if respErr != nil {
+		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceNotFoundException .CRD }}" {
 			return nil, ackerr.NotFound
 		}
 		return nil, err
@@ -61,11 +61,11 @@ func (rm *resourceManager) sdkFind(
 	}
 {{ $setCode := GoCodeGetAttributesSetOutput .CRD "resp" "ko.Status" 1 }}
 	{{ if and .CRD.StatusFields ( not ( Empty $setCode ) ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.GetAttributes.Name }}WithContext(ctx, input)
-	if err != nil {
-		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
+	if respErr != nil {
+		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceNotFoundException .CRD }}" {
 			return nil, ackerr.NotFound
 		}
-		return nil, err
+		return nil, respErr
 	}
 
 	// Merge in the information we read from the API call above to the copy of
@@ -80,11 +80,11 @@ func (rm *resourceManager) sdkFind(
 	}
 {{ $setCode := GoCodeSetReadManyOutput .CRD "resp" "ko" 1 }}
 	{{ if and .CRD.StatusFields ( not ( Empty $setCode ) ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.ReadMany.Name }}WithContext(ctx, input)
-	if err != nil {
-		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
+	if respErr != nil {
+		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceNotFoundException .CRD }}" {
 			return nil, ackerr.NotFound
 		}
-		return nil, err
+		return nil, respErr
 	}
 
 	// Merge in the information we read from the API call above to the copy of


### PR DESCRIPTION
The templated sdk.go file was looking for the string "NotFoundException"
to identify whether a call to an AWS API was returning a 404 NotFound.
Unfortunately this isn't correct for most APIs, including Elasticache.
The exception codes in Elasticache look like "CacheClusterNotFound"
instead of the generic "NotFoundException". Trying to match on the
string "NotFound" doesn't work either, since calls to, for example, the
DescribeCacheClusters API call legitimately return 400 with a code of
"ServiceLinkedRoleNotFound" which is actually a permissions problem.

This patch adds a `CRD.NotFoundException()` method which looks through
the read-like API calls for Error codes and looks for 404 HTTP status
codes and writes the matched exception code string into the sdk.go
template instead of the hard-coded 'NotFoundException'.

In the process, I also fixed up a shadowing problem where some of the
sdk.go template code referred to the wrong error variable (err instead
of respErr).

Finally, a few cleanups to `scripts/kind-build-test.sh` allow properly
testing with AWS_REGION set and in environments where the default
output encoding for the `aws` CLI tool isn't `json`.

Issue #127 
Issue #157

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
