### PR TITLE
add ExceptionsConfig instructions for code gen

### DIFF
--- a/pkg/model/generator_config.go
+++ b/pkg/model/generator_config.go
@@ -46,6 +46,12 @@ type ResourceGeneratorConfig struct {
 	// UnpackAttributeMapConfig contains instructions for converting a raw
 	// `map[string]*string` into real fields on a CRD's Spec or Status object
 	UnpackAttributesMapConfig *UnpackAttributesMapConfig `json:"unpack_attributes_map,omitempty"`
+	// ExceptionsConfig identifies the exception codes for the resource. Some
+	// API model files don't contain the ErrorInfo struct that contains the
+	// HTTPStatusCode attribute that we usually look for to identify 404 Not
+	// Found and other common error types for primary resources, and thus we
+	// need these instructions.
+	Exceptions *ExceptionsConfig `json:"exceptions,omitempty"`
 }
 
 // UnpackAttributesMapConfig informs the code generator that the API follows a
@@ -114,6 +120,18 @@ type FieldGeneratorConfig struct {
 	// that owns the resource. This is a special field that we direct to
 	// storage in the common `Status.ACKResourceMetadata.OwnerAccountID` field.
 	ContainsOwnerAccountID bool `json:"contains_owner_account_id"`
+}
+
+// ExceptionsConfig contains instructions to the code generator about how to
+// handle the exceptions for the operations on a resource. These instructions
+// are necessary for those APIs where the API models do not contain any
+// information about the HTTP status codes a particular exception has (or, like
+// the EC2 API, where the API model has no information at all about error
+// responses for any operation)
+type ExceptionsConfig struct {
+	// Codes is a map of HTTP status code to the name of the Exception shape
+	// that corresponds to that HTTP status code for this resource
+	Codes map[int]string `json:"codes"`
 }
 
 // NewGeneratorConfig returns a new GeneratorConfig object given a supplied

--- a/pkg/model/testdata/models/apis/codedeploy/0000-00-00/generator.yaml
+++ b/pkg/model/testdata/models/apis/codedeploy/0000-00-00/generator.yaml
@@ -1,0 +1,5 @@
+resources:
+  Deployment:
+    exceptions:
+      codes:
+        404: DeploymentDoesNotExistException

--- a/pkg/model/testdata/models/apis/dynamodb/0000-00-00/generator.yaml
+++ b/pkg/model/testdata/models/apis/dynamodb/0000-00-00/generator.yaml
@@ -1,0 +1,5 @@
+resources:
+  Table:
+    exceptions:
+      codes:
+        404: ResourceNotFoundException

--- a/pkg/model/testdata/models/apis/ecr/0000-00-00/generator.yaml
+++ b/pkg/model/testdata/models/apis/ecr/0000-00-00/generator.yaml
@@ -1,0 +1,5 @@
+resources:
+  Repository:
+    exceptions:
+      codes:
+        404: RepositoryNotFoundException

--- a/pkg/template/pkg/crd_sdk.go
+++ b/pkg/template/pkg/crd_sdk.go
@@ -39,8 +39,8 @@ func NewCRDSDKGoTemplate(tplDir string) (*ttpl.Template, error) {
 	}
 	t := ttpl.New("crd_sdk")
 	t = t.Funcs(ttpl.FuncMap{
-		"ResourceNotFoundException": func(r *model.CRD) string {
-			return r.NotFoundException()
+		"ResourceExceptionCode": func(r *model.CRD, httpStatusCode int) string {
+			return r.ExceptionCode(httpStatusCode)
 		},
 		"GoCodeSetReadOneOutput": func(r *model.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
 			return r.GoCodeSetOutput(model.OpTypeGet, sourceVarName, targetVarName, indentLevel)

--- a/scripts/build-controller.sh
+++ b/scripts/build-controller.sh
@@ -75,9 +75,9 @@ SERVICE="$1"
 
 # If there's a generator.yaml in the service's directory and the caller hasn't
 # specified an override, use that.
-if [ -n "$ACK_GENERATE_CONFIG_PATH" ]; then
-    if [ -f "services/$SERVICE/generator.yaml" ]; then
-        ACK_GENERATE_CONFIG_PATH="services/$SERVICE/generator.yaml"
+if [ -z "$ACK_GENERATE_CONFIG_PATH" ]; then
+    if [ -f "$ROOT_DIR/services/$SERVICE/generator.yaml" ]; then
+        ACK_GENERATE_CONFIG_PATH="$ROOT_DIR/services/$SERVICE/generator.yaml"
     fi
 fi
 

--- a/services/codedeploy/generator.yaml
+++ b/services/codedeploy/generator.yaml
@@ -1,0 +1,5 @@
+resources:
+  Deployment:
+    exceptions:
+      codes:
+        404: DeploymentDoesNotExistException

--- a/services/dynamodb/generator.yaml
+++ b/services/dynamodb/generator.yaml
@@ -1,0 +1,5 @@
+resources:
+  Table:
+    exceptions:
+      codes:
+        404: ResourceNotFoundException

--- a/services/elasticache/generator.yaml
+++ b/services/elasticache/generator.yaml
@@ -1,0 +1,6 @@
+resources:
+ignore:
+  operations:
+    - DeleteSnapshot
+  resource_names:
+    - GlobalReplicationGroup

--- a/services/sns/generator.yaml
+++ b/services/sns/generator.yaml
@@ -1,0 +1,33 @@
+resources:
+  Topic:
+    unpack_attributes_map:
+      fields:
+        DeliveryPolicy:
+        DisplayName:
+        Policy:
+        KmsMasterKeyId:
+        Owner:
+          is_read_only: true
+          contains_owner_account_id: true
+        EffectiveDeliveryPolicy:
+          is_read_only: true
+        TopicArn:
+          is_read_only: true
+  PlatformApplication:
+    unpack_attributes_map:
+      fields:
+        PlatformCredential:
+        PlatformPrincipal:
+        EventEndpointCreated:
+        EventEndpointDeleted:
+        EventEndpointUpdated:
+        EventDeliveryFailure:
+        SuccessFeedbackRoleArn:
+        FailureFeedbackRoleArn:
+        SuccessFeedbackSampleRate:
+  Endpoint:
+    unpack_attributes_map:
+      fields:
+        CustomUserData:
+        Enabled:
+        Token:

--- a/services/sqs/generator.yaml
+++ b/services/sqs/generator.yaml
@@ -1,0 +1,21 @@
+resources:
+  Queue:
+    unpack_attributes_map:
+      fields:
+        DelaySeconds:
+        MaximumMessageSize:
+        MessageRetentionPeriod:
+        KmsMasterKeyId:
+        KmsDataKeyReusePeriodSeconds:
+        Policy:
+        ReceiveMessageWaitTimeSeconds:
+        VisibilityTimeout:
+        FifoQueue:
+        ContentBasedDeduplication:
+        RedrivePolicy:
+        CreatedTimestamp:
+          is_read_only: true
+        LastModifiedTimestamp:
+          is_read_only: true
+        QueueArn:
+          is_read_only: true

--- a/templates/pkg/crd_sdk.go.tpl
+++ b/templates/pkg/crd_sdk.go.tpl
@@ -43,7 +43,7 @@ func (rm *resourceManager) sdkFind(
 {{ $setCode := GoCodeSetReadOneOutput .CRD "resp" "ko.Status" 1 }}
 	{{ if and .CRD.StatusFields ( not ( Empty $setCode ) ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.ReadOne.Name }}WithContext(ctx, input)
 	if respErr != nil {
-		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceNotFoundException .CRD }}" {
+		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceExceptionCode .CRD 404 }}" {
 			return nil, ackerr.NotFound
 		}
 		return nil, err
@@ -62,7 +62,7 @@ func (rm *resourceManager) sdkFind(
 {{ $setCode := GoCodeGetAttributesSetOutput .CRD "resp" "ko.Status" 1 }}
 	{{ if and .CRD.StatusFields ( not ( Empty $setCode ) ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.GetAttributes.Name }}WithContext(ctx, input)
 	if respErr != nil {
-		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceNotFoundException .CRD }}" {
+		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceExceptionCode .CRD 404 }}" {
 			return nil, ackerr.NotFound
 		}
 		return nil, respErr
@@ -81,7 +81,7 @@ func (rm *resourceManager) sdkFind(
 {{ $setCode := GoCodeSetReadManyOutput .CRD "resp" "ko" 1 }}
 	{{ if and .CRD.StatusFields ( not ( Empty $setCode ) ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.ReadMany.Name }}WithContext(ctx, input)
 	if respErr != nil {
-		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceNotFoundException .CRD }}" {
+		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceExceptionCode .CRD 404 }}" {
 			return nil, ackerr.NotFound
 		}
 		return nil, respErr


### PR DESCRIPTION
Adds a new ExceptionsConfig struct to the GeneratorConfig. This new
struct provides instructions to the code generator on how to identify
the Exception "Code" for a returned string error message for a
particular API resource's ReadOne/ReadMany/GetAttributes operations.

The `CRD.NotFoundException()` method has been changed to
`CRD.ExceptionCode()` and now accepts an HTTP status code that the
caller wants the string Exception code for a particular resource.

I've gone ahead and git add'd `generator.yaml` files for each of the
APIs where we've needed to give the code generator special instructions
into the `service/$ALIAS/generator.yaml` location. This will solve the
common problem that folks have been running into where they try
generating an API and run into errors like this:

```
error calling GoCodeGetAttributesSetOutput: called
GoCodeGetAttributesSetOutput for a resource `GetQueueAttributes` that
doesn't unpack attributes map
```

The above is due to the code generator recognizing an API uses the
GetXXXAttributes pattern but the code generator was not provided a
`generator.yaml` file instructing it how to handle the attribute maps.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
