### PR TITLE
adds Bash-based e2e test framework and ECR test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ delete-all-kind-clusters:
 	while read name ; do \
 	kind delete cluster --name $$name; \
 	done
+	@rm -rf build/tmp-test*
 
 mocks: $(MOCKS)
 

--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -8,6 +8,7 @@ set -Eo pipefail
 
 SCRIPTS_DIR=$(cd "$(dirname "$0")" || exit 1; pwd)
 ROOT_DIR="$SCRIPTS_DIR/.."
+TEST_E2E_DIR="$ROOT_DIR/test/e2e"
 
 source "$SCRIPTS_DIR/lib/common.sh"
 source "$SCRIPTS_DIR/lib/aws.sh"
@@ -184,6 +185,7 @@ if [ -n "$AWS_ROLE_ARN" ]; then
    echo "Added AWS Credentials to env vars map"
 fi
 
+sleep 10
 
 echo "======================================================================================================"
 echo "To poke around your test manually:"
@@ -191,4 +193,6 @@ echo "export KUBECONFIG=$TMP_DIR/kubeconfig"
 echo "kubectl get pods -A"
 echo "======================================================================================================"
 
-# TODO: export any necessary env vars and run tests
+export KUBECONFIG
+
+$TEST_E2E_DIR/run-tests.sh $AWS_SERVICE

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -17,7 +17,7 @@ is_installed() {
     fi
 }
 
-function display_timelines() {
+display_timelines() {
     echo ""
     echo "Displaying all step durations."
     echo "TIMELINE: Docker build took $DOCKER_BUILD_DURATION seconds."
@@ -34,4 +34,13 @@ should_execute() {
   else
     return 0
   fi
+}
+
+# filenoext returns just the name of the supplied filename without the
+# extension
+filenoext() {
+    local __name="$1"
+    local __filename=$( basename "$__name" )
+    # How much do I despise Bash?!
+    echo "${__filename%.*}"
 }

--- a/scripts/lib/k8s.sh
+++ b/scripts/lib/k8s.sh
@@ -62,3 +62,16 @@ ensure_service_controller_running() {
     fi
   done
 }
+
+# resource_exists returns 0 when the supplied resource can be found, 1
+# otherwise. An optional second parameter overrides the Kubernetes namespace
+# argument
+k8s_resource_exists() {
+    local __res_name="$1"
+    local __namespace="$2"
+    local __args=""
+    if [ -n "$__namespace" ]; then
+        __args="$__args-n $__namespace"
+    fi
+    kubectl get $__args "$__res_name" >/dev/null 2>&1
+}

--- a/scripts/lib/testutil.sh
+++ b/scripts/lib/testutil.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+DEFAULT_DEBUG_PREFIX="DEBUG: "
+
+# assert_equal returns 0 if the first two supplied arguments are equal, 1
+# otherwise after prining a failure message (optional third argument)
+#
+# Usage:
+#
+#   assert_equal "a" "b" "Expected a but got b!" || exit 1
+assert_equal() {
+    local __expected="$1"
+    local __actual="$2"
+    local __msg="$3"
+    if [ ! -n "$__msg" ]; then
+        __msg="Expected '$__expected' to equal '$__actual'"
+    fi
+    if [ "$__expected" != "$__actual" ]; then
+        echo "FAIL: $__msg"
+        return 1
+    fi
+    return 0
+}
+
+# debug_msg prints out a supplied message if the DEBUG environs variable is
+# set. An optional second argument indicates the "indentation level" for the
+# message. If the indentation level argument is missing, we look for the
+# existence of an environs variable called "indent_level" and use that
+debug_msg() {
+    local __msg="$1"
+    local __indent_level="$2"
+    local __debug="${DEBUG:-""}"
+    local __debug_prefix="${DEBUG_PREFIX:-$DEFAULT_DEBUG_PREFIX}"
+    if [ ! -n "$__debug" ]; then
+        return 0
+    fi
+    __indent=""
+    if [ -n "$__indent_level" ]; then
+        __indent="$( for each in $( seq 0 $__indent_level ); do printf " "; done )"
+    fi
+    echo "$__debug_prefix$__indent$__msg"
+}
+
+# controller_pod_id returns the ID of the pod running the ACK service
+# controller for the supplied service
+#
+# Usage:
+#
+#   echo controller_pod_id "ecr"
+controller_pod_id() {
+    local __msg="$1"
+    if [ ! -n "$__msg" ]; then
+        echo "ERROR: controller_pod_id requires a single argument, the name of the service"
+        exit 127
+    fi
+    kubectl get pods -n ack-system --field-selector="status.phase=Running" \
+        --sort-by=.metadata.creationTimestamp \
+        --output jsonpath='{.items[-1].metadata.name}'
+}

--- a/test/e2e/ecr/smoke.sh
+++ b/test/e2e/ecr/smoke.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="$THIS_DIR/../../.."
+SCRIPTS_DIR="$ROOT_DIR/scripts"
+
+source "$SCRIPTS_DIR/lib/common.sh"
+source "$SCRIPTS_DIR/lib/k8s.sh"
+source "$SCRIPTS_DIR/lib/testutil.sh"
+
+test_name="$( filenoext "${BASH_SOURCE[0]}" )"
+ack_ctrl_pod_id=$( controller_pod_id "ecr")
+debug_msg "executing test: $test_name"
+
+repo_name="ack-test-smoke-ecr"
+resource_name="repositories/$repo_name"
+
+# PRE-CHECKS
+
+aws ecr describe-repositories --repository-names "$repo_name" --output json >/dev/null 2>&1
+if [ $? -ne 255 ]; then
+    echo "FAIL: expected $repo_name to not exist in ECR. Did previous test run cleanup?"
+    exit 1
+fi
+
+if k8s_resource_exists "$resource_name"; then
+    echo "FAIL: expected $resource_name to not exist. Did previous test run cleanup?"
+    exit 1
+fi
+
+# TEST ACTIONS and ASSERTIONS
+
+cat <<EOF | kubectl apply -f -
+apiVersion: ecr.services.k8s.aws/v1alpha1
+kind: Repository
+metadata:
+  name: $repo_name
+spec:
+  repositoryName: $repo_name
+EOF
+
+sleep 5
+
+debug_msg "checking repository $repo_name created in ECR"
+aws ecr describe-repositories --repository-names "$repo_name" --output table
+if [ $? -eq 255 ]; then
+    echo "FAIL: expected $repo_name to have been created in ECR"
+    kubectl logs -n ack-system "$ack_ctrl_pod_id"
+    exit 1
+fi
+
+kubectl delete "$resource_name" 2>/dev/null
+assert_equal "0" "$?" "Expected success from kubectl delete but got $?" || exit 1
+
+aws ecr describe-repositories --repository-names "$repo_name" --output json >/dev/null 2>&1
+if [ $? -ne 255 ]; then
+    echo "FAIL: expected $repo_name to deleted in ECR"
+    kubectl logs -n ack-system "$ack_ctrl_pod_id"
+    exit 1
+fi

--- a/test/e2e/run-tests.sh
+++ b/test/e2e/run-tests.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="$THIS_DIR/../.."
+SCRIPTS_DIR="$ROOT_DIR/scripts"
+BIN_DIR="$ROOT_DIR/bin"
+
+source "$SCRIPTS_DIR/lib/common.sh"
+
+USAGE="
+Usage:
+  $(basename "$0") <service>
+
+<service> should be an AWS service for which you wish to run tests -- e.g.
+'s3' 'sns' or 'sqs'
+
+Environment variables:
+  DEBUG:        Set to any value to enable debug logging in the tests
+"
+
+if [ $# -ne 1 ]; then
+    echo "ERROR: $(basename "$0") only accepts a single parameter" 1>&2
+    echo "$USAGE"
+    exit 1
+fi
+
+SERVICE="$1"
+
+service_test_dir="$THIS_DIR/$SERVICE"
+
+if [ ! -d "$service_test_dir" ]; then
+    echo "No tests for service $SERVICE"
+    exit 0
+fi
+
+service_test_files=$( find "$service_test_dir" -type f ! -name '.*' | sort )
+
+for service_test_file in $service_test_files; do
+    test_name=$( filenoext "$service_test_file" )
+    test_start_time=$( date +%s )
+    bash $service_test_file
+    test_end_time=$( date +%s )
+    echo "$test_name took $( expr $test_end_time - $test_start_time ) second(s)"
+done


### PR DESCRIPTION
Adds a new Bash-based e2e test framework that can be integrated (at a
later point, as needed) with the `scripts/kind-build-test.sh`.

The first e2e test is a very simple ECR repository "smoke test" which
does the following:

1) check if a particular ECR repository exists via the `aws` CLI
   tool
2) check if that ecr.services.k8s.aws/Repository CR exists via
   `kubectl`
3) creates the ecr.services.k8s.aws/Repository CR via `kubectl`
4) verifies the ECR Repository was created via the `aws` CLI tool
5) deletes the ecr.services.k8s.aws/Repository CR via `kubectl`
6) verifies the ECR Repository no longer exists via the `aws` CLI tool

To run the new e2e test script for ECR, do this:

```
export ROLE_ARN="the ARN of the AWS Role you will use for testing"
make build-ack-generate
./scripts/build-controller.sh ecr
./scripts/kind-build-test.sh -p -s ecr -r "$ROLE_ARN"
```

example output:

```
jaypipes@thelio:~/go/src/github.com/aws/aws-controllers-k8s$ ./scripts/kind-build-test.sh -p -s ecr -r "$ROLE_ARN"
Using Kubernetes kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765
Creating k8s cluster using "kind" ...
No kind clusters found.
Created k8s cluster using "kind"
Building ecr docker image
Building 'ecr' controller docker image with tag: ack-ecr-controller:a1487ce-dirty
sha256:69feab81d8bac0ffc4a5fd01c56821f754fab75e237fb26e77cca46a1adc2d3c
Loading the images into the cluster
Image: "ack-ecr-controller:a1487ce-dirty" with ID "sha256:69feab81d8bac0ffc4a5fd01c56821f754fab75e237fb26e77cca46a1adc2d3c" not yet present on node "test-f0a12070-worker", loading...
Image: "ack-ecr-controller:a1487ce-dirty" with ID "sha256:69feab81d8bac0ffc4a5fd01c56821f754fab75e237fb26e77cca46a1adc2d3c" not yet present on node "test-f0a12070-control-plane", loading...
Loading CRD manifests for ecr into the cluster
customresourcedefinition.apiextensions.k8s.io/repositories.ecr.services.k8s.aws created
Loading RBAC manifests for ecr into the cluster
clusterrole.rbac.authorization.k8s.io/ack-controller-role created
clusterrolebinding.rbac.authorization.k8s.io/ack-controller-rolebinding created
Loading service controller Deployment for ecr into the cluster
namespace/ack-system created
deployment.apps/ack-ecr-controller created
Running aws sts assume-role --role-arn arn:aws:iam::750630568209:role/elasticache.services.k8s.aws.full, --role-session-name tmp-role-7cb1cb12  --duration-seconds 900,
Temporary credentials generated
deployment.apps/ack-ecr-controller env updated
Added AWS Credentials to env vars map
======================================================================================================
To poke around your test manually:
export KUBECONFIG=/home/jaypipes/go/src/github.com/aws/aws-controllers-k8s/scripts/../build/tmp-test-f0a12070/kubeconfig
kubectl get pods -A
======================================================================================================
repository.ecr.services.k8s.aws/ack-test-smoke-ecr created
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
|                                                                                     DescribeRepositories                                                                                      |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
||                                                                                        repositories                                                                                         ||
|+--------------+---------------+--------------------------------------------------------------------+---------------------+-------------------------------------------------------------------+|
||   createdAt  |  registryId   |                           repositoryArn                            |   repositoryName    |                           repositoryUri                           ||
|+--------------+---------------+--------------------------------------------------------------------+---------------------+-------------------------------------------------------------------+|
||  1597248827.0|  750630568209 |  arn:aws:ecr:us-west-2:750630568209:repository/ack-test-smoke-ecr  |  ack-test-smoke-ecr |  750630568209.dkr.ecr.us-west-2.amazonaws.com/ack-test-smoke-ecr  ||
|+--------------+---------------+--------------------------------------------------------------------+---------------------+-------------------------------------------------------------------+|
repository.ecr.services.k8s.aws "ack-test-smoke-ecr" deleted
smoke took 8 second(s)
To resume test with the same cluster use: "-c /home/jaypipes/go/src/github.com/aws/aws-controllers-k8s/scripts/../build/tmp-test-f0a12070"
```

Issue #6

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
