### PR TITLE
was missing an else-if in SDK template

### DIFF
--- a/templates/pkg/crd_sdk.go.tpl
+++ b/templates/pkg/crd_sdk.go.tpl
@@ -73,7 +73,7 @@ func (rm *resourceManager) sdkFind(
 	ko := r.ko.DeepCopy()
 {{ $setCode }}
 	return &resource{ko}, nil
-{{- else }}
+{{- else if .CRD.Ops.ReadMany }}
 	input, err := rm.newListRequestPayload(r)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
We were missing an else if statement in the sdk.go template, causing
failures when generating the RDS service controller.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
