### PR TITLE
Add make help and build-controller-image targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,10 @@ test: | mocks	## Run code tests
 clean-mocks:	## Remove mocks directory
 	rm -rf mocks
 
-build-controller-image: build-controller	## Build container image for SERVICE
+build-controller-image:	## Build container image for SERVICE
 	./scripts/build-controller-image.sh -s $(SERVICE)
 
-build-controller:	## Generate controller code for SERVICE
+build-controller: build-ack-generate	## Generate controller code for SERVICE
 	./scripts/build-controller.sh $(SERVICE)
 
 kind-cluster: test	## Run tests in a local kind cluster for SERVICE
@@ -55,5 +55,5 @@ $(MOCKS): mocks/% : %
 	${MOCKERY_BIN} --tags=codegen --case=underscore --output=$@ --dir=$^ --all
 
 help:           ## Show this help.
-	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' \
+	@fgrep -h "##" $(MAKEFILE_LIST) | grep -F -v grep | sed -e 's/\\$$//' \
 		| awk -F'[:#]' '{print $$1 = sprintf("%-30s", $$1), $$4}'

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ build-controller: build-ack-generate	## Generate controller code for SERVICE
 kind-cluster: test	## Run tests in a local kind cluster for SERVICE
 	./scripts/kind-build-test.sh -s $(SERVICE)
 
-kind-cluster-preserve: test	## Run tests in o local kind cluster for SERVICE and preserve cluster
+kind-cluster-preserve: test	## Run tests in a local kind cluster for SERVICE and preserve cluster
 	./scripts/kind-build-test.sh -s $(SERVICE) -p
 
 kind-cluster-functional: test	## Run functional tests for SERVICE with ROLE_ARN

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ GO_TAGS=-tags codegen
 
 all: test
 
-build-ack-generate:	## Bulid ack-generate binary
+build-ack-generate:	## Build ack-generate binary
 	go build ${GO_TAGS} -o bin/ack-generate cmd/ack-generate/main.go
 
 test: | mocks	## Run code tests
@@ -27,7 +27,7 @@ clean-mocks:	## Remove mocks directory
 build-controller-image: build-controller	## Build container image for SERVICE
 	./scripts/build-controller-image.sh -s $(SERVICE)
 
-build-controller:	## Build controller binary for SERVICE
+build-controller:	## Generate controller code for SERVICE
 	./scripts/build-controller.sh $(SERVICE)
 
 kind-cluster: test	## Run tests in a local kind cluster for SERVICE

--- a/Makefile
+++ b/Makefile
@@ -55,5 +55,5 @@ $(MOCKS): mocks/% : %
 	${MOCKERY_BIN} --tags=codegen --case=underscore --output=$@ --dir=$^ --all
 
 help:           ## Show this help.
-	@fgrep -h "##" $(MAKEFILE_LIST) | grep -F -v grep | sed -e 's/\\$$//' \
+	@grep -F -h "##" $(MAKEFILE_LIST) | grep -F -v grep | sed -e 's/\\$$//' \
 		| awk -F'[:#]' '{print $$1 = sprintf("%-30s", $$1), $$4}'

--- a/Makefile
+++ b/Makefile
@@ -10,43 +10,50 @@ MOCKERY_BIN=$(shell which mockery || "./bin/mockery")
 # aws-sdk-go/private/model/api package is gated behind a build tag "codegen"...
 GO_TAGS=-tags codegen
 
-.PHONY: all build-ack-generate test clean-mocks mocks build-controller build-kind-cluster build-kind-cluster-preserve \
+.PHONY: all build-ack-generate test clean-mocks mocks build-controller-image build-controller build-kind-cluster build-kind-cluster-preserve \
         build-kind-cluster-functional kind-get-cluster-names delete-all-kind-clusters
 
 all: test
 
-build-ack-generate:
+build-ack-generate:	## Bulid ack-generate binary
 	go build ${GO_TAGS} -o bin/ack-generate cmd/ack-generate/main.go
 
-test: | mocks
+test: | mocks	## Run code tests
 	go test ${GO_TAGS} ./...
 
-clean-mocks:
+clean-mocks:	## Remove mocks directory
 	rm -rf mocks
 
-build-controller:
+build-controller-image: build-controller	## Build container image for SERVICE
+	./scripts/build-controller-image.sh -s $(SERVICE)
+
+build-controller:	## Build controller binary for SERVICE
 	./scripts/build-controller.sh $(SERVICE)
 
-kind-cluster: test
+kind-cluster: test	## Run tests in a local kind cluster for SERVICE
 	./scripts/kind-build-test.sh -s $(SERVICE)
 
-kind-cluster-preserve: test
+kind-cluster-preserve: test	## Run tests in o local kind cluster for SERVICE and preserve cluster
 	./scripts/kind-build-test.sh -s $(SERVICE) -p
 
-kind-cluster-functional: test
+kind-cluster-functional: test	## Run functional tests for SERVICE with ROLE_ARN
 	./scripts/kind-build-test.sh -s $(SERVICE) -p -r $(ROLE_ARN)
 
-kind-get-cluster-names:
+kind-get-cluster-names:	## Get local kind clusters
 	@kind get clusters
 
-delete-all-kind-clusters:
+delete-all-kind-clusters:	## Delete all local kind clusters
 	@kind get clusters | \
 	while read name ; do \
 	kind delete cluster --name $$name; \
 	done
 	@rm -rf build/tmp-test*
 
-mocks: $(MOCKS)
+mocks: $(MOCKS)	## Run mock tests
 
 $(MOCKS): mocks/% : %
 	${MOCKERY_BIN} --tags=codegen --case=underscore --output=$@ --dir=$^ --all
+
+help:           ## Show this help.
+	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' \
+		| awk -F'[:#]' '{print $$1 = sprintf("%-30s", $$1), $$4}'

--- a/scripts/build-controller-image.sh
+++ b/scripts/build-controller-image.sh
@@ -9,6 +9,7 @@ BUILD_CONTEXT=$DIR/..
 QUIET=false
 OPTIND=1
 VERSION=$(git describe --tags --always --dirty || echo "unknown")
+export DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-1}
 
 source $SCRIPTS_DIR/lib/common.sh
 


### PR DESCRIPTION
In learning to build the project it's helpful, for me, to have a `make help` target with descriptions of what the targets do. I also added a target to build one of the container images and in the build-controller-image.sh script export `DOCKER_BUILDKIT=1` because builds are faster (and look better).

cc @nithu0115 
