### PR TITLE
S3 service controller enhancements and fixes

### DIFF
--- a/pkg/model/crd_test.go
+++ b/pkg/model/crd_test.go
@@ -3506,13 +3506,17 @@ func TestS3_Bucket(t *testing.T) {
 
 	expSpecFieldCamel := []string{
 		"ACL",
-		"Bucket",
 		"CreateBucketConfiguration",
 		"GrantFullControl",
 		"GrantRead",
 		"GrantReadACP",
 		"GrantWrite",
 		"GrantWriteACP",
+		// NOTE(jaypipes): Original field name in CreateBucket input is
+		// "Bucket" but should be renamed to "Name" from the generator.yaml (in
+		// order to match with the name of the field in the Output shape for a
+		// ListBuckets API call...
+		"Name",
 		"ObjectLockEnabledForBucket",
 	}
 	assert.Equal(expSpecFieldCamel, attrCamelNames(specFields))
@@ -3526,8 +3530,8 @@ func TestS3_Bucket(t *testing.T) {
 	if r.ko.Spec.ACL != nil {
 		res.SetACL(*r.ko.Spec.ACL)
 	}
-	if r.ko.Spec.Bucket != nil {
-		res.SetBucket(*r.ko.Spec.Bucket)
+	if r.ko.Spec.Name != nil {
+		res.SetBucket(*r.ko.Spec.Name)
 	}
 	if r.ko.Spec.CreateBucketConfiguration != nil {
 		f2 := &svcsdk.CreateBucketConfiguration{}

--- a/pkg/model/generator_config.go
+++ b/pkg/model/generator_config.go
@@ -49,12 +49,14 @@ type ResourceGeneratorConfig struct {
 	// UnpackAttributeMapConfig contains instructions for converting a raw
 	// `map[string]*string` into real fields on a CRD's Spec or Status object
 	UnpackAttributesMapConfig *UnpackAttributesMapConfig `json:"unpack_attributes_map,omitempty"`
-	// ExceptionsConfig identifies the exception codes for the resource. Some
-	// API model files don't contain the ErrorInfo struct that contains the
+	// Exceptions identifies the exception codes for the resource. Some API
+	// model files don't contain the ErrorInfo struct that contains the
 	// HTTPStatusCode attribute that we usually look for to identify 404 Not
 	// Found and other common error types for primary resources, and thus we
 	// need these instructions.
 	Exceptions *ExceptionsConfig `json:"exceptions,omitempty"`
+	// Renames identifies fields in Operations that should be renamed.
+	Renames *RenamesConfig `json:"renames,omitempty"`
 }
 
 // UnpackAttributesMapConfig informs the code generator that the API follows a
@@ -135,6 +137,23 @@ type ExceptionsConfig struct {
 	// Codes is a map of HTTP status code to the name of the Exception shape
 	// that corresponds to that HTTP status code for this resource
 	Codes map[int]string `json:"codes"`
+}
+
+// RenamesConfig contains instructions to the code generator how to rename
+// fields in various Operation payloads
+type RenamesConfig struct {
+	// Operations is a map, keyed by Operation ID, of instructions on how to
+	// handle renamed fields in Input and Output shapes.
+	Operations map[string]*OperationRenamesConfig `json:"operations"`
+}
+
+// OperationRenamesConfig contains instructions to the code generator on how to
+// rename fields in an Operation's input and output payload shapes
+type OperationRenamesConfig struct {
+	// InputFields is a map of Input shape fields to renamed field name.
+	InputFields map[string]string `json:"input_fields"`
+	// OutputFields is a map of Output shape fields to renamed field name.
+	OutputFields map[string]string `json:"output_fields"`
 }
 
 // NewGeneratorConfig returns a new GeneratorConfig object given a supplied

--- a/pkg/model/generator_config.go
+++ b/pkg/model/generator_config.go
@@ -57,6 +57,16 @@ type ResourceGeneratorConfig struct {
 	Exceptions *ExceptionsConfig `json:"exceptions,omitempty"`
 	// Renames identifies fields in Operations that should be renamed.
 	Renames *RenamesConfig `json:"renames,omitempty"`
+	// ListOperation contains instructions for the code generator to generate
+	// Go code that filters the results of a List operation looking for a
+	// singular object. Certain AWS services (e.g. S3's ListBuckets API) have
+	// absolutely no way to pass a filter to the operation. Instead, the List
+	// operation always returns ALL objects of that type.
+	//
+	// The ListOperationConfig object enables us to inject some custom code to
+	// filter the results of these List operations from within the generated
+	// code in sdk.go's sdkFind().
+	ListOperation *ListOperationConfig `json:"list_operation,omitempty"`
 }
 
 // UnpackAttributesMapConfig informs the code generator that the API follows a
@@ -154,6 +164,15 @@ type OperationRenamesConfig struct {
 	InputFields map[string]string `json:"input_fields"`
 	// OutputFields is a map of Output shape fields to renamed field name.
 	OutputFields map[string]string `json:"output_fields"`
+}
+
+// ListOperationConfig contains instructions for the code generator to handle
+// List operations for service APIs that have no built-in filtering ability and
+// whose List Operation always returns all objects.
+type ListOperationConfig struct {
+	// MatchFields lists the names of fields in the Shape of the
+	// list element in the List Operation's Output shape.
+	MatchFields []string `json:"match_fields"`
 }
 
 // NewGeneratorConfig returns a new GeneratorConfig object given a supplied

--- a/pkg/model/testdata/models/apis/s3/0000-00-00/generator.yaml
+++ b/pkg/model/testdata/models/apis/s3/0000-00-00/generator.yaml
@@ -12,3 +12,9 @@ resources:
         CreateBucket:
           input_fields:
             Bucket: Name
+        DeleteBucket:
+          input_fields:
+            Bucket: Name
+    list_operation:
+      match_fields:
+        - Name

--- a/pkg/model/testdata/models/apis/s3/0000-00-00/generator.yaml
+++ b/pkg/model/testdata/models/apis/s3/0000-00-00/generator.yaml
@@ -5,3 +5,10 @@ ignore:
   shape_names:
     # These shapes are structs with no members...
     - SSES3
+resources:
+  Bucket:
+    renames:
+      operations:
+        CreateBucket:
+          input_fields:
+            Bucket: Name

--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -194,5 +194,6 @@ echo "kubectl get pods -A"
 echo "======================================================================================================"
 
 export KUBECONFIG
+export AWS_REGION
 
 $TEST_E2E_DIR/run-tests.sh $AWS_SERVICE

--- a/services/s3/generator.yaml
+++ b/services/s3/generator.yaml
@@ -12,3 +12,9 @@ resources:
         CreateBucket:
           input_fields:
             Bucket: Name
+        DeleteBucket:
+          input_fields:
+            Bucket: Name
+    list_operation:
+      match_fields:
+        - Name

--- a/services/s3/generator.yaml
+++ b/services/s3/generator.yaml
@@ -5,3 +5,10 @@ ignore:
   shape_names:
     # These shapes are structs with no members...
     - SSES3
+resources:
+  Bucket:
+    renames:
+      operations:
+        CreateBucket:
+          input_fields:
+            Bucket: Name

--- a/test/e2e/ecr/smoke.sh
+++ b/test/e2e/ecr/smoke.sh
@@ -9,10 +9,11 @@ source "$SCRIPTS_DIR/lib/k8s.sh"
 source "$SCRIPTS_DIR/lib/testutil.sh"
 
 test_name="$( filenoext "${BASH_SOURCE[0]}" )"
-ack_ctrl_pod_id=$( controller_pod_id "ecr")
-debug_msg "executing test: $test_name"
+service_name="ecr"
+ack_ctrl_pod_id=$( controller_pod_id "$service_name")
+debug_msg "executing test: $service_name/$test_name"
 
-repo_name="ack-test-smoke-ecr"
+repo_name="ack-test-smoke-$service_name"
 resource_name="repositories/$repo_name"
 
 # PRE-CHECKS
@@ -54,7 +55,7 @@ assert_equal "0" "$?" "Expected success from kubectl delete but got $?" || exit 
 
 aws ecr describe-repositories --repository-names "$repo_name" --output json >/dev/null 2>&1
 if [ $? -ne 255 ]; then
-    echo "FAIL: expected $repo_name to deleted in ECR"
+    echo "FAIL: expected $repo_name to be deleted in ECR"
     kubectl logs -n ack-system "$ack_ctrl_pod_id"
     exit 1
 fi

--- a/test/e2e/s3/smoke.test
+++ b/test/e2e/s3/smoke.test
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="$THIS_DIR/../../.."
+SCRIPTS_DIR="$ROOT_DIR/scripts"
+
+source "$SCRIPTS_DIR/lib/common.sh"
+source "$SCRIPTS_DIR/lib/k8s.sh"
+source "$SCRIPTS_DIR/lib/testutil.sh"
+
+check_is_installed jq
+
+test_name="$( filenoext "${BASH_SOURCE[0]}" )"
+service_name="s3"
+ack_ctrl_pod_id=$( controller_pod_id "s3")
+debug_msg "executing test: $service_name/$test_name"
+
+bucket_name="ack-test-smoke-$service_name"
+resource_name="buckets/$bucket_name"
+
+list_bucket_json() {
+    jq_expr='.Buckets[] | select(.Name | contains($BUCKET_NAME))'
+    aws s3api list-buckets --output json | jq -e --arg BUCKET_NAME "$bucket_name" "$jq_expr"
+}
+
+# PRE-CHECKS
+list_bucket_json
+if [ $? -ne 4 ]; then
+    echo "FAIL: expected $bucket_name to not exist in S3. Did previous test run cleanup?"
+    exit 1
+fi
+
+if k8s_resource_exists "$resource_name"; then
+    echo "FAIL: expected $resource_name to not exist. Did previous test run cleanup?"
+    exit 1
+fi
+
+# TEST ACTIONS and ASSERTIONS
+
+cat <<EOF | kubectl apply -f -
+apiVersion: s3.services.k8s.aws/v1alpha1
+kind: Bucket
+metadata:
+  name: $bucket_name
+spec:
+  name: $bucket_name
+EOF
+
+sleep 20
+
+debug_msg "checking bucket $bucket_name created in ECR"
+list_bucket_json
+if [ $? -eq 4 ]; then
+    echo "FAIL: expected $bucket_name to have been created in S3"
+    kubectl logs -n ack-system "$ack_ctrl_pod_id"
+    exit 1
+fi
+
+kubectl delete "$resource_name" 2>/dev/null
+assert_equal "0" "$?" "Expected success from kubectl delete but got $?" || exit 1
+
+list_bucket_json
+if [ $? -ne 4 ]; then
+    echo "FAIL: expected $bucket_name to be deleted in S3"
+    kubectl logs -n ack-system "$ack_ctrl_pod_id"
+    exit 1
+fi


### PR DESCRIPTION
The S3 CreateBucket API Operation has an Input shape with a field called
"Bucket". This is actually the *name* of the Bucket to be created.
Unfortunately, the ListBuckets API Operation's Output shape (from which
we build the SDK linkage to find a particular object) calls this same
field "Name" (quite appropriately I might add, since that's what the
field represents... the bucket's name).

In order to handle mismatched field names like this, I have added a
`RenamesConfig` struct to the `GeneratorConfig` that holds instructions
on how to rename certain fields in the input and output shapes.

The S3 `generator.yaml` config has been modified with the following
rename instructions:

```yaml
resources:
  Bucket:
    renames:
      operations:
        CreateBucket:
          input_fields:
            Bucket: Name
```

which effectively renames the `BucketSpec.Bucket` field to
`BucketSpec.Name`.

Fixes the last build failure identified in #180.

Issue #180

Adds `ListOperationConfig` struct to the `GeneratorConfig`. This struct
allows us to instruct the code generator that a particular API's List
operation returns all resources of a particular type and that it will
need to add Go code to the `sdkFind()` method of the resource manager to
filter out results from the returned set of objects that do not match
the values of certain fields.

It's easier to talk about this with an example. Let's take the S3 Bucket
API. There is a ListBuckets API call. The Input shape for ListBuckets is
always empty. There is no ability to ask ListBuckets to only return
results for, say, a particular named Bucket. Instead, in order to use
the ListBuckets API call to find a *particular* named Bucket, you need
to ListBuckets and then loop over all the results, looking for a result
with a Name field matching the Bucket.Spec.Name that you are looking
for.

This patch changed the code generator to add Go code to the output shape
processing for the ListBuckets API that looks like this:

```go
if len(resp.Buckets) == 0 {
    return nil, ackerr.NotFound
}
found := false
for _, elem := range resp.Buckets {
    if elem.Name != nil {
        if ko.Spec.Name != nil {
            if *elem.Name != *ko.Spec.Name {
                continue
            }
        }
        r.ko.Spec.Name = elem.Name
    }
    found = true
}
if !found {
    return nil, ackerr.NotFound
}
```

The `generator.yaml` for S3 looks like this now:

```yaml
ignore:
  resource_names:
    - Object
    - MultipartUpload
  shape_names:
    # These shapes are structs with no members...
    - SSES3
resources:
  Bucket:
    renames:
      operations:
        CreateBucket:
          input_fields:
            Bucket: Name
        DeleteBucket:
          input_fields:
            Bucket: Name
    list_operation:
      match_fields:
        - Name
```

The `resources.Bucket.list_operation` element contains the instructions
telling the code generator to output special code to filter out results
that don't match the searched-for Bucket's Name.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
