### PR TITLE
SNS service controller codegen fixes

### DIFF
--- a/apis/core/v1alpha1/common.go
+++ b/apis/core/v1alpha1/common.go
@@ -13,6 +13,9 @@
 
 package v1alpha1
 
+// AWSRegion represents an AWS regional identifier
+type AWSRegion string
+
 // AWSAccountID represents an AWS account identifier
 type AWSAccountID string
 

--- a/mocks/pkg/types/aws_resource_manager.go
+++ b/mocks/pkg/types/aws_resource_manager.go
@@ -14,6 +14,20 @@ type AWSResourceManager struct {
 	mock.Mock
 }
 
+// ARNFromName provides a mock function with given fields: _a0
+func (_m *AWSResourceManager) ARNFromName(_a0 string) string {
+	ret := _m.Called(_a0)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(string) string); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // Create provides a mock function with given fields: _a0, _a1
 func (_m *AWSResourceManager) Create(_a0 context.Context, _a1 types.AWSResource) (types.AWSResource, error) {
 	ret := _m.Called(_a0, _a1)

--- a/mocks/pkg/types/aws_resource_manager_factory.go
+++ b/mocks/pkg/types/aws_resource_manager_factory.go
@@ -14,13 +14,13 @@ type AWSResourceManagerFactory struct {
 	mock.Mock
 }
 
-// ManagerFor provides a mock function with given fields: _a0, _a1
-func (_m *AWSResourceManagerFactory) ManagerFor(_a0 types.AWSResourceReconciler, _a1 v1alpha1.AWSAccountID) (types.AWSResourceManager, error) {
-	ret := _m.Called(_a0, _a1)
+// ManagerFor provides a mock function with given fields: _a0, _a1, _a2
+func (_m *AWSResourceManagerFactory) ManagerFor(_a0 types.AWSResourceReconciler, _a1 v1alpha1.AWSAccountID, _a2 v1alpha1.AWSRegion) (types.AWSResourceManager, error) {
+	ret := _m.Called(_a0, _a1, _a2)
 
 	var r0 types.AWSResourceManager
-	if rf, ok := ret.Get(0).(func(types.AWSResourceReconciler, v1alpha1.AWSAccountID) types.AWSResourceManager); ok {
-		r0 = rf(_a0, _a1)
+	if rf, ok := ret.Get(0).(func(types.AWSResourceReconciler, v1alpha1.AWSAccountID, v1alpha1.AWSRegion) types.AWSResourceManager); ok {
+		r0 = rf(_a0, _a1, _a2)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(types.AWSResourceManager)
@@ -28,8 +28,8 @@ func (_m *AWSResourceManagerFactory) ManagerFor(_a0 types.AWSResourceReconciler,
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(types.AWSResourceReconciler, v1alpha1.AWSAccountID) error); ok {
-		r1 = rf(_a0, _a1)
+	if rf, ok := ret.Get(1).(func(types.AWSResourceReconciler, v1alpha1.AWSAccountID, v1alpha1.AWSRegion) error); ok {
+		r1 = rf(_a0, _a1, _a2)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/model/crd_test.go
+++ b/pkg/model/crd_test.go
@@ -200,6 +200,8 @@ func TestSNSTopic(t *testing.T) {
 	expGetAttrsInput := `
 	if r.ko.Status.ACKResourceMetadata != nil && r.ko.Status.ACKResourceMetadata.ARN != nil {
 		res.SetTopicArn(string(*r.ko.Status.ACKResourceMetadata.ARN))
+	} else {
+		res.SetTopicArn(rm.ARNFromName(*r.ko.Spec.Name))
 	}
 `
 	assert.Equal(expGetAttrsInput, crd.GoCodeGetAttributesSetInput("r.ko", "res", 1))
@@ -210,6 +212,9 @@ func TestSNSTopic(t *testing.T) {
 	// (and thus in the Spec fields). Two of them are the tesource's ARN and
 	// AWS Owner account ID, both of which are handled specially.
 	expGetAttrsOutput := `
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
 	ko.Status.EffectiveDeliveryPolicy = resp.Attributes["EffectiveDeliveryPolicy"]
 	tmpOwnerID := ackv1alpha1.AWSAccountID(*resp.Attributes["Owner"])
 	ko.Status.ACKResourceMetadata.OwnerAccountID = &tmpOwnerID
@@ -1128,6 +1133,9 @@ func TestSQSQueue(t *testing.T) {
 	// (and thus in the Spec fields). One of them is the resource's ARN which
 	// is handled specially.
 	expGetAttrsOutput := `
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
 	ko.Status.CreatedTimestamp = resp.Attributes["CreatedTimestamp"]
 	ko.Status.LastModifiedTimestamp = resp.Attributes["LastModifiedTimestamp"]
 	tmpARN := ackv1alpha1.AWSResourceName(*resp.Attributes["QueueArn"])

--- a/pkg/model/generator_config.go
+++ b/pkg/model/generator_config.go
@@ -46,6 +46,12 @@ type IgnoreSpec struct {
 // ResourceGeneratorConfig represents instructions to the ACK code generator
 // for a particular CRD/resource on an AWS service API
 type ResourceGeneratorConfig struct {
+	// NameField is the name of the Member of the Create Input shape that
+	// represents the name/string identifier field for the resource. If this
+	// isn't set, then the generator will look for a field called "Name" or
+	// "{Resource}Name" or "{Resource}Id" because, well, because we can never
+	// have nice things.
+	NameField *string `json:"name_field,omitempty"`
 	// UnpackAttributeMapConfig contains instructions for converting a raw
 	// `map[string]*string` into real fields on a CRD's Spec or Status object
 	UnpackAttributesMapConfig *UnpackAttributesMapConfig `json:"unpack_attributes_map,omitempty"`

--- a/pkg/model/type_def.go
+++ b/pkg/model/type_def.go
@@ -56,7 +56,7 @@ func (h *Helper) HasConflictingTypeName(typeName string) bool {
 		inStrings(cleanTypeName, crdStatusNames))
 }
 
-// IgnoreShape returns true if the supplied shape name should be ignored by the
+// IsIgnoredShape returns true if the supplied shape name should be ignored by the
 // code generator, false otherwise
 func (h *Helper) IsIgnoredShape(shapeName string) bool {
 	if h.generatorConfig == nil || len(h.generatorConfig.Ignore.ShapeNames) == 0 {

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -91,13 +91,15 @@ func (r *reconciler) reconcile(req ctrlrt.Request) error {
 	}
 
 	acctID := r.getOwnerAccountID(res)
+	region := r.getRegion(res)
 
 	r.log.WithValues(
 		"account_id", acctID,
+		"region", region,
 		"kind", r.rd.GroupKind().String(),
 	)
 
-	rm, err := r.rmf.ManagerFor(r, acctID)
+	rm, err := r.rmf.ManagerFor(r, acctID, region)
 	if err != nil {
 		return err
 	}
@@ -322,6 +324,16 @@ func (r *reconciler) getOwnerAccountID(
 	// which indicates a cross-account resource request
 	// TODO(jaypipes)
 	return ackv1alpha1.AWSAccountID(r.cfg.AccountID)
+}
+
+// getRegion returns the AWS region that the given resource is in or should be
+// created in. If the Namespace has a region associated with it, that is used,
+// otherwise the region specified in the configuration is used.
+func (r *reconciler) getRegion(
+	res acktypes.AWSResource,
+) ackv1alpha1.AWSRegion {
+	// TODO(jaypipes): Do the Namespace region lookup...
+	return ackv1alpha1.AWSRegion(r.cfg.Region)
 }
 
 // NewReconciler returns a new reconciler object that

--- a/pkg/types/aws_resource_manager.go
+++ b/pkg/types/aws_resource_manager.go
@@ -48,6 +48,11 @@ type AWSResourceManager interface {
 	// Delete attempts to destroy the supplied AWSResource in the backend AWS
 	// service API.
 	Delete(context.Context, AWSResource) error
+	// ARNFromName returns an AWS Resource Name from a given string name. This
+	// is useful for constructing ARNs for APIs that require ARNs in their
+	// GetAttributes operations but all we have (for new CRs at least) is a
+	// name for the resource
+	ARNFromName(string) string
 }
 
 // AWSResourceManagerFactory returns an AWSResourceManager that can be used to
@@ -59,6 +64,10 @@ type AWSResourceManagerFactory interface {
 	// prototypes
 	ResourceDescriptor() AWSResourceDescriptor
 	// ManagerFor returns an AWSResourceManager that manages AWS resources on
-	// behalf of a particular AWS account
-	ManagerFor(AWSResourceReconciler, ackv1alpha1.AWSAccountID) (AWSResourceManager, error)
+	// behalf of a particular AWS account and in a specific AWS region
+	ManagerFor(
+		AWSResourceReconciler,
+		ackv1alpha1.AWSAccountID,
+		ackv1alpha1.AWSRegion,
+	) (AWSResourceManager, error)
 }

--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -16,7 +16,7 @@ source "$SCRIPTS_DIR/lib/k8s.sh"
 
 OPTIND=1
 CLUSTER_NAME_BASE="test"
-AWS_ACCOUNT_ID=${AWS_ACCOUNT_ID:-"123456789012"}
+AWS_ACCOUNT_ID=${AWS_ACCOUNT_ID:-""}
 AWS_REGION=${AWS_REGION_ID:-"us-west-2"}
 AWS_ROLE_ARN=""
 ACK_ENABLE_DEVELOPMENT_LOGGING="true"
@@ -29,6 +29,10 @@ START=$(date +%s)
 TMP_DIR=""
 # VERSION is the source revision that executables and images are built from.
 VERSION=$(git describe --tags --always --dirty || echo "unknown")
+
+if [ "z$AWS_ACCOUNT_ID" == "z" ]; then
+    AWS_ACCOUNT_ID=$( aws_account_id )
+fi
 
 function clean_up {
     if [[ "$PRESERVE" == false ]]; then
@@ -194,6 +198,5 @@ echo "kubectl get pods -A"
 echo "======================================================================================================"
 
 export KUBECONFIG
-export AWS_REGION
 
 $TEST_E2E_DIR/run-tests.sh $AWS_SERVICE

--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -68,3 +68,8 @@ generate_aws_temp_creds() {
       AWS_SESSION_TOKEN=$(echo "${JSON}" | jq --raw-output ".Credentials[\"SessionToken\"]")
       printf "\nTemporary credentials generated\n"
 }
+
+aws_account_id() {
+    JSON=$(aws sts get-caller-identity --output json || exit 1)
+    echo "${JSON}" | jq --raw-output ".Account"
+}

--- a/services/bookstore/pkg/resource/book/manager_factory.go
+++ b/services/bookstore/pkg/resource/book/manager_factory.go
@@ -41,6 +41,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 func (f *resourceManagerFactory) ManagerFor(
 	rr acktypes.AWSResourceReconciler,
 	id ackv1alpha1.AWSAccountID,
+	region ackv1alpha1.AWSRegion,
 ) (acktypes.AWSResourceManager, error) {
 	f.RLock()
 	rm, found := f.rmCache[id]
@@ -53,7 +54,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(rr, id)
+	rm, err := newResourceManager(rr, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/bookstore/pkg/resource/book/manager_factory_test.go
+++ b/services/bookstore/pkg/resource/book/manager_factory_test.go
@@ -43,14 +43,15 @@ func TestManagerFor(t *testing.T) {
 	require.NotNil(bookRMF)
 
 	acctID := ackv1alpha1.AWSAccountID("aws-account-id")
-	bookRM, err := bookRMF.ManagerFor(nil, acctID)
+	region := ackv1alpha1.AWSRegion("us-west-2")
+	bookRM, err := bookRMF.ManagerFor(nil, acctID, region)
 	require.Nil(err)
 	require.NotNil(bookRM)
 	require.Implements((*acktypes.AWSResourceManager)(nil), bookRM)
 
 	// The resource manager factory should keep a cache of resource manager
 	// objects, keyed by account ID.
-	otherBookRM, err := bookRMF.ManagerFor(nil, acctID)
+	otherBookRM, err := bookRMF.ManagerFor(nil, acctID, region)
 	require.Nil(err)
 	require.Exactly(bookRM, otherBookRM)
 }

--- a/services/petstore/pkg/resource/pet/manager.go
+++ b/services/petstore/pkg/resource/pet/manager.go
@@ -15,6 +15,7 @@ package pet
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -41,6 +42,8 @@ type resourceManager struct {
 	// awsAccountID is the AWS account identifier that contains the resources
 	// managed by this resource manager
 	awsAccountID ackv1alpha1.AWSAccountID
+	// The AWS Region that this resource manager targets
+	awsRegion ackv1alpha1.AWSRegion
 	// sess is the AWS SDK Session object used to communicate with the backend
 	// AWS service API
 	sess *session.Session
@@ -206,9 +209,23 @@ func (rm *resourceManager) newDeleteRequestPayload(
 	}, nil
 }
 
+// ARNFromName returns an AWS Resource Name from a given string name. This
+// is useful for constructing ARNs for APIs that require ARNs in their
+// GetAttributes operations but all we have (for new CRs at least) is a
+// name for the resource
+func (rm *resourceManager) ARNFromName(name string) string {
+	return fmt.Sprintf(
+		"arn:aws:petstore:%s:%s:%s",
+		rm.awsRegion,
+		rm.awsAccountID,
+		name,
+	)
+}
+
 func newResourceManager(
 	rr acktypes.AWSResourceReconciler,
 	id ackv1alpha1.AWSAccountID,
+	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	sess, err := ackrt.NewSession()
 	if err != nil {
@@ -217,6 +234,7 @@ func newResourceManager(
 	return &resourceManager{
 		rr:           rr,
 		awsAccountID: id,
+		awsRegion:    region,
 		sess:         sess,
 	}, nil
 }

--- a/services/petstore/pkg/resource/pet/manager_factory.go
+++ b/services/petstore/pkg/resource/pet/manager_factory.go
@@ -46,6 +46,7 @@ func (f *resourceManagerFactory) GroupKind() string {
 func (f *resourceManagerFactory) ManagerFor(
 	rr acktypes.AWSResourceReconciler,
 	id ackv1alpha1.AWSAccountID,
+	region ackv1alpha1.AWSRegion,
 ) (acktypes.AWSResourceManager, error) {
 	f.RLock()
 	rm, found := f.rmCache[id]
@@ -58,7 +59,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(rr, id)
+	rm, err := newResourceManager(rr, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/petstore/pkg/resource/pet/manager_factory_test.go
+++ b/services/petstore/pkg/resource/pet/manager_factory_test.go
@@ -43,14 +43,15 @@ func TestManagerFor(t *testing.T) {
 	require.NotNil(petRMF)
 
 	acctID := ackv1alpha1.AWSAccountID("aws-account-id")
-	petRM, err := petRMF.ManagerFor(nil, acctID)
+	region := ackv1alpha1.AWSRegion("us-west-2")
+	petRM, err := petRMF.ManagerFor(nil, acctID, region)
 	require.Nil(err)
 	require.NotNil(petRM)
 	require.Implements((*acktypes.AWSResourceManager)(nil), petRM)
 
 	// The resource manager factory should keep a cache of resource manager
 	// objects, keyed by account ID.
-	otherPetRM, err := petRMF.ManagerFor(nil, acctID)
+	otherPetRM, err := petRMF.ManagerFor(nil, acctID, region)
 	require.Nil(err)
 	require.Exactly(petRM, otherPetRM)
 }

--- a/templates/pkg/crd_manager.go.tpl
+++ b/templates/pkg/crd_manager.go.tpl
@@ -4,6 +4,7 @@ package {{ .CRD.Names.Snake }}
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/aws/aws-sdk-go/aws/session"
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
@@ -26,6 +27,8 @@ type resourceManager struct {
 	// awsAccountID is the AWS account identifier that contains the resources
 	// managed by this resource manager
 	awsAccountID ackv1alpha1.AWSAccountID
+	// The AWS Region that this resource manager targets
+	awsRegion ackv1alpha1.AWSRegion
 	// sess is the AWS SDK Session object used to communicate with the backend
 	// AWS service API
 	sess *session.Session
@@ -117,11 +120,25 @@ func (rm *resourceManager) Delete(
 	return rm.sdkDelete(ctx, r)
 }
 
+// ARNFromName returns an AWS Resource Name from a given string name. This
+// is useful for constructing ARNs for APIs that require ARNs in their
+// GetAttributes operations but all we have (for new CRs at least) is a
+// name for the resource
+func (rm *resourceManager) ARNFromName(name string) string {
+	return fmt.Sprintf(
+		"arn:aws:{{ .ServiceAlias }}:%s:%s:%s",
+		rm.awsRegion,
+		rm.awsAccountID,
+		name,
+	)
+}
+
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
 	rr acktypes.AWSResourceReconciler,
 	id ackv1alpha1.AWSAccountID,
+	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	sess, err := ackrt.NewSession()
 	if err != nil {
@@ -130,6 +147,7 @@ func newResourceManager(
 	return &resourceManager{
 		rr: rr,
 		awsAccountID: id,
+		awsRegion: region,
 		sess:		 sess,
 		sdkapi:	   svcsdk.New(sess),
 	}, nil

--- a/templates/pkg/crd_manager_factory.go.tpl
+++ b/templates/pkg/crd_manager_factory.go.tpl
@@ -30,6 +30,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 func (f *resourceManagerFactory) ManagerFor(
 	rr acktypes.AWSResourceReconciler,
 	id ackv1alpha1.AWSAccountID,
+	region ackv1alpha1.AWSRegion,
 ) (acktypes.AWSResourceManager, error) {
 	f.RLock()
 	rm, found := f.rmCache[id]
@@ -42,7 +43,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(rr, id)
+	rm, err := newResourceManager(rr, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/s3/smoke.sh
+++ b/test/e2e/s3/smoke.sh
@@ -48,7 +48,7 @@ EOF
 
 sleep 20
 
-debug_msg "checking bucket $bucket_name created in ECR"
+debug_msg "checking bucket $bucket_name created in S3"
 list_bucket_json
 if [ $? -eq 4 ]; then
     echo "FAIL: expected $bucket_name to have been created in S3"

--- a/test/e2e/sns/smoke.sh
+++ b/test/e2e/sns/smoke.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="$THIS_DIR/../../.."
+SCRIPTS_DIR="$ROOT_DIR/scripts"
+
+source "$SCRIPTS_DIR/lib/common.sh"
+source "$SCRIPTS_DIR/lib/k8s.sh"
+source "$SCRIPTS_DIR/lib/testutil.sh"
+
+check_is_installed jq
+
+test_name="$( filenoext "${BASH_SOURCE[0]}" )"
+service_name="sns"
+ack_ctrl_pod_id=$( controller_pod_id "sns")
+debug_msg "executing test: $service_name/$test_name"
+
+topic_name="ack-test-smoke-$service_name"
+resource_name="topics/$topic_name"
+
+get_topic_attributes() {
+    topic_arn="arn:aws:sns:$AWS_REGION:$AWS_ACCOUNT_ID:$topic_name"
+    aws sns get-topic-attributes --topic-arn "$topic_arn" --output json >/dev/null 2>&1
+}
+
+# PRE-CHECKS
+get_topic_attributes
+if [ $? -ne 255 ]; then
+    echo "FAIL: expected $topic_name to not exist in SNS. Did previous test run cleanup?"
+    exit 1
+fi
+
+if k8s_resource_exists "$resource_name"; then
+    echo "FAIL: expected $resource_name to not exist. Did previous test run cleanup?"
+    exit 1
+fi
+
+# TEST ACTIONS and ASSERTIONS
+
+cat <<EOF | kubectl apply -f -
+apiVersion: sns.services.k8s.aws/v1alpha1
+kind: Topic
+metadata:
+  name: $topic_name
+spec:
+  name: $topic_name
+EOF
+
+sleep 20
+
+debug_msg "checking topic $topic_name created in SNS"
+get_topic_attributes
+if [ $? -eq 255 ]; then
+    echo "FAIL: expected $topic_name to have been created in SNS"
+    kubectl logs -n ack-system "$ack_ctrl_pod_id"
+    exit 1
+fi
+
+kubectl delete "$resource_name" 2>/dev/null
+assert_equal "0" "$?" "Expected success from kubectl delete but got $?" || exit 1
+
+get_topic_attributes
+if [ $? -ne 255 ]; then
+    echo "FAIL: expected $topic_name to be deleted in SNS"
+    kubectl logs -n ack-system "$ack_ctrl_pod_id"
+    exit 1
+fi


### PR DESCRIPTION
Quite a few problems with the generation of the SNS service controller.
When I wrote the smoke test for SNS, it identified issues with how the
call to GetTopicAttributes was being incorrectly made. The TopicArn
field in the GetTopicAttributesInput shape was not being set. So, I
added code to set that value to a simulated ARN (when the ARN doesn't
exist yet due to the resource not being created yet in the AWS API, we
can construct an ARN using the AWS account ID and region associated with
the resource manager).

This way, the GetTopicAttributes API call will return a 404 as
appropriate and the sdkFind() code paths will work properly.

I'm still, however, getting failures when attempting to run the smoke
tests. I'm getting the following error:

```
2020-08-17T01:22:53.772Z	ERROR	controller-runtime.controller	Reconciler error	{"controller": "topic", "request": "default/ack-test-smoke-sns", "error": "InvalidParameter: Invalid parameter: TopicArn Reason: A ${AWS_REGION} ARN must begin with arn:null, not arn:aws:sns:${AWS_REGION}:${AWS_ACCOUNT_ID}:ack-test-smoke-sns\n\tstatus code: 400, request id: 9b8aea74-c027-5dc4-bf0a-bdc71e0a7af2"}
```

and I'm lost as to how to interpret it. Hoping to get some help in the
morning from others...

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
