### PR TITLE
check for NotFound using 255 or 254 for ECR

### DIFF
--- a/docs/contents/dev-docs/testing.md
+++ b/docs/contents/dev-docs/testing.md
@@ -85,7 +85,7 @@ in your account using `KinD` cluster, use `-r` and pass in `AWS ROLE ARN` to `sc
     Make sure the trust relationship in the role has `sts:assume-role` permission. 
 
 * To verify which IAM entity is making assume role API call, run `aws sts get-caller-identity` command:
-    
+
 ```
 aws sts get-caller-identity
 ```
@@ -107,7 +107,7 @@ aws sts get-caller-identity
 
 If you do not have a role, run below commands to create a role, add the trust relationship to the role along with a sample policy arn which has ECR full permissions. 
 If you have a role, verify your role has below trust relationship. 
-       
+
 ``` json
 cat > example-role-trust-policy.json << EOF
 {

--- a/test/e2e/ecr/smoke.sh
+++ b/test/e2e/ecr/smoke.sh
@@ -19,7 +19,7 @@ resource_name="repositories/$repo_name"
 # PRE-CHECKS
 
 aws ecr describe-repositories --repository-names "$repo_name" --output json >/dev/null 2>&1
-if [ $? -ne 255 ]; then
+if [[ $? -ne 255 && $? -ne 254 ]]; then
     echo "FAIL: expected $repo_name to not exist in ECR. Did previous test run cleanup?"
     exit 1
 fi
@@ -44,7 +44,7 @@ sleep 5
 
 debug_msg "checking repository $repo_name created in ECR"
 aws ecr describe-repositories --repository-names "$repo_name" --output table
-if [ $? -eq 255 ]; then
+if [[ $? -eq 255 || $? -eq 254 ]]; then
     echo "FAIL: expected $repo_name to have been created in ECR"
     kubectl logs -n ack-system "$ack_ctrl_pod_id"
     exit 1
@@ -54,7 +54,7 @@ kubectl delete "$resource_name" 2>/dev/null
 assert_equal "0" "$?" "Expected success from kubectl delete but got $?" || exit 1
 
 aws ecr describe-repositories --repository-names "$repo_name" --output json >/dev/null 2>&1
-if [ $? -ne 255 ]; then
+if [[ $? -ne 255 && $? -ne 254 ]]; then
     echo "FAIL: expected $repo_name to be deleted in ECR"
     kubectl logs -n ack-system "$ack_ctrl_pod_id"
     exit 1


### PR DESCRIPTION
The `aws` CLI tool apparently changed from using return code 255 to
using return code 254 between v1 and v2 of the CLI tool. So, this
modifies the ECR smoke test to simply check for either of those return
codes when determining if a repository already exists.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
