### PR TITLE
Add variable separators

### DIFF
--- a/docs/contents/dev-docs/testing.md
+++ b/docs/contents/dev-docs/testing.md
@@ -173,7 +173,7 @@ To generate the IAM role ARN, do:
 
 ```
 AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text) && \
-export AWS_ROLE_ARN=arn:aws:iam::$AWS_ACCOUNT_ID:role/$ACK_TEST_IAM_ROLE
+export AWS_ROLE_ARN=arn:aws:iam::${AWS_ACCOUNT_ID}:role/${ACK_TEST_IAM_ROLE}
 ```
 
 !!! info 


### PR DESCRIPTION
This fixes the fix from https://github.com/aws/aws-controllers-k8s/pull/220

I should have known better that I can't have a `:` after a bash variable. This ended up removing `:r` from the variable.
