### PR TITLE
Clean service alias names from white spaces

### DIFF
--- a/cmd/ack-generate/command/controller.go
+++ b/cmd/ack-generate/command/controller.go
@@ -114,7 +114,7 @@ func writeControllerMainGo(sh *model.Helper) error {
 
 	vars := &cmdtemplate.ControllerMainTemplateVars{
 		APIVersion:         latestAPIVersion,
-		ServiceAlias:       strings.ToLower(sh.GetServiceAlias()),
+		ServiceAlias:       sh.GetCleanServiceAlias(),
 		SnakeCasedCRDNames: snakeCasedCRDNames,
 	}
 
@@ -172,7 +172,7 @@ func writeResourcePackageRegistryGo(sh *model.Helper) error {
 	var b bytes.Buffer
 	vars := &pkgtemplate.ResourceRegistryGoTemplateVars{
 		APIVersion:   latestAPIVersion,
-		ServiceAlias: strings.ToLower(sh.GetServiceAlias()),
+		ServiceAlias: sh.GetCleanServiceAlias(),
 	}
 	tpl, err := pkgtemplate.NewResourceRegistryGoTemplate(optTemplatesDir)
 	if err != nil {
@@ -194,7 +194,7 @@ func writeCRDResourceGo(sh *model.Helper, crd *model.CRD) error {
 	var b bytes.Buffer
 	vars := &pkgtemplate.CRDResourceGoTemplateVars{
 		APIVersion:   latestAPIVersion,
-		ServiceAlias: strings.ToLower(sh.GetServiceAlias()),
+		ServiceAlias: sh.GetCleanServiceAlias(),
 		CRD:          crd,
 	}
 	tpl, err := pkgtemplate.NewCRDResourceGoTemplate(optTemplatesDir)
@@ -217,7 +217,7 @@ func writeCRDIdentifiersGo(sh *model.Helper, crd *model.CRD) error {
 	var b bytes.Buffer
 	vars := &pkgtemplate.CRDIdentifiersGoTemplateVars{
 		APIVersion:   latestAPIVersion,
-		ServiceAlias: strings.ToLower(sh.GetServiceAlias()),
+		ServiceAlias: sh.GetCleanServiceAlias(),
 		CRD:          crd,
 	}
 	tpl, err := pkgtemplate.NewCRDIdentifiersGoTemplate(optTemplatesDir)
@@ -241,7 +241,7 @@ func writeCRDDescriptorGo(sh *model.Helper, crd *model.CRD) error {
 	vars := &pkgtemplate.CRDDescriptorGoTemplateVars{
 		APIVersion:   latestAPIVersion,
 		APIGroup:     sh.GetAPIGroup(),
-		ServiceAlias: strings.ToLower(sh.GetServiceAlias()),
+		ServiceAlias: sh.GetCleanServiceAlias(),
 		CRD:          crd,
 	}
 	tpl, err := pkgtemplate.NewCRDDescriptorGoTemplate(optTemplatesDir)
@@ -265,7 +265,7 @@ func writeCRDManagerFactoryGo(sh *model.Helper, crd *model.CRD) error {
 	vars := &pkgtemplate.CRDManagerFactoryGoTemplateVars{
 		APIVersion:   latestAPIVersion,
 		APIGroup:     sh.GetAPIGroup(),
-		ServiceAlias: strings.ToLower(sh.GetServiceAlias()),
+		ServiceAlias: sh.GetCleanServiceAlias(),
 		CRD:          crd,
 	}
 	tpl, err := pkgtemplate.NewCRDManagerFactoryGoTemplate(optTemplatesDir)
@@ -289,7 +289,7 @@ func writeCRDManagerGo(sh *model.Helper, crd *model.CRD) error {
 	vars := &pkgtemplate.CRDManagerGoTemplateVars{
 		APIVersion:              latestAPIVersion,
 		APIGroup:                sh.GetAPIGroup(),
-		ServiceAlias:            strings.ToLower(sh.GetServiceAlias()),
+		ServiceAlias:            sh.GetCleanServiceAlias(),
 		SDKAPIInterfaceTypeName: sh.GetSDKAPIInterfaceTypeName(),
 		CRD:                     crd,
 	}
@@ -314,7 +314,7 @@ func writeCRDSDKGo(sh *model.Helper, crd *model.CRD) error {
 	vars := &pkgtemplate.CRDSDKGoTemplateVars{
 		APIVersion:              latestAPIVersion,
 		APIGroup:                sh.GetAPIGroup(),
-		ServiceAlias:            strings.ToLower(sh.GetServiceAlias()),
+		ServiceAlias:            sh.GetCleanServiceAlias(),
 		SDKAPIInterfaceTypeName: sh.GetSDKAPIInterfaceTypeName(),
 		CRD:                     crd,
 	}
@@ -370,7 +370,7 @@ func writeConfigDirs(sh *model.Helper) error {
 func writeConfigDefaultKustomizationYAML(sh *model.Helper) error {
 	var b bytes.Buffer
 	vars := &configdefaulttemplate.ConfigDefaultKustomizationYAMLTemplateVars{
-		ServiceAlias: strings.ToLower(sh.GetServiceAlias()),
+		ServiceAlias: sh.GetCleanServiceAlias(),
 	}
 	tpl, err := configdefaulttemplate.NewConfigDefaultKustomizationYAMLTemplate(optTemplatesDir)
 	if err != nil {
@@ -391,7 +391,7 @@ func writeConfigDefaultKustomizationYAML(sh *model.Helper) error {
 func writeConfigControllerKustomizationYAML(sh *model.Helper) error {
 	var b bytes.Buffer
 	vars := &configcontrollertemplate.ConfigControllerKustomizationYAMLTemplateVars{
-		ServiceAlias: strings.ToLower(sh.GetServiceAlias()),
+		ServiceAlias: sh.GetCleanServiceAlias(),
 	}
 	tpl, err := configcontrollertemplate.NewConfigControllerKustomizationYAMLTemplate(optTemplatesDir)
 	if err != nil {
@@ -412,7 +412,7 @@ func writeConfigControllerKustomizationYAML(sh *model.Helper) error {
 func writeConfigControllerDeploymentYAML(sh *model.Helper) error {
 	var b bytes.Buffer
 	vars := &configcontrollertemplate.ConfigControllerDeploymentYAMLTemplateVars{
-		ServiceAlias: strings.ToLower(sh.GetServiceAlias()),
+		ServiceAlias: sh.GetCleanServiceAlias(),
 	}
 	tpl, err := configcontrollertemplate.NewConfigControllerDeploymentYAMLTemplate(optTemplatesDir)
 	if err != nil {
@@ -433,7 +433,7 @@ func writeConfigControllerDeploymentYAML(sh *model.Helper) error {
 func writeConfigRBACKustomizationYAML(sh *model.Helper) error {
 	var b bytes.Buffer
 	vars := &configrbactemplate.ConfigRBACKustomizationYAMLTemplateVars{
-		ServiceAlias: strings.ToLower(sh.GetServiceAlias()),
+		ServiceAlias: sh.GetCleanServiceAlias(),
 	}
 	tpl, err := configrbactemplate.NewConfigRBACKustomizationYAMLTemplate(optTemplatesDir)
 	if err != nil {
@@ -454,7 +454,7 @@ func writeConfigRBACKustomizationYAML(sh *model.Helper) error {
 func writeConfigRBACClusterRoleBindingYAML(sh *model.Helper) error {
 	var b bytes.Buffer
 	vars := &configrbactemplate.ConfigRBACClusterRoleBindingYAMLTemplateVars{
-		ServiceAlias: strings.ToLower(sh.GetServiceAlias()),
+		ServiceAlias: sh.GetCleanServiceAlias(),
 	}
 	tpl, err := configrbactemplate.NewConfigRBACClusterRoleBindingYAMLTemplate(optTemplatesDir)
 	if err != nil {

--- a/pkg/model/helper.go
+++ b/pkg/model/helper.go
@@ -43,6 +43,11 @@ func (h *Helper) GetServiceAlias() string {
 	return awssdkmodel.ServiceID(h.sdkAPI)
 }
 
+func (h *Helper) GetCleanServiceAlias() string {
+	serviceAlias := strings.ToLower(h.GetServiceAlias())
+	return strings.Replace(serviceAlias, " ", "", -1)
+}
+
 func (h *Helper) GetServiceFullName() string {
 	if h.sdkAPI == nil {
 		return ""
@@ -51,8 +56,8 @@ func (h *Helper) GetServiceFullName() string {
 }
 
 func (h *Helper) GetAPIGroup() string {
-	serviceAlias := strings.ToLower(h.GetServiceAlias())
-	return fmt.Sprintf("%s.services.k8s.aws", serviceAlias)
+	cleanServiceAlias := h.GetCleanServiceAlias()
+	return fmt.Sprintf("%s.services.k8s.aws", cleanServiceAlias)
 }
 
 func (h *Helper) GetCRDNames() []names.Names {


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

Some service alias names contains white spaces, which is causing `controller-gen` to generate controllers files with white spaces in import paths, apis group name...
In this PR we remove white spaces from service alias names and move every name cleaning action to `Helper{}.GetCleanServiceAlias`

List of impacted services:
```bash
"Migration Hub"
"ACM PCA"
"Alexa For Business"
"API Gateway"
"Application Auto Scaling"
"Application Insights"
"App Mesh"
"Auto Scaling Plans"
"Auto Scaling"
"Cost Explorer"
"CloudHSM V2"
"CodeGuru Reviewer"
"CodeStar connections"
"codestar notifications"
"Cognito Identity"
"Cognito Identity Provider"
"Compute Optimizer"
"Config Service"
"Cost and Usage Report Service"
"Device Farm"
"Direct Connect"
"Application Discovery Service"
"Database Migration Service"
"Directory Service"
"EC2 Instance Connect"
"Elastic Inference"
"Elastic Beanstalk"
"Elastic Load Balancing"
"Elastic Load Balancing v2"
"Elastic Transcoder"
"Elasticsearch Service"
"CloudWatch Events"
"Global Accelerator"
"IoT Data Plane"
"IoT Jobs Data Plane"
"IoT 1Click Devices Service"
"IoT 1Click Projects"
"IoT Events Data"
"IoT Events"
"Kinesis Video Archived Media"
"Kinesis Video Media"
"Kinesis Video Signaling"
"Kinesis Analytics"
"Kinesis Analytics V2"
"Kinesis Video"
"Lex Model Building Service"
"License Manager"
"CloudWatch Logs"
"Marketplace Catalog"
"Marketplace Commerce Analytics"
"MediaPackage Vod"
"MediaStore Data"
"Marketplace Metering"
"MigrationHub Config"
"Personalize Events"
"Personalize Runtime"
"Pinpoint Email"
"QLDB Session"
"RDS Data"
"Resource Groups"
"Resource Groups Tagging API"
"Route 53"
"Route 53 Domains"
"Lex Runtime Service"
"SageMaker Runtime"
"S3 Control"
"SageMaker A2I Runtime"
"Secrets Manager"
"Service Quotas"
"Service Catalog"
"Pinpoint SMS Voice"
"SSO OIDC"
"Storage Gateway"
"Transcribe Streaming"
"WAF Regional"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
