### PR TITLE
Handling exception from invalid ReadOneInput

### DIFF
--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -372,7 +372,7 @@ func (r *CRD) ExceptionCode(httpStatusCode int) string {
 }
 
 /**
-This method return the required input fields names for ReadOne operation which are present in ko.Status .
+This method returns the required fields names for ReadOneInput which are present in ko.Status .
 During initial creation of aws resource, ReadOne call should be ignored if validation error
 occurs from absence of these fields.
 

--- a/pkg/model/validation_helper.go
+++ b/pkg/model/validation_helper.go
@@ -1,0 +1,53 @@
+package model
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type ValidationHelper struct{}
+
+type IErrInvalidParam interface {
+	Message() string
+	Error() string
+}
+
+/**
+This method performs a check if errInvalidParams is strictly caused by ignorableFieldNames.
+This means all the ignorableFieldNames should be present in errInvalidParams.
+
+The method returns true if all the validation errors are due to ignorableFieldNames, otherwise false.
+*/
+func (vh *ValidationHelper) IsValidationErrorIgnorable(ignorableFieldNames []string, errInvalidParams IErrInvalidParam) bool {
+
+	if len(ignorableFieldNames) == 0 {
+		return false
+	}
+	//Invalid parameter exception has predefined message telling total number of errors.
+	re, error := regexp.Compile(`(\d+) validation error\(s\) found`)
+	if error != nil {
+		return false
+	} else {
+		match := re.FindStringSubmatch(errInvalidParams.Message())
+		if len(match) != 2 {
+			return false
+		}
+		validationErrorCount, error := strconv.Atoi(match[1])
+		if error != nil {
+			return false
+		} else if validationErrorCount != len(ignorableFieldNames) { //strict check
+			return false
+		} else {
+			//Make sure all the requiredStatusFieldNames are present in the validationError
+			allIgnorableFieldsPresent := true
+			for _, ignorableFieldName := range ignorableFieldNames {
+				allIgnorableFieldsPresent = allIgnorableFieldsPresent && strings.Contains(strings.ToLower(errInvalidParams.Error()), strings.ToLower(ignorableFieldName))
+			}
+			if !allIgnorableFieldsPresent {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/pkg/model/validation_helper.go
+++ b/pkg/model/validation_helper.go
@@ -1,3 +1,16 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package model
 
 import (

--- a/pkg/model/validation_helper_test.go
+++ b/pkg/model/validation_helper_test.go
@@ -1,0 +1,111 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/aws/aws-controllers-k8s/pkg/model"
+	"github.com/stretchr/testify/assert"
+)
+
+type MockErrInvalidParams struct {
+	error   string
+	message string
+}
+
+func (mockErrInvalidParams MockErrInvalidParams) Error() string {
+	return mockErrInvalidParams.error
+}
+
+func (mockErrInvalidParams MockErrInvalidParams) Message() string {
+	return mockErrInvalidParams.message
+}
+
+func TestIsValidationErrorIgnorable(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		name                string
+		ignorableFieldNames []string
+		errInvalidParams    MockErrInvalidParams
+		expected            bool
+	}{
+		{
+			name:                "No status fields are required",
+			ignorableFieldNames: []string{},
+			errInvalidParams: MockErrInvalidParams{
+				error:   "",
+				message: "",
+			},
+			expected: false,
+		},
+		{
+			name:                "invalidParamError has unexpected content",
+			ignorableFieldNames: []string{"fieldA"},
+			errInvalidParams: MockErrInvalidParams{
+				error:   "some invalid content",
+				message: "some invalid content",
+			},
+			expected: false,
+		},
+		{
+			name:                "invalidParamError has more errors than required status fields",
+			ignorableFieldNames: []string{"GetApiInput.ApiId"},
+			errInvalidParams: MockErrInvalidParams{
+				error:   "- missing required field, GetApiInput.ApiId.\n- missing required field, GetApiInput.Dummy",
+				message: "2 validation error(s) found.",
+			},
+			expected: false,
+		},
+		{
+			name:                "invalidParamError less more errors than required status fields",
+			ignorableFieldNames: []string{"GetApiInput.ApiId", "GetApiInput.Dummy"},
+			errInvalidParams: MockErrInvalidParams{
+				error:   "- missing required field, GetApiInput.ApiId.",
+				message: "1 validation error(s) found.",
+			},
+			expected: false,
+		},
+		{
+			name:                "invalidParamsError does not contain all required status fields",
+			ignorableFieldNames: []string{"GetApiInput.ApiId"},
+			errInvalidParams: MockErrInvalidParams{
+				error:   "- missing required field, GetApiInput.Dummy.",
+				message: "1 validation error(s) found.",
+			},
+			expected: false,
+		},
+		{
+			name:                "invalidParamsError contains all required status fields. Test Case Insensitivity",
+			ignorableFieldNames: []string{"GetApiInput.APIID"},
+			errInvalidParams: MockErrInvalidParams{
+				error:   "- missing required field, GetApiInput.apiid.",
+				message: "1 validation error(s) found.",
+			},
+			expected: true,
+		},
+		{
+			name:                "invalidParamsError contains all required status fields. Test multiple parameters.",
+			ignorableFieldNames: []string{"GetApiInput.ApiId", "GetApiInput.Dummy"},
+			errInvalidParams: MockErrInvalidParams{
+				error:   "- missing required field, GetApiInput.ApiId.\n- missing required field, GetApiInput.Dummy",
+				message: "2 validation error(s) found.",
+			},
+			expected: true,
+		},
+		{
+			name:                "invalidParamsError contains all required status fields. Happy Case",
+			ignorableFieldNames: []string{"GetApiInput.ApiId"},
+			errInvalidParams: MockErrInvalidParams{
+				error:   "- missing required field, GetApiInput.ApiId.",
+				message: "1 validation error(s) found.",
+			},
+			expected: true,
+		},
+	}
+
+	validationHelper := model.ValidationHelper{}
+
+	for _, test := range tests {
+		assert.Equal(test.expected, validationHelper.IsValidationErrorIgnorable(test.ignorableFieldNames, test.errInvalidParams))
+	}
+}

--- a/pkg/model/validation_helper_test.go
+++ b/pkg/model/validation_helper_test.go
@@ -1,3 +1,16 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
 package model_test
 
 import (

--- a/pkg/template/pkg/crd_sdk.go
+++ b/pkg/template/pkg/crd_sdk.go
@@ -78,6 +78,9 @@ func NewCRDSDKGoTemplate(tplDir string) (*ttpl.Template, error) {
 		"Empty": func(subject string) bool {
 			return strings.TrimSpace(subject) == ""
 		},
+		"GoCodeRequiredStatusFieldsForReadOneInput": func(r *model.CRD, indentLevel int) string {
+			return r.RequiredStatusFieldsForReadOneInput(indentLevel)
+		},
 	})
 	if t, err = t.Parse(string(tplContents)); err != nil {
 		return nil, err

--- a/templates/pkg/crd_sdk.go.tpl
+++ b/templates/pkg/crd_sdk.go.tpl
@@ -4,6 +4,7 @@ package {{ .CRD.Names.Snake }}
 
 import (
 	"context"
+	"reflect"
 {{- if .CRD.TypeImports }}
 {{- range $packagePath, $alias := .CRD.TypeImports }}
 	{{ if $alias }}{{ $alias }} {{ end }}"{{ $packagePath }}"
@@ -13,7 +14,9 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	ackmodel "github.com/aws/aws-controllers-k8s/pkg/model"
 	"github.com/aws/aws-sdk-go/aws"
+	awsreq "github.com/aws/aws-sdk-go/aws/request"
 	svcsdk "github.com/aws/aws-sdk-go/service/{{ .ServiceAlias }}"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -40,13 +43,34 @@ func (rm *resourceManager) sdkFind(
 	if err != nil {
 		return nil, err
 	}
+	//If the input implements validate method, invoke Validate() before making ReadOne call
+	inputType := reflect.TypeOf(input)
+	_, validateable := inputType.MethodByName("Validate")
+	if validateable {
+		err := input.Validate()
+		if err != nil {
+			if validationError, ok := err.(awsreq.ErrInvalidParams); ok {
+				// In case of an input validation error, Ignore validationError only if it is exclusively caused by missing ko.Status fields.
+				// This is because the aws resource is yet to be created.
+				// * If the validation error is ignorable, return NotFoundException to avoid ReadOne call before Create call
+				// * If the validation error cannot be ignored, return ValidationError.
+				{{ GoCodeRequiredStatusFieldsForReadOneInput .CRD 0 }}
+				validationHelper := ackmodel.ValidationHelper{}
+				if validationHelper.IsValidationErrorIgnorable(requiredStatusFields, validationError) {
+					return nil, ackerr.NotFound
+				}
+				return nil, validationError
+			}
+		}
+	}
+
 {{ $setCode := GoCodeSetReadOneOutput .CRD "resp" "ko.Status" 1 }}
 	{{ if and .CRD.StatusFields ( not ( Empty $setCode ) ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.ReadOne.Name }}WithContext(ctx, input)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceExceptionCode .CRD 404 }}" {
 			return nil, ackerr.NotFound
 		}
-		return nil, err
+		return nil, respErr
 	}
 
 	// Merge in the information we read from the API call above to the copy of


### PR DESCRIPTION
Issue #209 , if available:

Description of changes:
`During reconciliation, Ignore ReadOne call before Create call only if ReadOneInput has required parameters from CreateOutput.`

* Created a type ValidationHelper to handle validation logic. This class can include more methods in future.
* Created a validation method which  validates that cause of ValidationException is from all the ignorable fields.
* Used this validation method after creating ReadOneInput and passing all the required field from ko.Status as ignorable fields
* These fields are okay to be ignored because these fields will not available until first create call.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
