### PR TITLE
Exclude ModifyCacheParameterGroup operation from generator.yaml

### DIFF
--- a/services/elasticache/generator.yaml
+++ b/services/elasticache/generator.yaml
@@ -6,5 +6,6 @@ resources:
 ignore:
   operations:
     - DeleteSnapshot
+    - ModifyCacheParameterGroup
   resource_names:
     - GlobalReplicationGroup


### PR DESCRIPTION
Description of changes:

The attributes of CacheParameterGroup are immutable. This API can be used to update individual key, value
parameters that are part of `CacheParameterGroup`. Without excluding the operation we keep on seeing 
```
2020-08-25T19:28:58.593-0700    ERROR   controller-runtime.controller   Reconciler error        {"controller": "cacheparametergroup", "request": "default/testccr", "error": "InvalidParameter: 1 validation error(s) found.\n- missing required field, ModifyCacheParameterGroupInput.ParameterNameValues.\n"}
```
as Modify operation is continuously invoked.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
