### PR TITLE
Fix dockerfile copy paths for LICENSE and attribution.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,5 @@ RUN  go build -a -o $work_dir/bin/controller $work_dir/services/$service_alias/c
 FROM amazonlinux:2
 ARG work_dir=/github.com/aws/aws-controllers-k8s
 WORKDIR /
-COPY --from=builder $work_dir/bin/controller LICENSE ATTRIBUTION.md /bin/.
+COPY --from=builder $work_dir/bin/controller $work_dir/LICENSE $work_dir/ATTRIBUTION.md /bin/.
 ENTRYPOINT ["/bin/controller"]


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

Fix dockerfile copy paths for `LICENSE` and `attribution.md`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
