### PR TITLE
handle NotFound from kube API

### DIFF
--- a/test/e2e/ecr/smoke.sh
+++ b/test/e2e/ecr/smoke.sh
@@ -11,7 +11,7 @@ source "$SCRIPTS_DIR/lib/testutil.sh"
 wait_seconds=5
 test_name="$( filenoext "${BASH_SOURCE[0]}" )"
 service_name="ecr"
-ack_ctrl_pod_id=$( controller_pod_id "$service_name")
+ack_ctrl_pod_id=$( controller_pod_id )
 debug_msg "executing test: $service_name/$test_name"
 
 # This smoke test creates and deletes a set of ECR repositories. It creates
@@ -89,3 +89,5 @@ for x in a b c; do
         exit 1
     fi
 done
+
+assert_pod_not_restarted $ack_ctrl_pod_id

--- a/test/e2e/elasticache/cache_subnet_group/smoke.sh
+++ b/test/e2e/elasticache/cache_subnet_group/smoke.sh
@@ -12,7 +12,7 @@ check_is_installed jq
 
 test_name="$( filenoext "${BASH_SOURCE[0]}" )"
 service_name="elasticache"
-ack_ctrl_pod_id=$( controller_pod_id "$service_name")
+ack_ctrl_pod_id=$( controller_pod_id )
 debug_msg "executing test: $service_name/$test_name"
 
 aws_resource_name="ack-test-smoke-${service_name}-subnet-gp"
@@ -80,3 +80,5 @@ if [[ $? -ne 255 && $? -ne 254 ]]; then
     kubectl logs -n ack-system "$ack_ctrl_pod_id"
     exit 1
 fi
+
+assert_pod_not_restarted $ack_ctrl_pod_id

--- a/test/e2e/s3/smoke.sh
+++ b/test/e2e/s3/smoke.sh
@@ -12,7 +12,7 @@ check_is_installed jq
 
 test_name="$( filenoext "${BASH_SOURCE[0]}" )"
 service_name="s3"
-ack_ctrl_pod_id=$( controller_pod_id "s3")
+ack_ctrl_pod_id=$( controller_pod_id )
 debug_msg "executing test: $service_name/$test_name"
 
 bucket_name="ack-test-smoke-$service_name-$AWS_ACCOUNT_ID"
@@ -65,3 +65,5 @@ if [ $? -ne 4 ]; then
     kubectl logs -n ack-system "$ack_ctrl_pod_id"
     exit 1
 fi
+
+assert_pod_not_restarted $ack_ctrl_pod_id

--- a/test/e2e/sns/smoke.sh
+++ b/test/e2e/sns/smoke.sh
@@ -12,7 +12,7 @@ check_is_installed jq
 
 test_name="$( filenoext "${BASH_SOURCE[0]}" )"
 service_name="sns"
-ack_ctrl_pod_id=$( controller_pod_id "sns")
+ack_ctrl_pod_id=$( controller_pod_id )
 debug_msg "executing test: $service_name/$test_name"
 
 topic_name="ack-test-smoke-$service_name"
@@ -65,3 +65,5 @@ if [[ $? -ne 255 && $? -ne 254 ]]; then
     kubectl logs -n ack-system "$ack_ctrl_pod_id"
     exit 1
 fi
+
+assert_pod_not_restarted $ack_ctrl_pod_id


### PR DESCRIPTION
The `pkg/runtime.reconciler.getAWSResource()` method was ignoring
NotFound errors, which was resulting in returning (nil, nil) from that
function, but functions like `getOwnerAccountID()` were counting on a
non-nil AWSResource.

We modify the code to simply return nil from `reconcile()` when a
resource with a supplied NamespacedName isn't found.

Adds a simple `assert_pod_not_restarted` check to each e2e test that
verifies the controller pod hasn't been restarted.

Issue #257
Issue #166

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
