### PR TITLE
Handling ValidationException in readOne call during initial creation.

### DIFF
--- a/apis/core/v1alpha1/resource_metadata.go
+++ b/apis/core/v1alpha1/resource_metadata.go
@@ -24,7 +24,9 @@ type ResourceMetadata struct {
 	// when it has verified that an "adopted" resource (a resource where the
 	// ARN annotation was set by the Kubernetes user on the CR) exists and
 	// matches the supplied CR's Spec field values.
-	ARN *AWSResourceName `json:"arn"`
+	//TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
+	// https://github.com/aws/aws-controllers-k8s/issues/270
+	ARN *AWSResourceName `json:"arn,omitempty"`
 	// OwnerAccountID is the AWS Account ID of the account that owns the
 	// backend AWS service API resource.
 	OwnerAccountID *AWSAccountID `json:"ownerAccountID"`

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -359,6 +359,24 @@ func (r *CRD) ExceptionCode(httpStatusCode int) string {
 	return "UNKNOWN"
 }
 
+// This method returns the required fields for ReadOneInput which are present in ko.Status .
+func (r *CRD) RequiredStatusFieldsForReadOneInput() []*CRDField {
+	var requiredStatusFields []*CRDField
+	op := r.Ops.ReadOne
+	inputShape := op.InputRef.Shape
+	if inputShape == nil || len(inputShape.Required) == 0 {
+		return requiredStatusFields
+	}
+	requiredFieldNames := inputShape.Required
+	for _, requiredFieldName := range requiredFieldNames {
+		koStatusField, found := r.StatusFields[requiredFieldName]
+		if found {
+			requiredStatusFields = append(requiredStatusFields, koStatusField)
+		}
+	}
+	return requiredStatusFields
+}
+
 // GoCodeSetInput returns the Go code that sets an input shape's member fields
 // from a CRD's fields.
 //
@@ -447,6 +465,24 @@ func (r *CRD) GoCodeSetInput(
 
 	out := "\n"
 	indent := strings.Repeat("\t", indentLevel)
+
+	// During initial creation of aws resource, return NotFoundError if all the required Status fields are missing for ReadOne call.
+	// Status fields will be populated after object creation
+	if OpTypeGet == opType {
+		var requiredKoStatusFields = r.RequiredStatusFieldsForReadOneInput()
+		if len(requiredKoStatusFields) > 0 {
+			allRequiredKoStatusFieldsMissingComment := "// If all the requiredKoStatusFields are missing, AWS resource is not created yet. Return NotFound exception\n"
+			allRequiredKoStatusFieldMissingCondition := ""
+			for _, fieldName := range requiredKoStatusFields {
+				// Use '&&' because all the requiredStatusFields should be missing if object is not created yet
+				allRequiredKoStatusFieldMissingCondition += fmt.Sprintf("r.ko.Status.%s == nil &&", fieldName.Names.Camel)
+			}
+			allRequiredKoStatusFieldMissingCondition = strings.TrimSuffix(allRequiredKoStatusFieldMissingCondition, "&&")
+			out += fmt.Sprintf("%sif %s {\n", allRequiredKoStatusFieldsMissingComment, allRequiredKoStatusFieldMissingCondition)
+			out += "return nil, ackerr.NotFound\n"
+			out += "}\n"
+		}
+	}
 
 	// Some input shapes for APIs that use GetAttributes API calls don't have
 	// an Attributes member (example: all the Delete shapes...)

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -207,7 +207,8 @@ func (r *reconciler) cleanup(
 	observed, err := rm.ReadOne(ctx, current)
 	if err != nil {
 		if err == ackerr.NotFound {
-			return nil
+			// If the aws resource is not found, remove finalizer
+			return r.setResourceUnmanaged(ctx, current)
 		}
 		return err
 	}

--- a/templates/apis/crd.go.tpl
+++ b/templates/apis/crd.go.tpl
@@ -38,6 +38,7 @@ type {{ .CRD.Kind }}Status struct {
 
 // {{ .CRD.Kind }} is the Schema for the {{ .CRD.Plural }} API
 // +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 type {{ .CRD.Kind }} struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/templates/pkg/crd_descriptor.go.tpl
+++ b/templates/pkg/crd_descriptor.go.tpl
@@ -85,7 +85,7 @@ func (d *resourceDescriptor) Diff(
 func (d *resourceDescriptor) UpdateCRStatus(
 	res acktypes.AWSResource,
 ) (bool, error) {
-	updated := false
+	updated := true
 	return updated, nil
 }
 

--- a/templates/pkg/crd_sdk.go.tpl
+++ b/templates/pkg/crd_sdk.go.tpl
@@ -155,6 +155,8 @@ func (rm *resourceManager) sdkCreate(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 {{ $createCode }}
+	ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{OwnerAccountID: &rm.awsAccountID}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	return &resource{ko}, nil
 }
 

--- a/test/e2e/ecr/smoke.sh
+++ b/test/e2e/ecr/smoke.sh
@@ -11,7 +11,7 @@ source "$SCRIPTS_DIR/lib/testutil.sh"
 wait_seconds=5
 test_name="$( filenoext "${BASH_SOURCE[0]}" )"
 service_name="ecr"
-ack_ctrl_pod_id=$( controller_pod_id "$service_name")
+ack_ctrl_pod_id=$( controller_pod_id )
 debug_msg "executing test: $service_name/$test_name"
 
 # This smoke test creates and deletes a set of ECR repositories. It creates
@@ -89,3 +89,5 @@ for x in a b c; do
         exit 1
     fi
 done
+
+assert_pod_not_restarted $ack_ctrl_pod_id

--- a/test/e2e/elasticache/cache_subnet_group/smoke.sh
+++ b/test/e2e/elasticache/cache_subnet_group/smoke.sh
@@ -12,7 +12,7 @@ check_is_installed jq
 
 test_name="$( filenoext "${BASH_SOURCE[0]}" )"
 service_name="elasticache"
-ack_ctrl_pod_id=$( controller_pod_id "$service_name")
+ack_ctrl_pod_id=$( controller_pod_id )
 debug_msg "executing test: $service_name/$test_name"
 
 aws_resource_name="ack-test-smoke-${service_name}-subnet-gp"
@@ -80,3 +80,5 @@ if [[ $? -ne 255 && $? -ne 254 ]]; then
     kubectl logs -n ack-system "$ack_ctrl_pod_id"
     exit 1
 fi
+
+assert_pod_not_restarted $ack_ctrl_pod_id

--- a/test/e2e/s3/smoke.sh
+++ b/test/e2e/s3/smoke.sh
@@ -12,7 +12,7 @@ check_is_installed jq
 
 test_name="$( filenoext "${BASH_SOURCE[0]}" )"
 service_name="s3"
-ack_ctrl_pod_id=$( controller_pod_id "s3")
+ack_ctrl_pod_id=$( controller_pod_id )
 debug_msg "executing test: $service_name/$test_name"
 
 bucket_name="ack-test-smoke-$service_name-$AWS_ACCOUNT_ID"
@@ -65,3 +65,5 @@ if [ $? -ne 4 ]; then
     kubectl logs -n ack-system "$ack_ctrl_pod_id"
     exit 1
 fi
+
+assert_pod_not_restarted $ack_ctrl_pod_id

--- a/test/e2e/sns/smoke.sh
+++ b/test/e2e/sns/smoke.sh
@@ -12,7 +12,7 @@ check_is_installed jq
 
 test_name="$( filenoext "${BASH_SOURCE[0]}" )"
 service_name="sns"
-ack_ctrl_pod_id=$( controller_pod_id "sns")
+ack_ctrl_pod_id=$( controller_pod_id )
 debug_msg "executing test: $service_name/$test_name"
 
 topic_name="ack-test-smoke-$service_name"
@@ -65,3 +65,5 @@ if [[ $? -ne 255 && $? -ne 254 ]]; then
     kubectl logs -n ack-system "$ack_ctrl_pod_id"
     exit 1
 fi
+
+assert_pod_not_restarted $ack_ctrl_pod_id


### PR DESCRIPTION
Issue #127 , if available:

Description of changes:
Adding a condition as per Jay's suggestion on PR #232 

The generate content now looks like

```
// newDescribeRequestPayload returns SDK-specific struct for the HTTP request
// payload of the Describe API call for the resource
func (rm *resourceManager) newDescribeRequestPayload(
	r *resource,
) (*svcsdk.GetApiInput, error) {
	res := &svcsdk.GetApiInput{}

	// If all the requiredKoStatusFields are missing, AWS resource is not created yet. Return NotFound exception
	if r.ko.Status.APIID == nil {
		return nil, ackerr.NotFound
	}
	if r.ko.Status.APIID != nil {
		res.SetApiId(*r.ko.Status.APIID)
	}

	return res, nil
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
