### PR TITLE
Implement Override values of Operations

### DIFF
--- a/pkg/generate/config/config.go
+++ b/pkg/generate/config/config.go
@@ -30,6 +30,14 @@ type Config struct {
 	Resources map[string]ResourceConfig `json:"resources"`
 	// CRDs to ignore. ACK generator would skip these resources.
 	Ignore IgnoreSpec `json:"ignore"`
+	// Contains generator instructions for individual API operations.
+	Operations map[string]OperationConfig `json:"operations"`
+}
+
+// OperationConfig represents instructions to the ACK code generator to
+// specify the overriding values for API operation parameters
+type OperationConfig struct {
+	OverrideValues map[string]string `json:"override_values"`
 }
 
 // IgnoreSpec represents instructions to the ACK code generator to
@@ -215,6 +223,18 @@ func (c *Config) IsIgnoredShape(shapeName string) bool {
 		return false
 	}
 	return util.InStrings(shapeName, c.Ignore.ShapeNames)
+}
+
+// OverrideValues gives list of member values to override.
+func (c *Config) OverrideValues(operationName string) (map[string]string, bool) {
+	if c == nil {
+		return nil, false
+	}
+	oConfig, ok := c.Operations[operationName]
+	if !ok {
+		return nil, false
+	}
+	return oConfig.OverrideValues, ok
 }
 
 // IsIgnoredResource returns true if Operation Name is configured to be ignored

--- a/pkg/generate/elasticache_test.go
+++ b/pkg/generate/elasticache_test.go
@@ -650,3 +650,84 @@ func TestElasticache_Ignored_Resources(t *testing.T) {
 	crd := getCRDByName("GlobalReplicationGroup", crds)
 	require.Nil(crd)
 }
+
+func TestElasticache_Override_Values(t *testing.T)  {
+	require := require.New(t)
+
+	g := testutil.NewGeneratorForService(t, "elasticache")
+	crds, err := g.GetCRDs()
+
+	require.Nil(err)
+
+	crd := getCRDByName("ReplicationGroup", crds)
+	require.NotNil(crd)
+
+	expected := `
+	res.SetApplyImmediately(true)
+	if r.ko.Spec.AuthToken != nil {
+		res.SetAuthToken(*r.ko.Spec.AuthToken)
+	}
+	if r.ko.Spec.AutoMinorVersionUpgrade != nil {
+		res.SetAutoMinorVersionUpgrade(*r.ko.Spec.AutoMinorVersionUpgrade)
+	}
+	if r.ko.Spec.AutomaticFailoverEnabled != nil {
+		res.SetAutomaticFailoverEnabled(*r.ko.Spec.AutomaticFailoverEnabled)
+	}
+	if r.ko.Spec.CacheNodeType != nil {
+		res.SetCacheNodeType(*r.ko.Spec.CacheNodeType)
+	}
+	if r.ko.Spec.CacheParameterGroupName != nil {
+		res.SetCacheParameterGroupName(*r.ko.Spec.CacheParameterGroupName)
+	}
+	if r.ko.Spec.CacheSecurityGroupNames != nil {
+		f7 := []*string{}
+		for _, f7iter := range r.ko.Spec.CacheSecurityGroupNames {
+			var f7elem string
+			f7elem = *f7iter
+			f7 = append(f7, &f7elem)
+		}
+		res.SetCacheSecurityGroupNames(f7)
+	}
+	if r.ko.Spec.EngineVersion != nil {
+		res.SetEngineVersion(*r.ko.Spec.EngineVersion)
+	}
+	if r.ko.Spec.MultiAZEnabled != nil {
+		res.SetMultiAZEnabled(*r.ko.Spec.MultiAZEnabled)
+	}
+	if r.ko.Spec.NotificationTopicARN != nil {
+		res.SetNotificationTopicArn(*r.ko.Spec.NotificationTopicARN)
+	}
+	if r.ko.Spec.PreferredMaintenanceWindow != nil {
+		res.SetPreferredMaintenanceWindow(*r.ko.Spec.PreferredMaintenanceWindow)
+	}
+	if r.ko.Spec.PrimaryClusterID != nil {
+		res.SetPrimaryClusterId(*r.ko.Spec.PrimaryClusterID)
+	}
+	if r.ko.Spec.ReplicationGroupDescription != nil {
+		res.SetReplicationGroupDescription(*r.ko.Spec.ReplicationGroupDescription)
+	}
+	if r.ko.Spec.ReplicationGroupID != nil {
+		res.SetReplicationGroupId(*r.ko.Spec.ReplicationGroupID)
+	}
+	if r.ko.Spec.SecurityGroupIDs != nil {
+		f17 := []*string{}
+		for _, f17iter := range r.ko.Spec.SecurityGroupIDs {
+			var f17elem string
+			f17elem = *f17iter
+			f17 = append(f17, &f17elem)
+		}
+		res.SetSecurityGroupIds(f17)
+	}
+	if r.ko.Spec.SnapshotRetentionLimit != nil {
+		res.SetSnapshotRetentionLimit(*r.ko.Spec.SnapshotRetentionLimit)
+	}
+	if r.ko.Spec.SnapshotWindow != nil {
+		res.SetSnapshotWindow(*r.ko.Spec.SnapshotWindow)
+	}
+	if r.ko.Status.SnapshottingClusterID != nil {
+		res.SetSnapshottingClusterId(*r.ko.Status.SnapshottingClusterID)
+	}
+`
+	assert := assert.New(t)
+	assert.Equal(expected, crd.GoCodeSetInput(model.OpTypeUpdate, "r.ko", "res", 1))
+}

--- a/pkg/generate/testdata/models/apis/elasticache/0000-00-00/generator.yaml
+++ b/pkg/generate/testdata/models/apis/elasticache/0000-00-00/generator.yaml
@@ -1,4 +1,11 @@
 resources:
+operations:
+  ModifyReplicationGroup:
+    override_values:
+      ApplyImmediately: true
+  ModifyCacheCluster:
+    override_values:
+      ApplyImmediately: true
 ignore:
   operations:
     - DeleteSnapshot

--- a/services/elasticache/generator.yaml
+++ b/services/elasticache/generator.yaml
@@ -3,6 +3,13 @@ resources:
     exceptions:
       codes:
         404: CacheSubnetGroupNotFoundFault
+operations:
+  ModifyReplicationGroup:
+    override_values:
+      ApplyImmediately: true
+  ModifyCacheCluster:
+    override_values:
+      ApplyImmediately: true
 ignore:
   operations:
     - DeleteSnapshot


### PR DESCRIPTION
Some operations input parameters are requiredto be overriden. This change would allow them to be configuredfrom generator.yaml. ElastiCache will use this to override SetApplyImmediately while modifying CacheCluster and ReplicationGroup

This would not solve the maintenance window handling, but allows us to disable it for now.

Issue #, if available: https://github.com/aws/aws-controllers-k8s/issues/229

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
