### PR TITLE
Add dependabot support for aws-sdk-go

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-name: "github.com/aws/aws-sdk-go"


### PR DESCRIPTION
Issue #241 

Description of changes: Added Dependabot support for `aws-sdk-go`. Made it weekly because updates to the SDK are frequent enough that daily PRs seemed tedious. Didn't modify any of the default commit messages, labels or add reviewers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
