### PR TITLE
Changes for successful k8s object status patching.

### DIFF
--- a/apis/core/v1alpha1/resource_metadata.go
+++ b/apis/core/v1alpha1/resource_metadata.go
@@ -24,7 +24,9 @@ type ResourceMetadata struct {
 	// when it has verified that an "adopted" resource (a resource where the
 	// ARN annotation was set by the Kubernetes user on the CR) exists and
 	// matches the supplied CR's Spec field values.
-	ARN *AWSResourceName `json:"arn"`
+	//TODO(vijat@): Find a better strategy for resources that do not have ARN in CreateOutputResponse
+	// https://github.com/aws/aws-controllers-k8s/issues/270
+	ARN *AWSResourceName `json:"arn,omitempty"`
 	// OwnerAccountID is the AWS Account ID of the account that owns the
 	// backend AWS service API resource.
 	OwnerAccountID *AWSAccountID `json:"ownerAccountID"`

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -208,7 +208,8 @@ func (r *reconciler) cleanup(
 	observed, err := rm.ReadOne(ctx, current)
 	if err != nil {
 		if err == ackerr.NotFound {
-			return nil
+			// If the aws resource is not found, remove finalizer
+			return r.setResourceUnmanaged(ctx, current)
 		}
 		return err
 	}

--- a/templates/apis/crd.go.tpl
+++ b/templates/apis/crd.go.tpl
@@ -38,6 +38,7 @@ type {{ .CRD.Kind }}Status struct {
 
 // {{ .CRD.Kind }} is the Schema for the {{ .CRD.Plural }} API
 // +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 type {{ .CRD.Kind }} struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/templates/pkg/crd_descriptor.go.tpl
+++ b/templates/pkg/crd_descriptor.go.tpl
@@ -85,7 +85,7 @@ func (d *resourceDescriptor) Diff(
 func (d *resourceDescriptor) UpdateCRStatus(
 	res acktypes.AWSResource,
 ) (bool, error) {
-	updated := false
+	updated := true
 	return updated, nil
 }
 

--- a/templates/pkg/crd_sdk.go.tpl
+++ b/templates/pkg/crd_sdk.go.tpl
@@ -168,6 +168,8 @@ func (rm *resourceManager) sdkCreate(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 {{ $createCode }}
+	ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{OwnerAccountID: &rm.awsAccountID}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	return &resource{ko}, nil
 }
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:

* make ARN optional in ACKResourceMetadata because some AWS resources do not return this field.
* add `+kubebuilder:subresource:status` tag for successful status patching.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
