### PR TITLE
Rely on aws-region cfg or region annotation instead of AWS_REGION variable

### DIFF
--- a/pkg/runtime/session.go
+++ b/pkg/runtime/session.go
@@ -13,16 +13,22 @@
 
 package runtime
 
-import "github.com/aws/aws-sdk-go/aws/session"
+import (
+	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/session"
+)
 
-func NewSession() (*session.Session, error) {
-	// NOTE(jaypipes): session.NewSession() is needed for the STS::AssumeRole
-	// stuff we will need to do...
-	sess, err := session.NewSession()
+func NewSession(region ackv1alpha1.AWSRegion) (*session.Session, error) {
+	awsCfg := aws.Config{
+		Region:              aws.String(string(region)),
+		STSRegionalEndpoint: endpoints.RegionalSTSEndpoint,
+	}
+	sess, err := session.NewSession(&awsCfg)
 	if err != nil {
 		return nil, err
 	}
-	// TODO(jaypipes): Handling all common region endpoint, throttling
-	// configuration, TLS, etc
+	// TODO(jaypipes): Handle throttling
 	return sess, nil
 }

--- a/services/apigatewayv2/pkg/resource/api/manager.go
+++ b/services/apigatewayv2/pkg/resource/api/manager.go
@@ -159,7 +159,7 @@ func newResourceManager(
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
-	sess, err := ackrt.NewSession()
+	sess, err := ackrt.NewSession(region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/api_mapping/manager.go
+++ b/services/apigatewayv2/pkg/resource/api_mapping/manager.go
@@ -159,7 +159,7 @@ func newResourceManager(
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
-	sess, err := ackrt.NewSession()
+	sess, err := ackrt.NewSession(region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/authorizer/manager.go
+++ b/services/apigatewayv2/pkg/resource/authorizer/manager.go
@@ -159,7 +159,7 @@ func newResourceManager(
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
-	sess, err := ackrt.NewSession()
+	sess, err := ackrt.NewSession(region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/deployment/manager.go
+++ b/services/apigatewayv2/pkg/resource/deployment/manager.go
@@ -159,7 +159,7 @@ func newResourceManager(
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
-	sess, err := ackrt.NewSession()
+	sess, err := ackrt.NewSession(region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/domain_name/manager.go
+++ b/services/apigatewayv2/pkg/resource/domain_name/manager.go
@@ -159,7 +159,7 @@ func newResourceManager(
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
-	sess, err := ackrt.NewSession()
+	sess, err := ackrt.NewSession(region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/integration/manager.go
+++ b/services/apigatewayv2/pkg/resource/integration/manager.go
@@ -159,7 +159,7 @@ func newResourceManager(
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
-	sess, err := ackrt.NewSession()
+	sess, err := ackrt.NewSession(region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/integration_response/manager.go
+++ b/services/apigatewayv2/pkg/resource/integration_response/manager.go
@@ -159,7 +159,7 @@ func newResourceManager(
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
-	sess, err := ackrt.NewSession()
+	sess, err := ackrt.NewSession(region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/model/manager.go
+++ b/services/apigatewayv2/pkg/resource/model/manager.go
@@ -159,7 +159,7 @@ func newResourceManager(
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
-	sess, err := ackrt.NewSession()
+	sess, err := ackrt.NewSession(region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/route/manager.go
+++ b/services/apigatewayv2/pkg/resource/route/manager.go
@@ -159,7 +159,7 @@ func newResourceManager(
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
-	sess, err := ackrt.NewSession()
+	sess, err := ackrt.NewSession(region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/route_response/manager.go
+++ b/services/apigatewayv2/pkg/resource/route_response/manager.go
@@ -159,7 +159,7 @@ func newResourceManager(
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
-	sess, err := ackrt.NewSession()
+	sess, err := ackrt.NewSession(region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/stage/manager.go
+++ b/services/apigatewayv2/pkg/resource/stage/manager.go
@@ -159,7 +159,7 @@ func newResourceManager(
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
-	sess, err := ackrt.NewSession()
+	sess, err := ackrt.NewSession(region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/vpc_link/manager.go
+++ b/services/apigatewayv2/pkg/resource/vpc_link/manager.go
@@ -159,7 +159,7 @@ func newResourceManager(
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
-	sess, err := ackrt.NewSession()
+	sess, err := ackrt.NewSession(region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/ecr/pkg/resource/repository/manager.go
+++ b/services/ecr/pkg/resource/repository/manager.go
@@ -159,7 +159,7 @@ func newResourceManager(
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
-	sess, err := ackrt.NewSession()
+	sess, err := ackrt.NewSession(region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/elasticache/pkg/resource/cache_subnet_group/manager.go
+++ b/services/elasticache/pkg/resource/cache_subnet_group/manager.go
@@ -159,7 +159,7 @@ func newResourceManager(
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
-	sess, err := ackrt.NewSession()
+	sess, err := ackrt.NewSession(region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/elasticache/pkg/resource/replication_group/manager.go
+++ b/services/elasticache/pkg/resource/replication_group/manager.go
@@ -159,7 +159,7 @@ func newResourceManager(
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
-	sess, err := ackrt.NewSession()
+	sess, err := ackrt.NewSession(region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/s3/pkg/resource/bucket/manager.go
+++ b/services/s3/pkg/resource/bucket/manager.go
@@ -159,7 +159,7 @@ func newResourceManager(
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
-	sess, err := ackrt.NewSession()
+	sess, err := ackrt.NewSession(region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/sns/pkg/resource/platform_application/manager.go
+++ b/services/sns/pkg/resource/platform_application/manager.go
@@ -159,7 +159,7 @@ func newResourceManager(
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
-	sess, err := ackrt.NewSession()
+	sess, err := ackrt.NewSession(region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/sns/pkg/resource/platform_endpoint/manager.go
+++ b/services/sns/pkg/resource/platform_endpoint/manager.go
@@ -159,7 +159,7 @@ func newResourceManager(
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
-	sess, err := ackrt.NewSession()
+	sess, err := ackrt.NewSession(region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/sns/pkg/resource/topic/manager.go
+++ b/services/sns/pkg/resource/topic/manager.go
@@ -159,7 +159,7 @@ func newResourceManager(
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
-	sess, err := ackrt.NewSession()
+	sess, err := ackrt.NewSession(region)
 	if err != nil {
 		return nil, err
 	}

--- a/templates/pkg/crd_manager.go.tpl
+++ b/templates/pkg/crd_manager.go.tpl
@@ -146,7 +146,7 @@ func newResourceManager(
 	id ackv1alpha1.AWSAccountID,
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
-	sess, err := ackrt.NewSession()
+	sess, err := ackrt.NewSession(region)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: This change will help us generate session with `ackv1alpha1.AWSRegion` passed via annotation instead of rely on user to pass AWS_REGION environment variable to generate session. 

Along with this, added:
1) Regional endpoint parameter instead of global endpoint. 
* Here we are going to rely on VPC private links and do not allow "custom" endpoint (not the default PrivateLink override to the regional sts endpoint) 



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
