### PR TITLE
NotFound when any required field missing in shape

### DIFF
--- a/pkg/generate/apigwv2_test.go
+++ b/pkg/generate/apigwv2_test.go
@@ -14,7 +14,7 @@
 package generate_test
 
 import (
-	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -228,12 +228,12 @@ func TestAPIGatewayV2_Route(t *testing.T) {
 `
 	assert.Equal(expCreateOutput, crd.GoCodeSetOutput(model.OpTypeCreate, "resp", "ko.Status", 1))
 
-	expRequiredStatusFieldsMissingFromReadOneInput := `
-	if r.ko.Status.RouteID == nil  {
-		return true
-	} else {
-		return false
-	}
+	expRequiredFieldsCode := `
+	return r.ko.Spec.APIID == nil || r.ko.Status.RouteID == nil
 `
-	assert.Equal(expRequiredStatusFieldsMissingFromReadOneInput, fmt.Sprintf("\n%s\n", crd.GoCodeRequiredStatusFieldsMissingFromReadOneInput("r.ko", 1)))
+	gotCode := crd.GoCodeRequiredFieldsMissingFromShape(model.OpTypeGet, "r.ko", 1)
+	assert.Equal(
+		strings.TrimSpace(expRequiredFieldsCode),
+		strings.TrimSpace(gotCode),
+	)
 }

--- a/pkg/generate/sqs_test.go
+++ b/pkg/generate/sqs_test.go
@@ -14,6 +14,7 @@
 package generate_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -173,4 +174,13 @@ func TestSQS_Queue(t *testing.T) {
 	ko.Status.ACKResourceMetadata.ARN = &tmpARN
 `
 	assert.Equal(expGetAttrsOutput, crd.GoCodeGetAttributesSetOutput("resp", "ko.Status", 1))
+
+	expRequiredFieldsCode := `
+	return r.ko.Status.QueueURL == nil
+`
+	gotCode := crd.GoCodeRequiredFieldsMissingFromShape(model.OpTypeGetAttributes, "r.ko", 1)
+	assert.Equal(
+		strings.TrimSpace(expRequiredFieldsCode),
+		strings.TrimSpace(gotCode),
+	)
 }

--- a/pkg/generate/template.go
+++ b/pkg/generate/template.go
@@ -88,8 +88,11 @@ var (
 		"Empty": func(subject string) bool {
 			return strings.TrimSpace(subject) == ""
 		},
-		"GoCodeRequiredStatusFieldsMissingFromReadOneInput": func(r *ackmodel.CRD, koVarName string, indentLevel int) string {
-			return r.GoCodeRequiredStatusFieldsMissingFromReadOneInput(koVarName, indentLevel)
+		"GoCodeRequiredFieldsMissingFromReadOneInput": func(r *ackmodel.CRD, koVarName string, indentLevel int) string {
+			return r.GoCodeRequiredFieldsMissingFromShape(ackmodel.OpTypeGet, koVarName, indentLevel)
+		},
+		"GoCodeRequiredFieldsMissingFromGetAttributesInput": func(r *ackmodel.CRD, koVarName string, indentLevel int) string {
+			return r.GoCodeRequiredFieldsMissingFromShape(ackmodel.OpTypeGetAttributes, koVarName, indentLevel)
 		},
 	}
 )

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -359,52 +359,79 @@ func (r *CRD) ExceptionCode(httpStatusCode int) string {
 	return "UNKNOWN"
 }
 
-// Return true if all the required status fields are missing from ReadOneInput. Else, return false
+// GoCodeRequiredFieldsMissingFromShape returns Go code that contains a
+// condition checking that the required fields in the supplied Shape have a
+// non-nil value in the corresponding CR's Spec or Status substruct.
+//
 // Sample Output:
-//if r.ko.Status.APIID == nil {
-//	return true
-//} else {
-//	return false
-//}
-func (r *CRD) GoCodeRequiredStatusFieldsMissingFromReadOneInput(koVarName string, indentLevel int) string {
-	out := ""
-	indent := strings.Repeat("\t", indentLevel)
-
-	var requiredKoStatusFields = r.RequiredStatusFieldsForReadOneInput()
-	if len(requiredKoStatusFields) > 0 {
-		allRequiredKoStatusFieldMissingCondition := ""
-		for _, fieldName := range requiredKoStatusFields {
-			// Use '&&' because all the requiredStatusFields should be missing if object is not created yet
-			allRequiredKoStatusFieldMissingCondition += fmt.Sprintf("%s.Status.%s == nil &&", koVarName, fieldName.Names.Camel)
-		}
-		allRequiredKoStatusFieldMissingCondition = strings.TrimSuffix(allRequiredKoStatusFieldMissingCondition, "&&")
-		out += fmt.Sprintf("%sif %s {\n", indent, allRequiredKoStatusFieldMissingCondition)
-		out += fmt.Sprintf("%s\treturn true\n", indent)
-		out += fmt.Sprintf("%s} else {\n", indent)
-		out += fmt.Sprintf("%s\treturn false\n", indent)
-		out += fmt.Sprintf("%s}", indent)
-	} else {
-		out += fmt.Sprintf("%sreturn false", indent)
+//
+// return r.ko.Spec.APIID == nil || r.ko.Status.RouteID != nil
+func (r *CRD) GoCodeRequiredFieldsMissingFromShape(
+	opType OpType,
+	koVarName string,
+	indentLevel int,
+) string {
+	var op *awssdkmodel.Operation
+	switch opType {
+	case OpTypeGet:
+		op = r.Ops.ReadOne
+	case OpTypeGetAttributes:
+		op = r.Ops.GetAttributes
+	default:
+		return ""
 	}
-	return out
+
+	shape := op.InputRef.Shape
+	return r.goCodeRequiredFieldsMissingFromShape(
+		koVarName,
+		indentLevel,
+		shape,
+	)
 }
 
-// This method returns the required fields for ReadOneInput which are present in ko.Status .
-func (r *CRD) RequiredStatusFieldsForReadOneInput() []*CRDField {
-	var requiredStatusFields []*CRDField
-	op := r.Ops.ReadOne
-	inputShape := op.InputRef.Shape
-	if inputShape == nil || len(inputShape.Required) == 0 {
-		return requiredStatusFields
+func (r *CRD) goCodeRequiredFieldsMissingFromShape(
+	koVarName string,
+	indentLevel int,
+	shape *awssdkmodel.Shape,
+) string {
+	indent := strings.Repeat("\t", indentLevel)
+	if shape == nil || len(shape.Required) == 0 {
+		return fmt.Sprintf("%sreturn false", indent)
 	}
-	requiredFieldNames := inputShape.Required
-	for _, requiredFieldName := range requiredFieldNames {
-		koStatusField, found := r.StatusFields[requiredFieldName]
+
+	// Loop over the required member fields in the shape and identify whether
+	// the field exists in either the Status or the Spec of the resource and
+	// generate an if condition checking for all required fields having non-nil
+	// corresponding resource Spec/Status values
+	missing := []string{}
+	for _, memberName := range shape.Required {
+		cleanMemberNames := names.New(memberName)
+		cleanMemberName := cleanMemberNames.Camel
+
+		resVarPath := koVarName
+		_, found := r.SpecFields[memberName]
 		if found {
-			requiredStatusFields = append(requiredStatusFields, koStatusField)
+			resVarPath = resVarPath + ".Spec." + cleanMemberName
+		} else {
+			_, found = r.StatusFields[memberName]
+			if !found {
+				// If it isn't in our spec/status fields, we have a problem!
+				msg := fmt.Sprintf(
+					"GENERATION FAILURE! there's a required field %s in "+
+						"Shape %s that isn't in either the CR's Spec or "+
+						"Status structs!",
+					memberName, shape.ShapeName,
+				)
+				panic(msg)
+			}
+			resVarPath = resVarPath + ".Status." + cleanMemberName
 		}
+		missing = append(missing, fmt.Sprintf("%s == nil", resVarPath))
 	}
-	return requiredStatusFields
+	// Use '||' because if any of the required fields are missing the object
+	// is not created yet
+	missingCondition := strings.Join(missing, " || ")
+	return fmt.Sprintf("%sreturn %s\n", indent, missingCondition)
 }
 
 // GoCodeSetInput returns the Go code that sets an input shape's member fields

--- a/test/e2e/sqs/smoke.sh
+++ b/test/e2e/sqs/smoke.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="$THIS_DIR/../../.."
+SCRIPTS_DIR="$ROOT_DIR/scripts"
+
+source "$SCRIPTS_DIR/lib/common.sh"
+source "$SCRIPTS_DIR/lib/k8s.sh"
+source "$SCRIPTS_DIR/lib/testutil.sh"
+
+test_name="$( filenoext "${BASH_SOURCE[0]}" )"
+service_name="sqs"
+ack_ctrl_pod_id=$( controller_pod_id "sqs")
+debug_msg "executing test: $service_name/$test_name"
+
+queue_name="ack-test-smoke-$service_name"
+resource_name="queues/$queue_name"
+
+get_queue_url() {
+    aws sqs get-queue-url --queue-name "$queue_name" --output json >/dev/null 2>&1
+}
+
+# PRE-CHECKS
+get_queue_url
+if [[ $? -ne 255 && $? -ne 254 ]]; then
+    echo "FAIL: expected $queue_name to not exist in SQS. Did previous test run cleanup?"
+    exit 1
+fi
+
+if k8s_resource_exists "$resource_name"; then
+    echo "FAIL: expected $resource_name to not exist. Did previous test run cleanup?"
+    exit 1
+fi
+
+# TEST ACTIONS and ASSERTIONS
+
+cat <<EOF | kubectl apply -f -
+apiVersion: sqs.services.k8s.aws/v1alpha1
+kind: Queue
+metadata:
+  name: $queue_name
+spec:
+  name: $queue_name
+EOF
+
+sleep 20
+
+debug_msg "checking queue $queue_name created in SQS"
+get_queue_url
+if [[ $? -eq 255 || $? -eq 254 ]]; then
+    echo "FAIL: expected $queue_name to have been created in SQS"
+    kubectl logs -n ack-system "$ack_ctrl_pod_id"
+    exit 1
+fi
+
+kubectl delete "$resource_name" 2>/dev/null
+assert_equal "0" "$?" "Expected success from kubectl delete but got $?" || exit 1
+
+get_queue_url
+if [[ $? -ne 255 && $? -ne 254 ]]; then
+    echo "FAIL: expected $queue_name to be deleted in SQS"
+    kubectl logs -n ack-system "$ack_ctrl_pod_id"
+    exit 1
+fi


### PR DESCRIPTION
In #271, @vijtrip2 added methods that output Go code that checked if the
Input shape for ReadOne operations for a resource had required fields
and if so, checked that the CR's `Status.{Field}` had a non-nil value,
otherwise the `resourceManager.sdkFind()` method would return
`NotFound`, indicating to callers (in particular when trying to
determine if a newly-created resource already existed) that the backend
AWS resource had not been created yet.

This patch makes that work generic in two ways:

* adds support for when required fields in an Input shape are in the
  CR's `Spec` struct in addition to the `Status` struct.
* adds support for any Input shape, not just the ReadOne operation's
  Input shape.

For SQS, the GetQueueAttributes' Input shape has required fields
(QueueUrl) that, if not present in the CR's `Status` struct, indicate
the resource has not been created yet.

Issue #287

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
