### PR TITLE
Enable finegrained diffs, update() args include desired state, latest state

### DIFF
--- a/mocks/pkg/types/aws_resource_manager.go
+++ b/mocks/pkg/types/aws_resource_manager.go
@@ -91,13 +91,13 @@ func (_m *AWSResourceManager) ReadOne(_a0 context.Context, _a1 types.AWSResource
 	return r0, r1
 }
 
-// Update provides a mock function with given fields: _a0, _a1, _a2
-func (_m *AWSResourceManager) Update(_a0 context.Context, _a1 types.AWSResource, _a2 *compare.Reporter) (types.AWSResource, error) {
-	ret := _m.Called(_a0, _a1, _a2)
+// Update provides a mock function with given fields: _a0, _a1, _a2, _a3
+func (_m *AWSResourceManager) Update(_a0 context.Context, _a1 types.AWSResource, _a2 types.AWSResource, _a3 *compare.Reporter) (types.AWSResource, error) {
+	ret := _m.Called(_a0, _a1, _a2, _a3)
 
 	var r0 types.AWSResource
-	if rf, ok := ret.Get(0).(func(context.Context, types.AWSResource, *compare.Reporter) types.AWSResource); ok {
-		r0 = rf(_a0, _a1, _a2)
+	if rf, ok := ret.Get(0).(func(context.Context, types.AWSResource, types.AWSResource, *compare.Reporter) types.AWSResource); ok {
+		r0 = rf(_a0, _a1, _a2, _a3)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(types.AWSResource)
@@ -105,8 +105,8 @@ func (_m *AWSResourceManager) Update(_a0 context.Context, _a1 types.AWSResource,
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, types.AWSResource, *compare.Reporter) error); ok {
-		r1 = rf(_a0, _a1, _a2)
+	if rf, ok := ret.Get(1).(func(context.Context, types.AWSResource, types.AWSResource, *compare.Reporter) error); ok {
+		r1 = rf(_a0, _a1, _a2, _a3)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/generate/config/config.go
+++ b/pkg/generate/config/config.go
@@ -35,8 +35,9 @@ type Config struct {
 }
 
 // OperationConfig represents instructions to the ACK code generator to
-// specify the overriding values for API operation parameters
+// specify the overriding values for API operation parameters and its custom implementation.
 type OperationConfig struct {
+	CustomImplementation string `json:"custom_implementation,omitempty"`
 	OverrideValues map[string]string `json:"override_values"`
 	// SetOutputCustomMethodName provides the name of the custom method on the
 	// `resourceManager` struct that will set fields on a `resource` struct
@@ -77,15 +78,6 @@ type ResourceConfig struct {
 	// need these instructions.
 	Exceptions *ExceptionsConfig `json:"exceptions,omitempty"`
 
-	// CustomUpdateOperations provides custom operations that depend upon the
-	// changes to the fields on custom resource.
-	// For APIs where resource Update method does not have all fields that
-	// are supported by resource Create method and remaining fields have
-	// specialized API methods.
-	// Maps custom operation name (key) to list of Resource fields paths (values)
-	// so that custom operation is invoked if field value changes.
-	CustomUpdateOperations map[string]CustomUpdateOperationConfig `json:"custom_update_operations,omitempty"`
-
 	// Renames identifies fields in Operations that should be renamed.
 	Renames *RenamesConfig `json:"renames,omitempty"`
 	// ListOperation contains instructions for the code generator to generate
@@ -98,14 +90,6 @@ type ResourceConfig struct {
 	// filter the results of these List operations from within the generated
 	// code in sdk.go's sdkFind().
 	ListOperation *ListOperationConfig `json:"list_operation,omitempty"`
-}
-
-// Custom resource fields paths list that map to custom operation
-type CustomUpdateOperationConfig struct {
-	// string paths to fields on the custom resource
-	// Example:
-	//  For field ReplicationGroup.Spec.ReplicasPerNodeGroup, the string value would be: Spec.ReplicasPerNodeGroup
-	DiffPaths []string `json:"diff_paths"`
 }
 
 // UnpackAttributesMapConfig informs the code generator that the API follows a

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -313,6 +313,7 @@ func (r *CRD) IsPrimaryARNField(fieldName string) bool {
 		strings.EqualFold(fieldName, r.Names.Original+"arn")
 }
 
+
 // SetOutputCustomMethodName returns custom set output operation as *string for
 // given operation on custom resource, if specified in generator config
 func (r *CRD) SetOutputCustomMethodName(
@@ -332,34 +333,22 @@ func (r *CRD) SetOutputCustomMethodName(
 	return &resGenConfig.SetOutputCustomMethodName
 }
 
-// HasCustomUpdateOperations returns true if the resource has custom update operations
-// specified in generator config
-func (r *CRD) HasCustomUpdateOperations() bool {
-	if r.genCfg != nil {
-		resGenConfig, found := r.genCfg.Resources[r.Names.Original]
-		if found && resGenConfig.CustomUpdateOperations != nil {
-			return true
-		}
+// GetCustomImplementation returns custom implementation method name for the
+// supplied operation as specified in generator config
+func (r *CRD) GetCustomImplementation(
+// The type of operation
+	op *awssdkmodel.Operation,
+) string {
+	if op == nil || r.genCfg == nil {
+		return ""
 	}
-	return false
-}
 
-// GetCustomUpdateOperations returns map of diff path (as key) and custom operation (as value) on custom resource,
-// as specified in generator config
-func (r *CRD) GetCustomUpdateOperations() map[string]string {
-	var diffPathToCustomOperationMap map[string]string
-	if r.genCfg != nil {
-		diffPathToCustomOperationMap = make(map[string]string)
-		resGenConfig, found := r.genCfg.Resources[r.Names.Original]
-		if found && resGenConfig.CustomUpdateOperations != nil {
-			for customOperation, fields := range resGenConfig.CustomUpdateOperations {
-				for _, diffPath := range fields.DiffPaths {
-					diffPathToCustomOperationMap[diffPath] = customOperation
-				}
-			}
-		}
+	operationConfig, found := r.genCfg.Operations[op.Name]
+	if !found {
+		return ""
 	}
-	return diffPathToCustomOperationMap
+
+	return operationConfig.CustomImplementation
 }
 
 // ExceptionCode returns the name of the resource's Exception code for the

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -170,7 +170,7 @@ func (r *reconciler) sync(
 			"arn", latest.Identifiers().ARN(),
 			"is_adopted", isAdopted,
 		)
-		latest, err = rm.Update(ctx, desired, diffReporter)
+		latest, err = rm.Update(ctx, desired, latest, diffReporter)
 		if err != nil {
 			return err
 		}

--- a/pkg/types/aws_resource_manager.go
+++ b/pkg/types/aws_resource_manager.go
@@ -37,14 +37,15 @@ type AWSResourceManager interface {
 	// service API, returning an AWSResource representing the newly-created
 	// resource
 	Create(context.Context, AWSResource) (AWSResource, error)
-	// Update attempts to mutate the supplied AWSResource in the backend AWS
+	// Update attempts to mutate the supplied desired AWSResource in the backend AWS
 	// service API, returning an AWSResource representing the newly-mutated
-	// resource. Note that implementers should NOT check to see if the latest
+	// resource.
+	// Note for specialized logic implementers can check to see how the latest
 	// observed resource differs from the supplied desired state. The
 	// higher-level reonciler determines whether or not the desired differs
 	// from the latest observed and decides whether to call the resource
 	// manager's Update method
-	Update(context.Context, AWSResource, *ackcompare.Reporter) (AWSResource, error)
+	Update(context.Context, /*desired*/ AWSResource, /*latest*/ AWSResource, *ackcompare.Reporter) (AWSResource, error)
 
 	// Delete attempts to destroy the supplied AWSResource in the backend AWS
 	// service API.

--- a/services/apigatewayv2/pkg/resource/api/manager.go
+++ b/services/apigatewayv2/pkg/resource/api/manager.go
@@ -98,23 +98,27 @@ func (rm *resourceManager) Create(
 	return created, nil
 }
 
-// Update attempts to mutate the supplied AWSResource in the backend AWS
+// Update attempts to mutate the supplied desired AWSResource in the backend AWS
 // service API, returning an AWSResource representing the newly-mutated
-// resource. Note that implementers should NOT check to see if the latest
-// observed resource differs from the supplied desired state. The higher-level
-// reonciler determines whether or not the desired differs from the latest
-// observed and decides whether to call the resource manager's Update method
+// resource.
+// Note for specialized logic implementers can check to see how the latest
+// observed resource differs from the supplied desired state. The
+// higher-level reonciler determines whether or not the desired differs
+// from the latest observed and decides whether to call the resource
+// manager's Update method
 func (rm *resourceManager) Update(
 	ctx context.Context,
-	res acktypes.AWSResource,
+	resDesired acktypes.AWSResource,
+	resLatest acktypes.AWSResource,
 	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
-	r := rm.concreteResource(res)
-	if r.ko == nil {
+	desired := rm.concreteResource(resDesired)
+	latest := rm.concreteResource(resLatest)
+	if desired.ko == nil || latest.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
+	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/api/sdk.go
+++ b/services/apigatewayv2/pkg/resource/api/sdk.go
@@ -298,10 +298,12 @@ func (rm *resourceManager) newCreateRequestPayload(
 // returns a new resource with updated fields.
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
-	r *resource,
+	desired *resource,
+	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
-	input, err := rm.newUpdateRequestPayload(r)
+
+	input, err := rm.newUpdateRequestPayload(desired)
 	if err != nil {
 		return nil, err
 	}
@@ -312,7 +314,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := r.ko.DeepCopy()
+	ko := desired.ko.DeepCopy()
 
 	if resp.ApiEndpoint != nil {
 		ko.Status.APIEndpoint = resp.ApiEndpoint

--- a/services/apigatewayv2/pkg/resource/api_mapping/manager.go
+++ b/services/apigatewayv2/pkg/resource/api_mapping/manager.go
@@ -98,23 +98,27 @@ func (rm *resourceManager) Create(
 	return created, nil
 }
 
-// Update attempts to mutate the supplied AWSResource in the backend AWS
+// Update attempts to mutate the supplied desired AWSResource in the backend AWS
 // service API, returning an AWSResource representing the newly-mutated
-// resource. Note that implementers should NOT check to see if the latest
-// observed resource differs from the supplied desired state. The higher-level
-// reonciler determines whether or not the desired differs from the latest
-// observed and decides whether to call the resource manager's Update method
+// resource.
+// Note for specialized logic implementers can check to see how the latest
+// observed resource differs from the supplied desired state. The
+// higher-level reonciler determines whether or not the desired differs
+// from the latest observed and decides whether to call the resource
+// manager's Update method
 func (rm *resourceManager) Update(
 	ctx context.Context,
-	res acktypes.AWSResource,
+	resDesired acktypes.AWSResource,
+	resLatest acktypes.AWSResource,
 	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
-	r := rm.concreteResource(res)
-	if r.ko == nil {
+	desired := rm.concreteResource(resDesired)
+	latest := rm.concreteResource(resLatest)
+	if desired.ko == nil || latest.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
+	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/api_mapping/sdk.go
+++ b/services/apigatewayv2/pkg/resource/api_mapping/sdk.go
@@ -175,10 +175,12 @@ func (rm *resourceManager) newCreateRequestPayload(
 // returns a new resource with updated fields.
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
-	r *resource,
+	desired *resource,
+	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
-	input, err := rm.newUpdateRequestPayload(r)
+
+	input, err := rm.newUpdateRequestPayload(desired)
 	if err != nil {
 		return nil, err
 	}
@@ -189,7 +191,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := r.ko.DeepCopy()
+	ko := desired.ko.DeepCopy()
 
 	if resp.ApiMappingId != nil {
 		ko.Status.APIMappingID = resp.ApiMappingId

--- a/services/apigatewayv2/pkg/resource/authorizer/manager.go
+++ b/services/apigatewayv2/pkg/resource/authorizer/manager.go
@@ -98,23 +98,27 @@ func (rm *resourceManager) Create(
 	return created, nil
 }
 
-// Update attempts to mutate the supplied AWSResource in the backend AWS
+// Update attempts to mutate the supplied desired AWSResource in the backend AWS
 // service API, returning an AWSResource representing the newly-mutated
-// resource. Note that implementers should NOT check to see if the latest
-// observed resource differs from the supplied desired state. The higher-level
-// reonciler determines whether or not the desired differs from the latest
-// observed and decides whether to call the resource manager's Update method
+// resource.
+// Note for specialized logic implementers can check to see how the latest
+// observed resource differs from the supplied desired state. The
+// higher-level reonciler determines whether or not the desired differs
+// from the latest observed and decides whether to call the resource
+// manager's Update method
 func (rm *resourceManager) Update(
 	ctx context.Context,
-	res acktypes.AWSResource,
+	resDesired acktypes.AWSResource,
+	resLatest acktypes.AWSResource,
 	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
-	r := rm.concreteResource(res)
-	if r.ko == nil {
+	desired := rm.concreteResource(resDesired)
+	latest := rm.concreteResource(resLatest)
+	if desired.ko == nil || latest.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
+	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/authorizer/sdk.go
+++ b/services/apigatewayv2/pkg/resource/authorizer/sdk.go
@@ -215,10 +215,12 @@ func (rm *resourceManager) newCreateRequestPayload(
 // returns a new resource with updated fields.
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
-	r *resource,
+	desired *resource,
+	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
-	input, err := rm.newUpdateRequestPayload(r)
+
+	input, err := rm.newUpdateRequestPayload(desired)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +231,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := r.ko.DeepCopy()
+	ko := desired.ko.DeepCopy()
 
 	if resp.AuthorizerId != nil {
 		ko.Status.AuthorizerID = resp.AuthorizerId

--- a/services/apigatewayv2/pkg/resource/deployment/manager.go
+++ b/services/apigatewayv2/pkg/resource/deployment/manager.go
@@ -98,23 +98,27 @@ func (rm *resourceManager) Create(
 	return created, nil
 }
 
-// Update attempts to mutate the supplied AWSResource in the backend AWS
+// Update attempts to mutate the supplied desired AWSResource in the backend AWS
 // service API, returning an AWSResource representing the newly-mutated
-// resource. Note that implementers should NOT check to see if the latest
-// observed resource differs from the supplied desired state. The higher-level
-// reonciler determines whether or not the desired differs from the latest
-// observed and decides whether to call the resource manager's Update method
+// resource.
+// Note for specialized logic implementers can check to see how the latest
+// observed resource differs from the supplied desired state. The
+// higher-level reonciler determines whether or not the desired differs
+// from the latest observed and decides whether to call the resource
+// manager's Update method
 func (rm *resourceManager) Update(
 	ctx context.Context,
-	res acktypes.AWSResource,
+	resDesired acktypes.AWSResource,
+	resLatest acktypes.AWSResource,
 	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
-	r := rm.concreteResource(res)
-	if r.ko == nil {
+	desired := rm.concreteResource(resDesired)
+	latest := rm.concreteResource(resLatest)
+	if desired.ko == nil || latest.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
+	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/deployment/sdk.go
+++ b/services/apigatewayv2/pkg/resource/deployment/sdk.go
@@ -196,10 +196,12 @@ func (rm *resourceManager) newCreateRequestPayload(
 // returns a new resource with updated fields.
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
-	r *resource,
+	desired *resource,
+	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
-	input, err := rm.newUpdateRequestPayload(r)
+
+	input, err := rm.newUpdateRequestPayload(desired)
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +212,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := r.ko.DeepCopy()
+	ko := desired.ko.DeepCopy()
 
 	if resp.AutoDeployed != nil {
 		ko.Status.AutoDeployed = resp.AutoDeployed

--- a/services/apigatewayv2/pkg/resource/domain_name/manager.go
+++ b/services/apigatewayv2/pkg/resource/domain_name/manager.go
@@ -98,23 +98,27 @@ func (rm *resourceManager) Create(
 	return created, nil
 }
 
-// Update attempts to mutate the supplied AWSResource in the backend AWS
+// Update attempts to mutate the supplied desired AWSResource in the backend AWS
 // service API, returning an AWSResource representing the newly-mutated
-// resource. Note that implementers should NOT check to see if the latest
-// observed resource differs from the supplied desired state. The higher-level
-// reonciler determines whether or not the desired differs from the latest
-// observed and decides whether to call the resource manager's Update method
+// resource.
+// Note for specialized logic implementers can check to see how the latest
+// observed resource differs from the supplied desired state. The
+// higher-level reonciler determines whether or not the desired differs
+// from the latest observed and decides whether to call the resource
+// manager's Update method
 func (rm *resourceManager) Update(
 	ctx context.Context,
-	res acktypes.AWSResource,
+	resDesired acktypes.AWSResource,
+	resLatest acktypes.AWSResource,
 	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
-	r := rm.concreteResource(res)
-	if r.ko == nil {
+	desired := rm.concreteResource(resDesired)
+	latest := rm.concreteResource(resLatest)
+	if desired.ko == nil || latest.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
+	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/domain_name/sdk.go
+++ b/services/apigatewayv2/pkg/resource/domain_name/sdk.go
@@ -213,10 +213,12 @@ func (rm *resourceManager) newCreateRequestPayload(
 // returns a new resource with updated fields.
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
-	r *resource,
+	desired *resource,
+	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
-	input, err := rm.newUpdateRequestPayload(r)
+
+	input, err := rm.newUpdateRequestPayload(desired)
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +229,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := r.ko.DeepCopy()
+	ko := desired.ko.DeepCopy()
 
 	if resp.ApiMappingSelectionExpression != nil {
 		ko.Status.APIMappingSelectionExpression = resp.ApiMappingSelectionExpression

--- a/services/apigatewayv2/pkg/resource/integration/manager.go
+++ b/services/apigatewayv2/pkg/resource/integration/manager.go
@@ -98,23 +98,27 @@ func (rm *resourceManager) Create(
 	return created, nil
 }
 
-// Update attempts to mutate the supplied AWSResource in the backend AWS
+// Update attempts to mutate the supplied desired AWSResource in the backend AWS
 // service API, returning an AWSResource representing the newly-mutated
-// resource. Note that implementers should NOT check to see if the latest
-// observed resource differs from the supplied desired state. The higher-level
-// reonciler determines whether or not the desired differs from the latest
-// observed and decides whether to call the resource manager's Update method
+// resource.
+// Note for specialized logic implementers can check to see how the latest
+// observed resource differs from the supplied desired state. The
+// higher-level reonciler determines whether or not the desired differs
+// from the latest observed and decides whether to call the resource
+// manager's Update method
 func (rm *resourceManager) Update(
 	ctx context.Context,
-	res acktypes.AWSResource,
+	resDesired acktypes.AWSResource,
+	resLatest acktypes.AWSResource,
 	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
-	r := rm.concreteResource(res)
-	if r.ko == nil {
+	desired := rm.concreteResource(resDesired)
+	latest := rm.concreteResource(resLatest)
+	if desired.ko == nil || latest.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
+	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/integration/sdk.go
+++ b/services/apigatewayv2/pkg/resource/integration/sdk.go
@@ -242,10 +242,12 @@ func (rm *resourceManager) newCreateRequestPayload(
 // returns a new resource with updated fields.
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
-	r *resource,
+	desired *resource,
+	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
-	input, err := rm.newUpdateRequestPayload(r)
+
+	input, err := rm.newUpdateRequestPayload(desired)
 	if err != nil {
 		return nil, err
 	}
@@ -256,7 +258,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := r.ko.DeepCopy()
+	ko := desired.ko.DeepCopy()
 
 	if resp.ApiGatewayManaged != nil {
 		ko.Status.APIGatewayManaged = resp.ApiGatewayManaged

--- a/services/apigatewayv2/pkg/resource/integration_response/manager.go
+++ b/services/apigatewayv2/pkg/resource/integration_response/manager.go
@@ -98,23 +98,27 @@ func (rm *resourceManager) Create(
 	return created, nil
 }
 
-// Update attempts to mutate the supplied AWSResource in the backend AWS
+// Update attempts to mutate the supplied desired AWSResource in the backend AWS
 // service API, returning an AWSResource representing the newly-mutated
-// resource. Note that implementers should NOT check to see if the latest
-// observed resource differs from the supplied desired state. The higher-level
-// reonciler determines whether or not the desired differs from the latest
-// observed and decides whether to call the resource manager's Update method
+// resource.
+// Note for specialized logic implementers can check to see how the latest
+// observed resource differs from the supplied desired state. The
+// higher-level reonciler determines whether or not the desired differs
+// from the latest observed and decides whether to call the resource
+// manager's Update method
 func (rm *resourceManager) Update(
 	ctx context.Context,
-	res acktypes.AWSResource,
+	resDesired acktypes.AWSResource,
+	resLatest acktypes.AWSResource,
 	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
-	r := rm.concreteResource(res)
-	if r.ko == nil {
+	desired := rm.concreteResource(resDesired)
+	latest := rm.concreteResource(resLatest)
+	if desired.ko == nil || latest.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
+	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/integration_response/sdk.go
+++ b/services/apigatewayv2/pkg/resource/integration_response/sdk.go
@@ -202,10 +202,12 @@ func (rm *resourceManager) newCreateRequestPayload(
 // returns a new resource with updated fields.
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
-	r *resource,
+	desired *resource,
+	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
-	input, err := rm.newUpdateRequestPayload(r)
+
+	input, err := rm.newUpdateRequestPayload(desired)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +218,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := r.ko.DeepCopy()
+	ko := desired.ko.DeepCopy()
 
 	if resp.IntegrationResponseId != nil {
 		ko.Status.IntegrationResponseID = resp.IntegrationResponseId

--- a/services/apigatewayv2/pkg/resource/model/manager.go
+++ b/services/apigatewayv2/pkg/resource/model/manager.go
@@ -98,23 +98,27 @@ func (rm *resourceManager) Create(
 	return created, nil
 }
 
-// Update attempts to mutate the supplied AWSResource in the backend AWS
+// Update attempts to mutate the supplied desired AWSResource in the backend AWS
 // service API, returning an AWSResource representing the newly-mutated
-// resource. Note that implementers should NOT check to see if the latest
-// observed resource differs from the supplied desired state. The higher-level
-// reonciler determines whether or not the desired differs from the latest
-// observed and decides whether to call the resource manager's Update method
+// resource.
+// Note for specialized logic implementers can check to see how the latest
+// observed resource differs from the supplied desired state. The
+// higher-level reonciler determines whether or not the desired differs
+// from the latest observed and decides whether to call the resource
+// manager's Update method
 func (rm *resourceManager) Update(
 	ctx context.Context,
-	res acktypes.AWSResource,
+	resDesired acktypes.AWSResource,
+	resLatest acktypes.AWSResource,
 	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
-	r := rm.concreteResource(res)
-	if r.ko == nil {
+	desired := rm.concreteResource(resDesired)
+	latest := rm.concreteResource(resLatest)
+	if desired.ko == nil || latest.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
+	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/model/sdk.go
+++ b/services/apigatewayv2/pkg/resource/model/sdk.go
@@ -178,10 +178,12 @@ func (rm *resourceManager) newCreateRequestPayload(
 // returns a new resource with updated fields.
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
-	r *resource,
+	desired *resource,
+	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
-	input, err := rm.newUpdateRequestPayload(r)
+
+	input, err := rm.newUpdateRequestPayload(desired)
 	if err != nil {
 		return nil, err
 	}
@@ -192,7 +194,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := r.ko.DeepCopy()
+	ko := desired.ko.DeepCopy()
 
 	if resp.ModelId != nil {
 		ko.Status.ModelID = resp.ModelId

--- a/services/apigatewayv2/pkg/resource/route/manager.go
+++ b/services/apigatewayv2/pkg/resource/route/manager.go
@@ -98,23 +98,27 @@ func (rm *resourceManager) Create(
 	return created, nil
 }
 
-// Update attempts to mutate the supplied AWSResource in the backend AWS
+// Update attempts to mutate the supplied desired AWSResource in the backend AWS
 // service API, returning an AWSResource representing the newly-mutated
-// resource. Note that implementers should NOT check to see if the latest
-// observed resource differs from the supplied desired state. The higher-level
-// reonciler determines whether or not the desired differs from the latest
-// observed and decides whether to call the resource manager's Update method
+// resource.
+// Note for specialized logic implementers can check to see how the latest
+// observed resource differs from the supplied desired state. The
+// higher-level reonciler determines whether or not the desired differs
+// from the latest observed and decides whether to call the resource
+// manager's Update method
 func (rm *resourceManager) Update(
 	ctx context.Context,
-	res acktypes.AWSResource,
+	resDesired acktypes.AWSResource,
+	resLatest acktypes.AWSResource,
 	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
-	r := rm.concreteResource(res)
-	if r.ko == nil {
+	desired := rm.concreteResource(resDesired)
+	latest := rm.concreteResource(resLatest)
+	if desired.ko == nil || latest.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
+	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/route/sdk.go
+++ b/services/apigatewayv2/pkg/resource/route/sdk.go
@@ -225,10 +225,12 @@ func (rm *resourceManager) newCreateRequestPayload(
 // returns a new resource with updated fields.
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
-	r *resource,
+	desired *resource,
+	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
-	input, err := rm.newUpdateRequestPayload(r)
+
+	input, err := rm.newUpdateRequestPayload(desired)
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +241,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := r.ko.DeepCopy()
+	ko := desired.ko.DeepCopy()
 
 	if resp.ApiGatewayManaged != nil {
 		ko.Status.APIGatewayManaged = resp.ApiGatewayManaged

--- a/services/apigatewayv2/pkg/resource/route_response/manager.go
+++ b/services/apigatewayv2/pkg/resource/route_response/manager.go
@@ -98,23 +98,27 @@ func (rm *resourceManager) Create(
 	return created, nil
 }
 
-// Update attempts to mutate the supplied AWSResource in the backend AWS
+// Update attempts to mutate the supplied desired AWSResource in the backend AWS
 // service API, returning an AWSResource representing the newly-mutated
-// resource. Note that implementers should NOT check to see if the latest
-// observed resource differs from the supplied desired state. The higher-level
-// reonciler determines whether or not the desired differs from the latest
-// observed and decides whether to call the resource manager's Update method
+// resource.
+// Note for specialized logic implementers can check to see how the latest
+// observed resource differs from the supplied desired state. The
+// higher-level reonciler determines whether or not the desired differs
+// from the latest observed and decides whether to call the resource
+// manager's Update method
 func (rm *resourceManager) Update(
 	ctx context.Context,
-	res acktypes.AWSResource,
+	resDesired acktypes.AWSResource,
+	resLatest acktypes.AWSResource,
 	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
-	r := rm.concreteResource(res)
-	if r.ko == nil {
+	desired := rm.concreteResource(resDesired)
+	latest := rm.concreteResource(resLatest)
+	if desired.ko == nil || latest.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
+	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/route_response/sdk.go
+++ b/services/apigatewayv2/pkg/resource/route_response/sdk.go
@@ -201,10 +201,12 @@ func (rm *resourceManager) newCreateRequestPayload(
 // returns a new resource with updated fields.
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
-	r *resource,
+	desired *resource,
+	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
-	input, err := rm.newUpdateRequestPayload(r)
+
+	input, err := rm.newUpdateRequestPayload(desired)
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +217,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := r.ko.DeepCopy()
+	ko := desired.ko.DeepCopy()
 
 	if resp.RouteResponseId != nil {
 		ko.Status.RouteResponseID = resp.RouteResponseId

--- a/services/apigatewayv2/pkg/resource/stage/manager.go
+++ b/services/apigatewayv2/pkg/resource/stage/manager.go
@@ -98,23 +98,27 @@ func (rm *resourceManager) Create(
 	return created, nil
 }
 
-// Update attempts to mutate the supplied AWSResource in the backend AWS
+// Update attempts to mutate the supplied desired AWSResource in the backend AWS
 // service API, returning an AWSResource representing the newly-mutated
-// resource. Note that implementers should NOT check to see if the latest
-// observed resource differs from the supplied desired state. The higher-level
-// reonciler determines whether or not the desired differs from the latest
-// observed and decides whether to call the resource manager's Update method
+// resource.
+// Note for specialized logic implementers can check to see how the latest
+// observed resource differs from the supplied desired state. The
+// higher-level reonciler determines whether or not the desired differs
+// from the latest observed and decides whether to call the resource
+// manager's Update method
 func (rm *resourceManager) Update(
 	ctx context.Context,
-	res acktypes.AWSResource,
+	resDesired acktypes.AWSResource,
+	resLatest acktypes.AWSResource,
 	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
-	r := rm.concreteResource(res)
-	if r.ko == nil {
+	desired := rm.concreteResource(resDesired)
+	latest := rm.concreteResource(resLatest)
+	if desired.ko == nil || latest.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
+	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/stage/sdk.go
+++ b/services/apigatewayv2/pkg/resource/stage/sdk.go
@@ -269,10 +269,12 @@ func (rm *resourceManager) newCreateRequestPayload(
 // returns a new resource with updated fields.
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
-	r *resource,
+	desired *resource,
+	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
-	input, err := rm.newUpdateRequestPayload(r)
+
+	input, err := rm.newUpdateRequestPayload(desired)
 	if err != nil {
 		return nil, err
 	}
@@ -283,7 +285,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := r.ko.DeepCopy()
+	ko := desired.ko.DeepCopy()
 
 	if resp.ApiGatewayManaged != nil {
 		ko.Status.APIGatewayManaged = resp.ApiGatewayManaged

--- a/services/apigatewayv2/pkg/resource/vpc_link/manager.go
+++ b/services/apigatewayv2/pkg/resource/vpc_link/manager.go
@@ -98,23 +98,27 @@ func (rm *resourceManager) Create(
 	return created, nil
 }
 
-// Update attempts to mutate the supplied AWSResource in the backend AWS
+// Update attempts to mutate the supplied desired AWSResource in the backend AWS
 // service API, returning an AWSResource representing the newly-mutated
-// resource. Note that implementers should NOT check to see if the latest
-// observed resource differs from the supplied desired state. The higher-level
-// reonciler determines whether or not the desired differs from the latest
-// observed and decides whether to call the resource manager's Update method
+// resource.
+// Note for specialized logic implementers can check to see how the latest
+// observed resource differs from the supplied desired state. The
+// higher-level reonciler determines whether or not the desired differs
+// from the latest observed and decides whether to call the resource
+// manager's Update method
 func (rm *resourceManager) Update(
 	ctx context.Context,
-	res acktypes.AWSResource,
+	resDesired acktypes.AWSResource,
+	resLatest acktypes.AWSResource,
 	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
-	r := rm.concreteResource(res)
-	if r.ko == nil {
+	desired := rm.concreteResource(resDesired)
+	latest := rm.concreteResource(resLatest)
+	if desired.ko == nil || latest.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
+	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/vpc_link/sdk.go
+++ b/services/apigatewayv2/pkg/resource/vpc_link/sdk.go
@@ -210,10 +210,12 @@ func (rm *resourceManager) newCreateRequestPayload(
 // returns a new resource with updated fields.
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
-	r *resource,
+	desired *resource,
+	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
-	input, err := rm.newUpdateRequestPayload(r)
+
+	input, err := rm.newUpdateRequestPayload(desired)
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +226,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := r.ko.DeepCopy()
+	ko := desired.ko.DeepCopy()
 
 	if resp.CreatedDate != nil {
 		ko.Status.CreatedDate = &metav1.Time{*resp.CreatedDate}

--- a/services/ecr/pkg/resource/repository/manager.go
+++ b/services/ecr/pkg/resource/repository/manager.go
@@ -98,23 +98,27 @@ func (rm *resourceManager) Create(
 	return created, nil
 }
 
-// Update attempts to mutate the supplied AWSResource in the backend AWS
+// Update attempts to mutate the supplied desired AWSResource in the backend AWS
 // service API, returning an AWSResource representing the newly-mutated
-// resource. Note that implementers should NOT check to see if the latest
-// observed resource differs from the supplied desired state. The higher-level
-// reonciler determines whether or not the desired differs from the latest
-// observed and decides whether to call the resource manager's Update method
+// resource.
+// Note for specialized logic implementers can check to see how the latest
+// observed resource differs from the supplied desired state. The
+// higher-level reonciler determines whether or not the desired differs
+// from the latest observed and decides whether to call the resource
+// manager's Update method
 func (rm *resourceManager) Update(
 	ctx context.Context,
-	res acktypes.AWSResource,
+	resDesired acktypes.AWSResource,
+	resLatest acktypes.AWSResource,
 	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
-	r := rm.concreteResource(res)
-	if r.ko == nil {
+	desired := rm.concreteResource(resDesired)
+	latest := rm.concreteResource(resLatest)
+	if desired.ko == nil || latest.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
+	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/ecr/pkg/resource/repository/sdk.go
+++ b/services/ecr/pkg/resource/repository/sdk.go
@@ -231,7 +231,8 @@ func (rm *resourceManager) newCreateRequestPayload(
 // returns a new resource with updated fields.
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
-	r *resource,
+	desired *resource,
+	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 	// TODO(jaypipes): Figure this out...

--- a/services/elasticache/generator.yaml
+++ b/services/elasticache/generator.yaml
@@ -3,20 +3,13 @@ resources:
     exceptions:
       codes:
         404: CacheSubnetGroupNotFoundFault
-  ReplicationGroup:
-    custom_update_operations:
-      UpdateShardConfiguration:
-        diff_paths:
-          - Spec.NumNodeGroups
-      UpdateReplicaCount:
-        diff_paths:
-          - Spec.ReplicasPerNodeGroup
 operations:
   DescribeReplicationGroups:
     set_output_custom_method_name: CustomDescribeReplicationGroupsSetOutput
   CreateReplicationGroup:
     set_output_custom_method_name: CustomCreateReplicationGroupSetOutput
   ModifyReplicationGroup:
+    custom_implementation: CustomModifyReplicationGroup
     set_output_custom_method_name: CustomModifyReplicationGroupSetOutput
     override_values:
       ApplyImmediately: true

--- a/services/elasticache/pkg/resource/cache_subnet_group/manager.go
+++ b/services/elasticache/pkg/resource/cache_subnet_group/manager.go
@@ -98,23 +98,28 @@ func (rm *resourceManager) Create(
 	return created, nil
 }
 
-// Update attempts to mutate the supplied AWSResource in the backend AWS
+// Update attempts to mutate the supplied desired AWSResource in the backend AWS
 // service API, returning an AWSResource representing the newly-mutated
-// resource. Note that implementers should NOT check to see if the latest
-// observed resource differs from the supplied desired state. The higher-level
-// reonciler determines whether or not the desired differs from the latest
-// observed and decides whether to call the resource manager's Update method
+// resource.
+// Note for specialized logic implementers can check to see how the latest
+// observed resource differs from the supplied desired state. The
+// higher-level reonciler determines whether or not the desired differs
+// from the latest observed and decides whether to call the resource
+// manager's Update method
 func (rm *resourceManager) Update(
 	ctx context.Context,
-	res acktypes.AWSResource,
+	resDesired acktypes.AWSResource, // desired
+	resLatest acktypes.AWSResource, // latest
 	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
-	r := rm.concreteResource(res)
-	if r.ko == nil {
+	rd := rm.concreteResource(resDesired)
+	rl := rm.concreteResource(resLatest)
+	if rd.ko == nil || rl.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
+
+	updated, err := rm.sdkUpdate(ctx, rd, rl, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/elasticache/pkg/resource/cache_subnet_group/manager.go
+++ b/services/elasticache/pkg/resource/cache_subnet_group/manager.go
@@ -108,18 +108,17 @@ func (rm *resourceManager) Create(
 // manager's Update method
 func (rm *resourceManager) Update(
 	ctx context.Context,
-	resDesired acktypes.AWSResource, // desired
-	resLatest acktypes.AWSResource, // latest
+	resDesired acktypes.AWSResource,
+	resLatest acktypes.AWSResource,
 	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
-	rd := rm.concreteResource(resDesired)
-	rl := rm.concreteResource(resLatest)
-	if rd.ko == nil || rl.ko == nil {
+	desired := rm.concreteResource(resDesired)
+	latest := rm.concreteResource(resLatest)
+	if desired.ko == nil || latest.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-
-	updated, err := rm.sdkUpdate(ctx, rd, rl, diffReporter)
+	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/elasticache/pkg/resource/cache_subnet_group/sdk.go
+++ b/services/elasticache/pkg/resource/cache_subnet_group/sdk.go
@@ -211,12 +211,12 @@ func (rm *resourceManager) newCreateRequestPayload(
 // returns a new resource with updated fields.
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
-	rd *resource, // desired
-	rl *resource, // latest
+	desired *resource,
+	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 
-	input, err := rm.newUpdateRequestPayload(rd)
+	input, err := rm.newUpdateRequestPayload(desired)
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +227,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := rd.ko.DeepCopy()
+	ko := desired.ko.DeepCopy()
 
 	if ko.Status.ACKResourceMetadata == nil {
 		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}

--- a/services/elasticache/pkg/resource/cache_subnet_group/sdk.go
+++ b/services/elasticache/pkg/resource/cache_subnet_group/sdk.go
@@ -211,10 +211,12 @@ func (rm *resourceManager) newCreateRequestPayload(
 // returns a new resource with updated fields.
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
-	r *resource,
+	rd *resource, // desired
+	rl *resource, // latest
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
-	input, err := rm.newUpdateRequestPayload(r)
+
+	input, err := rm.newUpdateRequestPayload(rd)
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +227,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := r.ko.DeepCopy()
+	ko := rd.ko.DeepCopy()
 
 	if ko.Status.ACKResourceMetadata == nil {
 		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}

--- a/services/elasticache/pkg/resource/replication_group/manager.go
+++ b/services/elasticache/pkg/resource/replication_group/manager.go
@@ -98,23 +98,28 @@ func (rm *resourceManager) Create(
 	return created, nil
 }
 
-// Update attempts to mutate the supplied AWSResource in the backend AWS
+// Update attempts to mutate the supplied desired AWSResource in the backend AWS
 // service API, returning an AWSResource representing the newly-mutated
-// resource. Note that implementers should NOT check to see if the latest
-// observed resource differs from the supplied desired state. The higher-level
-// reonciler determines whether or not the desired differs from the latest
-// observed and decides whether to call the resource manager's Update method
+// resource.
+// Note for specialized logic implementers can check to see how the latest
+// observed resource differs from the supplied desired state. The
+// higher-level reonciler determines whether or not the desired differs
+// from the latest observed and decides whether to call the resource
+// manager's Update method
 func (rm *resourceManager) Update(
 	ctx context.Context,
-	res acktypes.AWSResource,
+	resDesired acktypes.AWSResource, // desired
+	resLatest acktypes.AWSResource, // latest
 	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
-	r := rm.concreteResource(res)
-	if r.ko == nil {
+	rd := rm.concreteResource(resDesired)
+	rl := rm.concreteResource(resLatest)
+	if rd.ko == nil || rl.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
+
+	updated, err := rm.sdkUpdate(ctx, rd, rl, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/elasticache/pkg/resource/replication_group/manager.go
+++ b/services/elasticache/pkg/resource/replication_group/manager.go
@@ -108,18 +108,17 @@ func (rm *resourceManager) Create(
 // manager's Update method
 func (rm *resourceManager) Update(
 	ctx context.Context,
-	resDesired acktypes.AWSResource, // desired
-	resLatest acktypes.AWSResource, // latest
+	resDesired acktypes.AWSResource,
+	resLatest acktypes.AWSResource,
 	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
-	rd := rm.concreteResource(resDesired)
-	rl := rm.concreteResource(resLatest)
-	if rd.ko == nil || rl.ko == nil {
+	desired := rm.concreteResource(resDesired)
+	latest := rm.concreteResource(resLatest)
+	if desired.ko == nil || latest.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-
-	updated, err := rm.sdkUpdate(ctx, rd, rl, diffReporter)
+	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/elasticache/pkg/resource/replication_group/sdk.go
+++ b/services/elasticache/pkg/resource/replication_group/sdk.go
@@ -793,7 +793,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	// custom set output from response
-	rm.CustomModifyReplicationGroupSetOutput(r, resp, ko)
+	rm.CustomModifyReplicationGroupSetOutput(desired, resp, ko)
 
 	return &resource{ko}, nil
 }

--- a/services/elasticache/pkg/resource/replication_group/sdk.go
+++ b/services/elasticache/pkg/resource/replication_group/sdk.go
@@ -617,21 +617,19 @@ func (rm *resourceManager) newCreateRequestPayload(
 // returns a new resource with updated fields.
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
-	r *resource,
+	rd *resource, // desired
+	rl *resource, // latest
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
-	input, err := rm.newUpdateRequestPayload(r)
-	if err != nil {
-		return nil, err
+
+	customResp, customRespErr := rm.CustomModifyReplicationGroup(ctx, rd, rl, diffReporter)
+	if customResp != nil || customRespErr != nil {
+		return customResp, customRespErr
 	}
 
-	for _, diff := range diffReporter.Differences {
-		switch diff.Path {
-		case "Spec.NumNodeGroups":
-			return rm.UpdateShardConfiguration(ctx, r, diffReporter)
-		case "Spec.ReplicasPerNodeGroup":
-			return rm.UpdateReplicaCount(ctx, r, diffReporter)
-		}
+	input, err := rm.newUpdateRequestPayload(rd)
+	if err != nil {
+		return nil, err
 	}
 
 	resp, respErr := rm.sdkapi.ModifyReplicationGroupWithContext(ctx, input)
@@ -640,7 +638,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := r.ko.DeepCopy()
+	ko := rd.ko.DeepCopy()
 
 	if ko.Status.ACKResourceMetadata == nil {
 		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}

--- a/services/elasticache/pkg/resource/replication_group/sdk.go
+++ b/services/elasticache/pkg/resource/replication_group/sdk.go
@@ -617,17 +617,17 @@ func (rm *resourceManager) newCreateRequestPayload(
 // returns a new resource with updated fields.
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
-	rd *resource, // desired
-	rl *resource, // latest
+	desired *resource,
+	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 
-	customResp, customRespErr := rm.CustomModifyReplicationGroup(ctx, rd, rl, diffReporter)
+	customResp, customRespErr := rm.CustomModifyReplicationGroup(ctx, desired, latest, diffReporter)
 	if customResp != nil || customRespErr != nil {
 		return customResp, customRespErr
 	}
 
-	input, err := rm.newUpdateRequestPayload(rd)
+	input, err := rm.newUpdateRequestPayload(desired)
 	if err != nil {
 		return nil, err
 	}
@@ -638,7 +638,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := rd.ko.DeepCopy()
+	ko := desired.ko.DeepCopy()
 
 	if ko.Status.ACKResourceMetadata == nil {
 		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}

--- a/services/s3/pkg/resource/bucket/manager.go
+++ b/services/s3/pkg/resource/bucket/manager.go
@@ -98,23 +98,27 @@ func (rm *resourceManager) Create(
 	return created, nil
 }
 
-// Update attempts to mutate the supplied AWSResource in the backend AWS
+// Update attempts to mutate the supplied desired AWSResource in the backend AWS
 // service API, returning an AWSResource representing the newly-mutated
-// resource. Note that implementers should NOT check to see if the latest
-// observed resource differs from the supplied desired state. The higher-level
-// reonciler determines whether or not the desired differs from the latest
-// observed and decides whether to call the resource manager's Update method
+// resource.
+// Note for specialized logic implementers can check to see how the latest
+// observed resource differs from the supplied desired state. The
+// higher-level reonciler determines whether or not the desired differs
+// from the latest observed and decides whether to call the resource
+// manager's Update method
 func (rm *resourceManager) Update(
 	ctx context.Context,
-	res acktypes.AWSResource,
+	resDesired acktypes.AWSResource,
+	resLatest acktypes.AWSResource,
 	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
-	r := rm.concreteResource(res)
-	if r.ko == nil {
+	desired := rm.concreteResource(resDesired)
+	latest := rm.concreteResource(resLatest)
+	if desired.ko == nil || latest.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
+	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/s3/pkg/resource/bucket/sdk.go
+++ b/services/s3/pkg/resource/bucket/sdk.go
@@ -172,7 +172,8 @@ func (rm *resourceManager) newCreateRequestPayload(
 // returns a new resource with updated fields.
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
-	r *resource,
+	desired *resource,
+	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 	// TODO(jaypipes): Figure this out...

--- a/services/sns/pkg/resource/platform_application/manager.go
+++ b/services/sns/pkg/resource/platform_application/manager.go
@@ -98,23 +98,27 @@ func (rm *resourceManager) Create(
 	return created, nil
 }
 
-// Update attempts to mutate the supplied AWSResource in the backend AWS
+// Update attempts to mutate the supplied desired AWSResource in the backend AWS
 // service API, returning an AWSResource representing the newly-mutated
-// resource. Note that implementers should NOT check to see if the latest
-// observed resource differs from the supplied desired state. The higher-level
-// reonciler determines whether or not the desired differs from the latest
-// observed and decides whether to call the resource manager's Update method
+// resource.
+// Note for specialized logic implementers can check to see how the latest
+// observed resource differs from the supplied desired state. The
+// higher-level reonciler determines whether or not the desired differs
+// from the latest observed and decides whether to call the resource
+// manager's Update method
 func (rm *resourceManager) Update(
 	ctx context.Context,
-	res acktypes.AWSResource,
+	resDesired acktypes.AWSResource,
+	resLatest acktypes.AWSResource,
 	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
-	r := rm.concreteResource(res)
-	if r.ko == nil {
+	desired := rm.concreteResource(resDesired)
+	latest := rm.concreteResource(resLatest)
+	if desired.ko == nil || latest.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
+	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/sns/pkg/resource/platform_application/sdk.go
+++ b/services/sns/pkg/resource/platform_application/sdk.go
@@ -193,17 +193,18 @@ func (rm *resourceManager) newCreateRequestPayload(
 // returns a new resource with updated fields.
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
-	r *resource,
+	desired *resource,
+	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 	// If any required fields in the input shape are missing, AWS resource is
 	// not created yet. And sdkUpdate should never be called if this is the
 	// case, and it's an error in the generated code if it is...
-	if rm.requiredFieldsMissingFromSetAttributesInput(r) {
+	if rm.requiredFieldsMissingFromSetAttributesInput(desired) {
 		panic("Required field in SetAttributes input shape missing!")
 	}
 
-	input, err := rm.newSetAttributesRequestPayload(r)
+	input, err := rm.newSetAttributesRequestPayload(desired)
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +225,7 @@ func (rm *resourceManager) sdkUpdate(
 
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := r.ko.DeepCopy()
+	ko := desired.ko.DeepCopy()
 	return &resource{ko}, nil
 }
 

--- a/services/sns/pkg/resource/platform_endpoint/manager.go
+++ b/services/sns/pkg/resource/platform_endpoint/manager.go
@@ -98,23 +98,27 @@ func (rm *resourceManager) Create(
 	return created, nil
 }
 
-// Update attempts to mutate the supplied AWSResource in the backend AWS
+// Update attempts to mutate the supplied desired AWSResource in the backend AWS
 // service API, returning an AWSResource representing the newly-mutated
-// resource. Note that implementers should NOT check to see if the latest
-// observed resource differs from the supplied desired state. The higher-level
-// reonciler determines whether or not the desired differs from the latest
-// observed and decides whether to call the resource manager's Update method
+// resource.
+// Note for specialized logic implementers can check to see how the latest
+// observed resource differs from the supplied desired state. The
+// higher-level reonciler determines whether or not the desired differs
+// from the latest observed and decides whether to call the resource
+// manager's Update method
 func (rm *resourceManager) Update(
 	ctx context.Context,
-	res acktypes.AWSResource,
+	resDesired acktypes.AWSResource,
+	resLatest acktypes.AWSResource,
 	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
-	r := rm.concreteResource(res)
-	if r.ko == nil {
+	desired := rm.concreteResource(resDesired)
+	latest := rm.concreteResource(resLatest)
+	if desired.ko == nil || latest.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
+	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/sns/pkg/resource/platform_endpoint/sdk.go
+++ b/services/sns/pkg/resource/platform_endpoint/sdk.go
@@ -115,7 +115,8 @@ func (rm *resourceManager) newCreateRequestPayload(
 // returns a new resource with updated fields.
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
-	r *resource,
+	desired *resource,
+	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 	// TODO(jaypipes): Figure this out...

--- a/services/sns/pkg/resource/topic/manager.go
+++ b/services/sns/pkg/resource/topic/manager.go
@@ -98,23 +98,27 @@ func (rm *resourceManager) Create(
 	return created, nil
 }
 
-// Update attempts to mutate the supplied AWSResource in the backend AWS
+// Update attempts to mutate the supplied desired AWSResource in the backend AWS
 // service API, returning an AWSResource representing the newly-mutated
-// resource. Note that implementers should NOT check to see if the latest
-// observed resource differs from the supplied desired state. The higher-level
-// reonciler determines whether or not the desired differs from the latest
-// observed and decides whether to call the resource manager's Update method
+// resource.
+// Note for specialized logic implementers can check to see how the latest
+// observed resource differs from the supplied desired state. The
+// higher-level reonciler determines whether or not the desired differs
+// from the latest observed and decides whether to call the resource
+// manager's Update method
 func (rm *resourceManager) Update(
 	ctx context.Context,
-	res acktypes.AWSResource,
+	resDesired acktypes.AWSResource,
+	resLatest acktypes.AWSResource,
 	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
-	r := rm.concreteResource(res)
-	if r.ko == nil {
+	desired := rm.concreteResource(resDesired)
+	latest := rm.concreteResource(resLatest)
+	if desired.ko == nil || latest.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
+	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/sns/pkg/resource/topic/sdk.go
+++ b/services/sns/pkg/resource/topic/sdk.go
@@ -198,17 +198,18 @@ func (rm *resourceManager) newCreateRequestPayload(
 // returns a new resource with updated fields.
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
-	r *resource,
+	desired *resource,
+	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 	// If any required fields in the input shape are missing, AWS resource is
 	// not created yet. And sdkUpdate should never be called if this is the
 	// case, and it's an error in the generated code if it is...
-	if rm.requiredFieldsMissingFromSetAttributesInput(r) {
+	if rm.requiredFieldsMissingFromSetAttributesInput(desired) {
 		panic("Required field in SetAttributes input shape missing!")
 	}
 
-	input, err := rm.newSetAttributesRequestPayload(r)
+	input, err := rm.newSetAttributesRequestPayload(desired)
 	if err != nil {
 		return nil, err
 	}
@@ -229,7 +230,7 @@ func (rm *resourceManager) sdkUpdate(
 
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := r.ko.DeepCopy()
+	ko := desired.ko.DeepCopy()
 	return &resource{ko}, nil
 }
 

--- a/templates/pkg/crd_manager.go.tpl
+++ b/templates/pkg/crd_manager.go.tpl
@@ -95,18 +95,17 @@ func (rm *resourceManager) Create(
 // manager's Update method
 func (rm *resourceManager) Update(
 	ctx context.Context,
-	resDesired acktypes.AWSResource,	// desired
-	resLatest acktypes.AWSResource,		// latest
+	resDesired acktypes.AWSResource,
+	resLatest acktypes.AWSResource,
 	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
-	rd := rm.concreteResource(resDesired)
-	rl := rm.concreteResource(resLatest)
-	if rd.ko == nil || rl.ko == nil{
+	desired := rm.concreteResource(resDesired)
+	latest := rm.concreteResource(resLatest)
+	if desired.ko == nil || latest.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-
-	updated, err := rm.sdkUpdate(ctx, rd, rl, diffReporter)
+	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/templates/pkg/crd_manager.go.tpl
+++ b/templates/pkg/crd_manager.go.tpl
@@ -85,23 +85,28 @@ func (rm *resourceManager) Create(
 	return created, nil
 }
 
-// Update attempts to mutate the supplied AWSResource in the backend AWS
+// Update attempts to mutate the supplied desired AWSResource in the backend AWS
 // service API, returning an AWSResource representing the newly-mutated
-// resource. Note that implementers should NOT check to see if the latest
-// observed resource differs from the supplied desired state. The higher-level
-// reonciler determines whether or not the desired differs from the latest
-// observed and decides whether to call the resource manager's Update method
+// resource.
+// Note for specialized logic implementers can check to see how the latest
+// observed resource differs from the supplied desired state. The
+// higher-level reonciler determines whether or not the desired differs
+// from the latest observed and decides whether to call the resource
+// manager's Update method
 func (rm *resourceManager) Update(
 	ctx context.Context,
-	res acktypes.AWSResource,
+	resDesired acktypes.AWSResource,	// desired
+	resLatest acktypes.AWSResource,		// latest
 	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
-	r := rm.concreteResource(res)
-	if r.ko == nil {
+	rd := rm.concreteResource(resDesired)
+	rl := rm.concreteResource(resLatest)
+	if rd.ko == nil || rl.ko == nil{
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
+
+	updated, err := rm.sdkUpdate(ctx, rd, rl, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/templates/pkg/crd_sdk.go.tpl
+++ b/templates/pkg/crd_sdk.go.tpl
@@ -220,21 +220,21 @@ func (rm *resourceManager) newCreateRequestPayload(
 // returns a new resource with updated fields.
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
-	rd *resource,	// desired
-	rl *resource,	// latest
+	desired *resource,
+	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 {{- if .CRD.Ops.Update }}
 
 {{ $customMethod := .CRD.GetCustomImplementation .CRD.Ops.Update }}
 {{ if $customMethod }}
-	customResp, customRespErr := rm.{{ $customMethod }}(ctx, rd, rl, diffReporter)
+	customResp, customRespErr := rm.{{ $customMethod }}(ctx, desired, latest, diffReporter)
 	if customResp != nil || customRespErr != nil {
 		return customResp, customRespErr
 	}
 {{ end }}
 
-	input, err := rm.newUpdateRequestPayload(rd)
+	input, err := rm.newUpdateRequestPayload(desired)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +246,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := rd.ko.DeepCopy()
+	ko := desired.ko.DeepCopy()
 {{ $setCode }}
 {{ if $setOutputCustomMethodName := .CRD.SetOutputCustomMethodName .CRD.Ops.Update }}
 	// custom set output from response

--- a/templates/pkg/crd_sdk.go.tpl
+++ b/templates/pkg/crd_sdk.go.tpl
@@ -250,18 +250,18 @@ func (rm *resourceManager) sdkUpdate(
 {{ $setCode }}
 {{ if $setOutputCustomMethodName := .CRD.SetOutputCustomMethodName .CRD.Ops.Update }}
 	// custom set output from response
-	rm.{{ $setOutputCustomMethodName }}(r, resp, ko)
+	rm.{{ $setOutputCustomMethodName }}(desired, resp, ko)
 {{ end }}
 	return &resource{ko}, nil
 {{- else if .CRD.Ops.SetAttributes }}
 	// If any required fields in the input shape are missing, AWS resource is
 	// not created yet. And sdkUpdate should never be called if this is the
 	// case, and it's an error in the generated code if it is...
-	if rm.requiredFieldsMissingFromSetAttributesInput(r) {
+	if rm.requiredFieldsMissingFromSetAttributesInput(desired) {
 		panic("Required field in SetAttributes input shape missing!")
 	}
 
-	input, err := rm.newSetAttributesRequestPayload(r)
+	input, err := rm.newSetAttributesRequestPayload(desired)
 	if err != nil {
 		return nil, err
 	}
@@ -282,7 +282,7 @@ func (rm *resourceManager) sdkUpdate(
 
 	// Merge in the information we read from the API call above to the copy of
 	// the original Kubernetes object we passed to the function
-	ko := r.ko.DeepCopy()
+	ko := desired.ko.DeepCopy()
 	return &resource{ko}, nil
 {{- else }}
 	// TODO(jaypipes): Figure this out...


### PR DESCRIPTION
Issue #, if available: #298 

**Description of changes:**
Changed the update() method args to include 'latest' state as well. 
Now both desired state and latest state is available inside update()
method to compute finegrained diffs to make service api calls.

Also, it addresses comment received on #245 to simplify 
the mechanism to configure custom implementation for operation 
on a custom resource. Following is an example to 
configure `CustomModifyReplicationGroup` as custom_implementation operation 
for `ModifyReplicationGroup` operation in elasticache `generator.yaml`
config file:
```
operations:
  ModifyReplicationGroup:
    custom_implementation: CustomModifyReplicationGroup
```

**Due to open issue #296 not all services' controllers are auto generated in this
revision of the PR. Thus, `make test` fails for other services as of now.**
> This PR includes service controllers generated for `elasticache` and
> manually updated for `petstore`, `bookstore` services to help this review.
> Once issue #296 is fixed, remaining service controller will be generated
> and this PR will include corresponding updates.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
