### PR TITLE
update apigwv2 service controller for Diff

### DIFF
--- a/services/apigatewayv2/pkg/resource/api/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/api/descriptor.go
@@ -16,6 +16,7 @@
 package api
 
 import (
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -78,18 +79,19 @@ func (d *resourceDescriptor) Equal(
 	return cmp.Equal(ac.ko, bc.ko, opts)
 }
 
-// Diff returns a string representing the difference between two supplied
+// Diff returns a Reporter which provides the difference between two supplied
 // AWSResources. The underlying types of the two supplied AWSResources should
 // be the same. In other words, the Diff() method should be called with the
 // same concrete implementing AWSResource type
 func (d *resourceDescriptor) Diff(
 	a acktypes.AWSResource,
 	b acktypes.AWSResource,
-) string {
+) *ackcompare.Reporter {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Diff(ac.ko, bc.ko, opts)
+	var diffReporter ackcompare.Reporter
+	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.API{}))
+	return &diffReporter
 }
 
 // UpdateCRStatus accepts an AWSResource object and changes the Status

--- a/services/apigatewayv2/pkg/resource/api/manager.go
+++ b/services/apigatewayv2/pkg/resource/api/manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -106,13 +107,14 @@ func (rm *resourceManager) Create(
 func (rm *resourceManager) Update(
 	ctx context.Context,
 	res acktypes.AWSResource,
+	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
 	r := rm.concreteResource(res)
 	if r.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r)
+	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/api/sdk.go
+++ b/services/apigatewayv2/pkg/resource/api/sdk.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
@@ -284,6 +285,7 @@ func (rm *resourceManager) newCreateRequestPayload(
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
 	r *resource,
+	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 	input, err := rm.newUpdateRequestPayload(r)
 	if err != nil {

--- a/services/apigatewayv2/pkg/resource/api_mapping/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/api_mapping/descriptor.go
@@ -16,6 +16,7 @@
 package api_mapping
 
 import (
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -78,18 +79,19 @@ func (d *resourceDescriptor) Equal(
 	return cmp.Equal(ac.ko, bc.ko, opts)
 }
 
-// Diff returns a string representing the difference between two supplied
+// Diff returns a Reporter which provides the difference between two supplied
 // AWSResources. The underlying types of the two supplied AWSResources should
 // be the same. In other words, the Diff() method should be called with the
 // same concrete implementing AWSResource type
 func (d *resourceDescriptor) Diff(
 	a acktypes.AWSResource,
 	b acktypes.AWSResource,
-) string {
+) *ackcompare.Reporter {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Diff(ac.ko, bc.ko, opts)
+	var diffReporter ackcompare.Reporter
+	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.APIMapping{}))
+	return &diffReporter
 }
 
 // UpdateCRStatus accepts an AWSResource object and changes the Status

--- a/services/apigatewayv2/pkg/resource/api_mapping/manager.go
+++ b/services/apigatewayv2/pkg/resource/api_mapping/manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -106,13 +107,14 @@ func (rm *resourceManager) Create(
 func (rm *resourceManager) Update(
 	ctx context.Context,
 	res acktypes.AWSResource,
+	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
 	r := rm.concreteResource(res)
 	if r.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r)
+	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/api_mapping/sdk.go
+++ b/services/apigatewayv2/pkg/resource/api_mapping/sdk.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
@@ -170,6 +171,7 @@ func (rm *resourceManager) newCreateRequestPayload(
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
 	r *resource,
+	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 	input, err := rm.newUpdateRequestPayload(r)
 	if err != nil {

--- a/services/apigatewayv2/pkg/resource/authorizer/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/authorizer/descriptor.go
@@ -16,6 +16,7 @@
 package authorizer
 
 import (
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -78,18 +79,19 @@ func (d *resourceDescriptor) Equal(
 	return cmp.Equal(ac.ko, bc.ko, opts)
 }
 
-// Diff returns a string representing the difference between two supplied
+// Diff returns a Reporter which provides the difference between two supplied
 // AWSResources. The underlying types of the two supplied AWSResources should
 // be the same. In other words, the Diff() method should be called with the
 // same concrete implementing AWSResource type
 func (d *resourceDescriptor) Diff(
 	a acktypes.AWSResource,
 	b acktypes.AWSResource,
-) string {
+) *ackcompare.Reporter {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Diff(ac.ko, bc.ko, opts)
+	var diffReporter ackcompare.Reporter
+	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.Authorizer{}))
+	return &diffReporter
 }
 
 // UpdateCRStatus accepts an AWSResource object and changes the Status

--- a/services/apigatewayv2/pkg/resource/authorizer/manager.go
+++ b/services/apigatewayv2/pkg/resource/authorizer/manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -106,13 +107,14 @@ func (rm *resourceManager) Create(
 func (rm *resourceManager) Update(
 	ctx context.Context,
 	res acktypes.AWSResource,
+	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
 	r := rm.concreteResource(res)
 	if r.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r)
+	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/authorizer/sdk.go
+++ b/services/apigatewayv2/pkg/resource/authorizer/sdk.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
@@ -204,6 +205,7 @@ func (rm *resourceManager) newCreateRequestPayload(
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
 	r *resource,
+	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 	input, err := rm.newUpdateRequestPayload(r)
 	if err != nil {

--- a/services/apigatewayv2/pkg/resource/deployment/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/deployment/descriptor.go
@@ -16,6 +16,7 @@
 package deployment
 
 import (
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -78,18 +79,19 @@ func (d *resourceDescriptor) Equal(
 	return cmp.Equal(ac.ko, bc.ko, opts)
 }
 
-// Diff returns a string representing the difference between two supplied
+// Diff returns a Reporter which provides the difference between two supplied
 // AWSResources. The underlying types of the two supplied AWSResources should
 // be the same. In other words, the Diff() method should be called with the
 // same concrete implementing AWSResource type
 func (d *resourceDescriptor) Diff(
 	a acktypes.AWSResource,
 	b acktypes.AWSResource,
-) string {
+) *ackcompare.Reporter {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Diff(ac.ko, bc.ko, opts)
+	var diffReporter ackcompare.Reporter
+	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.Deployment{}))
+	return &diffReporter
 }
 
 // UpdateCRStatus accepts an AWSResource object and changes the Status

--- a/services/apigatewayv2/pkg/resource/deployment/manager.go
+++ b/services/apigatewayv2/pkg/resource/deployment/manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -106,13 +107,14 @@ func (rm *resourceManager) Create(
 func (rm *resourceManager) Update(
 	ctx context.Context,
 	res acktypes.AWSResource,
+	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
 	r := rm.concreteResource(res)
 	if r.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r)
+	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/deployment/sdk.go
+++ b/services/apigatewayv2/pkg/resource/deployment/sdk.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
@@ -191,6 +192,7 @@ func (rm *resourceManager) newCreateRequestPayload(
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
 	r *resource,
+	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 	input, err := rm.newUpdateRequestPayload(r)
 	if err != nil {

--- a/services/apigatewayv2/pkg/resource/domain_name/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/domain_name/descriptor.go
@@ -16,6 +16,7 @@
 package domain_name
 
 import (
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -78,18 +79,19 @@ func (d *resourceDescriptor) Equal(
 	return cmp.Equal(ac.ko, bc.ko, opts)
 }
 
-// Diff returns a string representing the difference between two supplied
+// Diff returns a Reporter which provides the difference between two supplied
 // AWSResources. The underlying types of the two supplied AWSResources should
 // be the same. In other words, the Diff() method should be called with the
 // same concrete implementing AWSResource type
 func (d *resourceDescriptor) Diff(
 	a acktypes.AWSResource,
 	b acktypes.AWSResource,
-) string {
+) *ackcompare.Reporter {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Diff(ac.ko, bc.ko, opts)
+	var diffReporter ackcompare.Reporter
+	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.DomainName{}))
+	return &diffReporter
 }
 
 // UpdateCRStatus accepts an AWSResource object and changes the Status

--- a/services/apigatewayv2/pkg/resource/domain_name/manager.go
+++ b/services/apigatewayv2/pkg/resource/domain_name/manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -106,13 +107,14 @@ func (rm *resourceManager) Create(
 func (rm *resourceManager) Update(
 	ctx context.Context,
 	res acktypes.AWSResource,
+	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
 	r := rm.concreteResource(res)
 	if r.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r)
+	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/domain_name/sdk.go
+++ b/services/apigatewayv2/pkg/resource/domain_name/sdk.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
@@ -198,6 +199,7 @@ func (rm *resourceManager) newCreateRequestPayload(
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
 	r *resource,
+	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 	input, err := rm.newUpdateRequestPayload(r)
 	if err != nil {

--- a/services/apigatewayv2/pkg/resource/integration/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/integration/descriptor.go
@@ -16,6 +16,7 @@
 package integration
 
 import (
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -78,18 +79,19 @@ func (d *resourceDescriptor) Equal(
 	return cmp.Equal(ac.ko, bc.ko, opts)
 }
 
-// Diff returns a string representing the difference between two supplied
+// Diff returns a Reporter which provides the difference between two supplied
 // AWSResources. The underlying types of the two supplied AWSResources should
 // be the same. In other words, the Diff() method should be called with the
 // same concrete implementing AWSResource type
 func (d *resourceDescriptor) Diff(
 	a acktypes.AWSResource,
 	b acktypes.AWSResource,
-) string {
+) *ackcompare.Reporter {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Diff(ac.ko, bc.ko, opts)
+	var diffReporter ackcompare.Reporter
+	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.Integration{}))
+	return &diffReporter
 }
 
 // UpdateCRStatus accepts an AWSResource object and changes the Status

--- a/services/apigatewayv2/pkg/resource/integration/manager.go
+++ b/services/apigatewayv2/pkg/resource/integration/manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -106,13 +107,14 @@ func (rm *resourceManager) Create(
 func (rm *resourceManager) Update(
 	ctx context.Context,
 	res acktypes.AWSResource,
+	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
 	r := rm.concreteResource(res)
 	if r.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r)
+	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/integration/sdk.go
+++ b/services/apigatewayv2/pkg/resource/integration/sdk.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
@@ -234,6 +235,7 @@ func (rm *resourceManager) newCreateRequestPayload(
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
 	r *resource,
+	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 	input, err := rm.newUpdateRequestPayload(r)
 	if err != nil {

--- a/services/apigatewayv2/pkg/resource/integration_response/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/integration_response/descriptor.go
@@ -16,6 +16,7 @@
 package integration_response
 
 import (
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -78,18 +79,19 @@ func (d *resourceDescriptor) Equal(
 	return cmp.Equal(ac.ko, bc.ko, opts)
 }
 
-// Diff returns a string representing the difference between two supplied
+// Diff returns a Reporter which provides the difference between two supplied
 // AWSResources. The underlying types of the two supplied AWSResources should
 // be the same. In other words, the Diff() method should be called with the
 // same concrete implementing AWSResource type
 func (d *resourceDescriptor) Diff(
 	a acktypes.AWSResource,
 	b acktypes.AWSResource,
-) string {
+) *ackcompare.Reporter {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Diff(ac.ko, bc.ko, opts)
+	var diffReporter ackcompare.Reporter
+	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.IntegrationResponse{}))
+	return &diffReporter
 }
 
 // UpdateCRStatus accepts an AWSResource object and changes the Status

--- a/services/apigatewayv2/pkg/resource/integration_response/manager.go
+++ b/services/apigatewayv2/pkg/resource/integration_response/manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -106,13 +107,14 @@ func (rm *resourceManager) Create(
 func (rm *resourceManager) Update(
 	ctx context.Context,
 	res acktypes.AWSResource,
+	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
 	r := rm.concreteResource(res)
 	if r.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r)
+	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/integration_response/sdk.go
+++ b/services/apigatewayv2/pkg/resource/integration_response/sdk.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
@@ -197,6 +198,7 @@ func (rm *resourceManager) newCreateRequestPayload(
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
 	r *resource,
+	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 	input, err := rm.newUpdateRequestPayload(r)
 	if err != nil {

--- a/services/apigatewayv2/pkg/resource/model/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/model/descriptor.go
@@ -16,6 +16,7 @@
 package model
 
 import (
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -78,18 +79,19 @@ func (d *resourceDescriptor) Equal(
 	return cmp.Equal(ac.ko, bc.ko, opts)
 }
 
-// Diff returns a string representing the difference between two supplied
+// Diff returns a Reporter which provides the difference between two supplied
 // AWSResources. The underlying types of the two supplied AWSResources should
 // be the same. In other words, the Diff() method should be called with the
 // same concrete implementing AWSResource type
 func (d *resourceDescriptor) Diff(
 	a acktypes.AWSResource,
 	b acktypes.AWSResource,
-) string {
+) *ackcompare.Reporter {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Diff(ac.ko, bc.ko, opts)
+	var diffReporter ackcompare.Reporter
+	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.Model{}))
+	return &diffReporter
 }
 
 // UpdateCRStatus accepts an AWSResource object and changes the Status

--- a/services/apigatewayv2/pkg/resource/model/manager.go
+++ b/services/apigatewayv2/pkg/resource/model/manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -106,13 +107,14 @@ func (rm *resourceManager) Create(
 func (rm *resourceManager) Update(
 	ctx context.Context,
 	res acktypes.AWSResource,
+	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
 	r := rm.concreteResource(res)
 	if r.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r)
+	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/model/sdk.go
+++ b/services/apigatewayv2/pkg/resource/model/sdk.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
@@ -173,6 +174,7 @@ func (rm *resourceManager) newCreateRequestPayload(
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
 	r *resource,
+	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 	input, err := rm.newUpdateRequestPayload(r)
 	if err != nil {

--- a/services/apigatewayv2/pkg/resource/route/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/route/descriptor.go
@@ -16,6 +16,7 @@
 package route
 
 import (
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -78,18 +79,19 @@ func (d *resourceDescriptor) Equal(
 	return cmp.Equal(ac.ko, bc.ko, opts)
 }
 
-// Diff returns a string representing the difference between two supplied
+// Diff returns a Reporter which provides the difference between two supplied
 // AWSResources. The underlying types of the two supplied AWSResources should
 // be the same. In other words, the Diff() method should be called with the
 // same concrete implementing AWSResource type
 func (d *resourceDescriptor) Diff(
 	a acktypes.AWSResource,
 	b acktypes.AWSResource,
-) string {
+) *ackcompare.Reporter {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Diff(ac.ko, bc.ko, opts)
+	var diffReporter ackcompare.Reporter
+	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.Route{}))
+	return &diffReporter
 }
 
 // UpdateCRStatus accepts an AWSResource object and changes the Status

--- a/services/apigatewayv2/pkg/resource/route/manager.go
+++ b/services/apigatewayv2/pkg/resource/route/manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -106,13 +107,14 @@ func (rm *resourceManager) Create(
 func (rm *resourceManager) Update(
 	ctx context.Context,
 	res acktypes.AWSResource,
+	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
 	r := rm.concreteResource(res)
 	if r.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r)
+	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/route/sdk.go
+++ b/services/apigatewayv2/pkg/resource/route/sdk.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
@@ -220,6 +221,7 @@ func (rm *resourceManager) newCreateRequestPayload(
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
 	r *resource,
+	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 	input, err := rm.newUpdateRequestPayload(r)
 	if err != nil {

--- a/services/apigatewayv2/pkg/resource/route_response/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/route_response/descriptor.go
@@ -16,6 +16,7 @@
 package route_response
 
 import (
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -78,18 +79,19 @@ func (d *resourceDescriptor) Equal(
 	return cmp.Equal(ac.ko, bc.ko, opts)
 }
 
-// Diff returns a string representing the difference between two supplied
+// Diff returns a Reporter which provides the difference between two supplied
 // AWSResources. The underlying types of the two supplied AWSResources should
 // be the same. In other words, the Diff() method should be called with the
 // same concrete implementing AWSResource type
 func (d *resourceDescriptor) Diff(
 	a acktypes.AWSResource,
 	b acktypes.AWSResource,
-) string {
+) *ackcompare.Reporter {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Diff(ac.ko, bc.ko, opts)
+	var diffReporter ackcompare.Reporter
+	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.RouteResponse{}))
+	return &diffReporter
 }
 
 // UpdateCRStatus accepts an AWSResource object and changes the Status

--- a/services/apigatewayv2/pkg/resource/route_response/manager.go
+++ b/services/apigatewayv2/pkg/resource/route_response/manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -106,13 +107,14 @@ func (rm *resourceManager) Create(
 func (rm *resourceManager) Update(
 	ctx context.Context,
 	res acktypes.AWSResource,
+	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
 	r := rm.concreteResource(res)
 	if r.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r)
+	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/route_response/sdk.go
+++ b/services/apigatewayv2/pkg/resource/route_response/sdk.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
@@ -196,6 +197,7 @@ func (rm *resourceManager) newCreateRequestPayload(
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
 	r *resource,
+	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 	input, err := rm.newUpdateRequestPayload(r)
 	if err != nil {

--- a/services/apigatewayv2/pkg/resource/stage/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/stage/descriptor.go
@@ -16,6 +16,7 @@
 package stage
 
 import (
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -78,18 +79,19 @@ func (d *resourceDescriptor) Equal(
 	return cmp.Equal(ac.ko, bc.ko, opts)
 }
 
-// Diff returns a string representing the difference between two supplied
+// Diff returns a Reporter which provides the difference between two supplied
 // AWSResources. The underlying types of the two supplied AWSResources should
 // be the same. In other words, the Diff() method should be called with the
 // same concrete implementing AWSResource type
 func (d *resourceDescriptor) Diff(
 	a acktypes.AWSResource,
 	b acktypes.AWSResource,
-) string {
+) *ackcompare.Reporter {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Diff(ac.ko, bc.ko, opts)
+	var diffReporter ackcompare.Reporter
+	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.Stage{}))
+	return &diffReporter
 }
 
 // UpdateCRStatus accepts an AWSResource object and changes the Status

--- a/services/apigatewayv2/pkg/resource/stage/manager.go
+++ b/services/apigatewayv2/pkg/resource/stage/manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -106,13 +107,14 @@ func (rm *resourceManager) Create(
 func (rm *resourceManager) Update(
 	ctx context.Context,
 	res acktypes.AWSResource,
+	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
 	r := rm.concreteResource(res)
 	if r.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r)
+	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/stage/sdk.go
+++ b/services/apigatewayv2/pkg/resource/stage/sdk.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
@@ -264,6 +265,7 @@ func (rm *resourceManager) newCreateRequestPayload(
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
 	r *resource,
+	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 	input, err := rm.newUpdateRequestPayload(r)
 	if err != nil {

--- a/services/apigatewayv2/pkg/resource/vpc_link/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/vpc_link/descriptor.go
@@ -16,6 +16,7 @@
 package vpc_link
 
 import (
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -78,18 +79,19 @@ func (d *resourceDescriptor) Equal(
 	return cmp.Equal(ac.ko, bc.ko, opts)
 }
 
-// Diff returns a string representing the difference between two supplied
+// Diff returns a Reporter which provides the difference between two supplied
 // AWSResources. The underlying types of the two supplied AWSResources should
 // be the same. In other words, the Diff() method should be called with the
 // same concrete implementing AWSResource type
 func (d *resourceDescriptor) Diff(
 	a acktypes.AWSResource,
 	b acktypes.AWSResource,
-) string {
+) *ackcompare.Reporter {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Diff(ac.ko, bc.ko, opts)
+	var diffReporter ackcompare.Reporter
+	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.VPCLink{}))
+	return &diffReporter
 }
 
 // UpdateCRStatus accepts an AWSResource object and changes the Status

--- a/services/apigatewayv2/pkg/resource/vpc_link/manager.go
+++ b/services/apigatewayv2/pkg/resource/vpc_link/manager.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -106,13 +107,14 @@ func (rm *resourceManager) Create(
 func (rm *resourceManager) Update(
 	ctx context.Context,
 	res acktypes.AWSResource,
+	diffReporter *ackcompare.Reporter,
 ) (acktypes.AWSResource, error) {
 	r := rm.concreteResource(res)
 	if r.ko == nil {
 		// Should never happen... if it does, it's buggy code.
 		panic("resource manager's Update() method received resource with nil CR object")
 	}
-	updated, err := rm.sdkUpdate(ctx, r)
+	updated, err := rm.sdkUpdate(ctx, r, diffReporter)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/vpc_link/sdk.go
+++ b/services/apigatewayv2/pkg/resource/vpc_link/sdk.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/apigatewayv2"
@@ -205,6 +206,7 @@ func (rm *resourceManager) newCreateRequestPayload(
 func (rm *resourceManager) sdkUpdate(
 	ctx context.Context,
 	r *resource,
+	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 	input, err := rm.newUpdateRequestPayload(r)
 	if err != nil {


### PR DESCRIPTION
Recent PR changed the AWSDescriptor interface signature and this PR
simply updates the API Gateway V2 service controller to abide by that
new interface.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
