### PR TITLE
`ack-generate` call `git pull` if aws-sdk-go repository already exist in the cache

### DIFF
--- a/cmd/ack-generate/command/common.go
+++ b/cmd/ack-generate/command/common.go
@@ -77,6 +77,12 @@ func ensureSDKRepo(cacheDir string) error {
 // returns the filepath to the clone'd repo
 func cloneSDKRepo(srcPath string) (string, error) {
 	clonePath := filepath.Join(srcPath, "aws-sdk-go")
+	if optRefreshCache {
+		if _, err := os.Stat(filepath.Join(clonePath, ".git")); !os.IsNotExist(err) {
+			cmd := exec.Command("git", "-C", clonePath, "pull")
+			return clonePath, cmd.Run()
+		}
+	}
 	if _, err := os.Stat(clonePath); os.IsNotExist(err) {
 		cmd := exec.Command("git", "clone", "--depth", "1", sdkRepoURL, clonePath)
 		return clonePath, cmd.Run()

--- a/cmd/ack-generate/command/root.go
+++ b/cmd/ack-generate/command/root.go
@@ -36,6 +36,7 @@ var (
 	buildDate              string
 	defaultCacheDir        string
 	optCacheDir            string
+	optRefreshCache        bool
 	defaultTemplatesDir    string
 	optTemplatesDir        string
 	defaultServicesDir     string
@@ -104,6 +105,9 @@ func init() {
 	)
 	rootCmd.PersistentFlags().StringVar(
 		&optCacheDir, "cache-dir", defaultCacheDir, "Path to directory to store cached files (including clone'd aws-sdk-go repo)",
+	)
+	rootCmd.PersistentFlags().BoolVar(
+		&optRefreshCache, "refresh-cache", true, "If true, and aws-sdk-go repo is already cloned, will git pull the latest aws-sdk-go commit",
 	)
 	rootCmd.PersistentFlags().StringVar(
 		&optGeneratorConfigPath, "generator-config-path", "", "Path to file containing instructions for code generation to use",


### PR DESCRIPTION
Issue #291  

Description of changes:

`ack-generate` now will call `git pull` if aws-sdk-go repository already exist in the cache

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
