### PR TITLE
Service names arguments are accepted as case insensitive for make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ PKGS=$(sort $(dir $(wildcard pkg/*/*/)))
 MOCKS=$(foreach x, $(PKGS), mocks/$(x))
 
 MOCKERY_BIN=$(shell which mockery || "./bin/mockery")
+AWS_SERVICE=$(shell echo $(SERVICE) | tr '[:upper:]' '[:lower:]')
 
 # Build ldflags
 VERSION ?= "v0.0.0"
@@ -36,17 +37,17 @@ clean-mocks:	## Remove mocks directory
 	rm -rf mocks
 
 build-controller-image:	## Build container image for SERVICE
-	./scripts/build-controller-image.sh -s $(SERVICE)
+	./scripts/build-controller-image.sh -s $(AWS_SERVICE)
 
 publish-controller-image:  ## docker push a container image for SERVICE
 	@echo $(DOCKER_PASSWORD) | docker login -u $(DOCKER_USERNAME) --password-stdin
-	./scripts/publish-controller-image.sh -r $(DOCKER_REPOSITORY) -s $(SERVICE)
+	./scripts/publish-controller-image.sh -r $(DOCKER_REPOSITORY) -s $(AWS_SERVICE)
 
 build-controller: build-ack-generate	## Generate controller code for SERVICE
-	./scripts/build-controller.sh $(SERVICE)
+	./scripts/build-controller.sh $(AWS_SERVICE)
 
 kind-test: test	## Run functional tests for SERVICE with AWS_ROLE_ARN
-	./scripts/kind-build-test.sh -s $(SERVICE) -p -r $(AWS_ROLE_ARN)
+	./scripts/kind-build-test.sh -s $(AWS_SERVICE) -p -r $(AWS_ROLE_ARN)
 
 delete-all-kind-clusters:	## Delete all local kind clusters
 	@kind get clusters | \

--- a/scripts/build-controller.sh
+++ b/scripts/build-controller.sh
@@ -70,8 +70,7 @@ from the root directory or install ack-generate using:
         exit 1;
     fi
 fi
-
-SERVICE="$1"
+SERVICE=$(echo "$1" | tr '[:upper:]' '[:lower:]')
 
 # If there's a generator.yaml in the service's directory and the caller hasn't
 # specified an override, use that.

--- a/scripts/build-controllers.sh
+++ b/scripts/build-controllers.sh
@@ -54,7 +54,8 @@ if [[ ${#SERVICES[@]} -eq 0 ]]; then
 fi
 
 for SERVICE in ${SERVICES[@]}; do
-    $DIR/build-controller.sh "$SERVICE"
+    SERVICE=$(echo "$SERVICE" | tr '[:upper:]' '[:lower:]')
+    $DIR/build-controller.sh $SERVICE
     if [ $? -ne 0 ]; then
         exit 2
     fi


### PR DESCRIPTION
Issue #302 

Description of changes:
Convert service name to lowercase in `Makefile` and helper script files - `build-controllers.sh` and `build-controller.sh`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
