### PR TITLE
Enable custom set output operations

### DIFF
--- a/pkg/generate/config/config.go
+++ b/pkg/generate/config/config.go
@@ -38,6 +38,8 @@ type Config struct {
 // specify the overriding values for API operation parameters
 type OperationConfig struct {
 	OverrideValues map[string]string `json:"override_values"`
+	// CustomSetOutputOperation provides custom operation to process operation's output shape.
+	CustomSetOutputOperation string `json:"custom_set_output_operation,omitempty"`
 }
 
 // IgnoreSpec represents instructions to the ACK code generator to

--- a/pkg/generate/config/config.go
+++ b/pkg/generate/config/config.go
@@ -38,8 +38,10 @@ type Config struct {
 // specify the overriding values for API operation parameters
 type OperationConfig struct {
 	OverrideValues map[string]string `json:"override_values"`
-	// CustomSetOutputOperation provides custom operation to process operation's output shape.
-	CustomSetOutputOperation string `json:"custom_set_output_operation,omitempty"`
+	// SetOutputCustomMethodName provides the name of the custom method on the
+	// `resourceManager` struct that will set fields on a `resource` struct
+	// depending on the output of the operation.
+	SetOutputCustomMethodName string `json:"set_output_custom_method_name,omitempty"`
 }
 
 // IgnoreSpec represents instructions to the ACK code generator to

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -304,23 +304,23 @@ func (r *CRD) IsPrimaryARNField(fieldName string) bool {
 		strings.EqualFold(fieldName, r.Names.Original+"arn")
 }
 
-// GetCustomSetOutputOperation returns custom set output operation as string for
+// SetOutputCustomMethodName returns custom set output operation as *string for
 // given operation on custom resource, if specified in generator config
-func (r *CRD) GetCustomSetOutputOperation(
+func (r *CRD) SetOutputCustomMethodName(
 	// The operation to look for the Output shape
 	op *awssdkmodel.Operation,
-) string {
+) *string {
 	if op == nil {
-		return ""
+		return nil
 	}
 	if r.genCfg == nil {
-		return ""
+		return nil
 	}
 	resGenConfig, found := r.genCfg.Operations[op.Name]
 	if !found {
-		return ""
+		return nil
 	}
-	return resGenConfig.CustomSetOutputOperation
+	return &resGenConfig.SetOutputCustomMethodName
 }
 
 // HasCustomUpdateOperations returns true if the resource has custom update operations

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -304,6 +304,25 @@ func (r *CRD) IsPrimaryARNField(fieldName string) bool {
 		strings.EqualFold(fieldName, r.Names.Original+"arn")
 }
 
+// GetCustomSetOutputOperation returns custom set output operation as string for
+// given operation on custom resource, if specified in generator config
+func (r *CRD) GetCustomSetOutputOperation(
+	// The operation to look for the Output shape
+	op *awssdkmodel.Operation,
+) string {
+	if op == nil {
+		return ""
+	}
+	if r.genCfg == nil {
+		return ""
+	}
+	resGenConfig, found := r.genCfg.Operations[op.Name]
+	if !found {
+		return ""
+	}
+	return resGenConfig.CustomSetOutputOperation
+}
+
 // HasCustomUpdateOperations returns true if the resource has custom update operations
 // specified in generator config
 func (r *CRD) HasCustomUpdateOperations() bool {

--- a/services/elasticache/config/rbac/cluster-role-binding.yaml
+++ b/services/elasticache/config/rbac/cluster-role-binding.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ack-controller-role
+  name: ack-controller
 subjects:
 - kind: ServiceAccount
   name: default

--- a/services/elasticache/config/rbac/role.yaml
+++ b/services/elasticache/config/rbac/role.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: ack-controller-role
+  name: ack-controller
 rules:
 - apiGroups:
   - elasticache.services.k8s.aws

--- a/services/elasticache/generator.yaml
+++ b/services/elasticache/generator.yaml
@@ -12,7 +12,12 @@ resources:
         diff_paths:
           - Spec.ReplicasPerNodeGroup
 operations:
+  DescribeReplicationGroups:
+    custom_set_output_operation: CustomDescribeReplicationGroupsSetOutput
+  CreateReplicationGroup:
+    custom_set_output_operation: CustomCreateReplicationGroupSetOutput
   ModifyReplicationGroup:
+    custom_set_output_operation: CustomModifyReplicationGroupSetOutput
     override_values:
       ApplyImmediately: true
 ignore:

--- a/services/elasticache/generator.yaml
+++ b/services/elasticache/generator.yaml
@@ -13,11 +13,11 @@ resources:
           - Spec.ReplicasPerNodeGroup
 operations:
   DescribeReplicationGroups:
-    custom_set_output_operation: CustomDescribeReplicationGroupsSetOutput
+    set_output_custom_method_name: CustomDescribeReplicationGroupsSetOutput
   CreateReplicationGroup:
-    custom_set_output_operation: CustomCreateReplicationGroupSetOutput
+    set_output_custom_method_name: CustomCreateReplicationGroupSetOutput
   ModifyReplicationGroup:
-    custom_set_output_operation: CustomModifyReplicationGroupSetOutput
+    set_output_custom_method_name: CustomModifyReplicationGroupSetOutput
     override_values:
       ApplyImmediately: true
 ignore:

--- a/services/elasticache/pkg/resource/replication_group/custom_set_output.go
+++ b/services/elasticache/pkg/resource/replication_group/custom_set_output.go
@@ -1,0 +1,65 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package replication_group
+
+import (
+	svcapitypes "github.com/aws/aws-controllers-k8s/services/elasticache/apis/v1alpha1"
+	"github.com/aws/aws-sdk-go/service/elasticache"
+)
+
+func (rm *resourceManager) CustomDescribeReplicationGroupsSetOutput(
+	r *resource,
+	resp *elasticache.DescribeReplicationGroupsOutput,
+	ko *svcapitypes.ReplicationGroup,
+) *svcapitypes.ReplicationGroup {
+	if len(resp.ReplicationGroups) == 0 {
+		return ko
+	}
+	elem := resp.ReplicationGroups[0]
+	rm.customSetOutput(r, elem, ko)
+	return ko
+}
+
+func (rm *resourceManager) CustomCreateReplicationGroupSetOutput(
+	r *resource,
+	resp *elasticache.CreateReplicationGroupOutput,
+	ko *svcapitypes.ReplicationGroup,
+) *svcapitypes.ReplicationGroup {
+	rm.customSetOutput(r, resp.ReplicationGroup, ko)
+	return ko
+}
+
+func (rm *resourceManager) CustomModifyReplicationGroupSetOutput(
+	r *resource,
+	resp *elasticache.ModifyReplicationGroupOutput,
+	ko *svcapitypes.ReplicationGroup,
+) *svcapitypes.ReplicationGroup {
+	rm.customSetOutput(r, resp.ReplicationGroup, ko)
+	return ko
+}
+
+func (rm *resourceManager) customSetOutput(
+	r *resource,
+	respRG *elasticache.ReplicationGroup,
+	ko *svcapitypes.ReplicationGroup,
+) {
+	// TODO: custom code
+	if ko.Status.NodeGroups != nil {
+		for _, nodegroup := range ko.Status.NodeGroups {
+			membersCount := int64(len(nodegroup.NodeGroupMembers))
+			ko.Spec.ReplicasPerNodeGroup = &membersCount
+			break
+		}
+	}
+}

--- a/services/elasticache/pkg/resource/replication_group/sdk.go
+++ b/services/elasticache/pkg/resource/replication_group/sdk.go
@@ -244,6 +244,9 @@ func (rm *resourceManager) sdkFind(
 		return nil, ackerr.NotFound
 	}
 
+	// custom set output from response
+	rm.CustomDescribeReplicationGroupsSetOutput(r, resp, ko)
+
 	return &resource{ko}, nil
 }
 
@@ -424,6 +427,9 @@ func (rm *resourceManager) sdkCreate(
 	if resp.ReplicationGroup.Status != nil {
 		ko.Status.Status = resp.ReplicationGroup.Status
 	}
+
+	// custom set output from response
+	rm.CustomCreateReplicationGroupSetOutput(r, resp, ko)
 
 	ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{OwnerAccountID: &rm.awsAccountID}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
@@ -768,6 +774,9 @@ func (rm *resourceManager) sdkUpdate(
 	if resp.ReplicationGroup.Status != nil {
 		ko.Status.Status = resp.ReplicationGroup.Status
 	}
+
+	// custom set output from response
+	rm.CustomModifyReplicationGroupSetOutput(r, resp, ko)
 
 	return &resource{ko}, nil
 }

--- a/templates/pkg/crd_sdk.go.tpl
+++ b/templates/pkg/crd_sdk.go.tpl
@@ -94,7 +94,6 @@ func (rm *resourceManager) sdkFind(
 		return nil, err
 	}
 {{ $setCode := GoCodeSetReadManyOutput .CRD "resp" "ko" 1 }}
-{{ $setCustomOutputOperation := .CRD.GetCustomSetOutputOperation .CRD.Ops.ReadMany }}
 	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.ReadMany.Name }}WithContext(ctx, input)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceExceptionCode .CRD 404 }}" {
@@ -107,9 +106,9 @@ func (rm *resourceManager) sdkFind(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 {{ $setCode }}
-{{ if $setCustomOutputOperation }}
+{{ if $setOutputCustomMethodName := .CRD.SetOutputCustomMethodName .CRD.Ops.ReadMany }}
 	// custom set output from response
-	rm.{{ $setCustomOutputOperation }}(r, resp, ko)
+	rm.{{ $setOutputCustomMethodName }}(r, resp, ko)
 {{ end }}
 	return &resource{ko}, nil
 {{- else }}
@@ -185,7 +184,6 @@ func (rm *resourceManager) sdkCreate(
 		return nil, err
 	}
 {{ $createCode := GoCodeSetCreateOutput .CRD "resp" "ko.Status" 1 }}
-{{ $setCustomOutputOperation := .CRD.GetCustomSetOutputOperation .CRD.Ops.Create }}
 	{{ if and .CRD.StatusFields ( not ( Empty $createCode ) ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.Create.Name }}WithContext(ctx, input)
 	if respErr != nil {
 		return nil, respErr
@@ -194,9 +192,9 @@ func (rm *resourceManager) sdkCreate(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 {{ $createCode }}
-{{ if $setCustomOutputOperation }}
+{{ if $setOutputCustomMethodName := .CRD.SetOutputCustomMethodName .CRD.Ops.Create }}
 	// custom set output from response
-	rm.{{ $setCustomOutputOperation }}(r, resp, ko)
+	rm.{{ $setOutputCustomMethodName }}(r, resp, ko)
 {{ end }}
 	ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{OwnerAccountID: &rm.awsAccountID}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
@@ -238,7 +236,6 @@ func (rm *resourceManager) sdkUpdate(
 {{ end }}
 
 {{ $setCode := GoCodeSetUpdateOutput .CRD "resp" "ko.Status" 1 }}
-{{ $setCustomOutputOperation := .CRD.GetCustomSetOutputOperation .CRD.Ops.Update }}
 	{{ if and .CRD.StatusFields ( not ( Empty $setCode ) ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.Update.Name }}WithContext(ctx, input)
 	if respErr != nil {
 		return nil, respErr
@@ -247,9 +244,9 @@ func (rm *resourceManager) sdkUpdate(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 {{ $setCode }}
-{{ if $setCustomOutputOperation }}
+{{ if $setOutputCustomMethodName := .CRD.SetOutputCustomMethodName .CRD.Ops.Update }}
 	// custom set output from response
-	rm.{{ $setCustomOutputOperation }}(r, resp, ko)
+	rm.{{ $setOutputCustomMethodName }}(r, resp, ko)
 {{ end }}
 	return &resource{ko}, nil
 {{- else }}


### PR DESCRIPTION
Issue #282 

Description of changes:
Added support for custom set output operations using generator.yaml configuration.
Example:
```
operations:
  DescribeReplicationGroups:
    custom_set_output_operation: CustomDescribeReplicationGroupsSetOutput
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
