### PR TITLE
Add Github action job to build AWS service controllers

### DIFF
--- a/.github/workflows/on.pull-request.main.yaml
+++ b/.github/workflows/on.pull-request.main.yaml
@@ -21,3 +21,27 @@ jobs:
         run: ./scripts/install_mockery.sh
       - name: make test
         run: make test
+
+  build-controllers:
+    name: build service
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+         - s3
+         - ecr
+         - sns
+         - sqs
+         - elasticache
+         - dynamodb
+         - apigatewayv2
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: build service controller
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          make build-controller SERVICE=$SERVICE
+        env:
+          SERVICE: ${{ matrix.service }}

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ publish-controller-image:  ## docker push a container image for SERVICE
 	@echo $(DOCKER_PASSWORD) | docker login -u $(DOCKER_USERNAME) --password-stdin
 	./scripts/publish-controller-image.sh -r $(DOCKER_REPOSITORY) -s $(AWS_SERVICE)
 
-build-controller: build-ack-generate	## Generate controller code for SERVICE
+build-controller: build-ack-generate ## Generate controller code for SERVICE
 	./scripts/build-controller.sh $(AWS_SERVICE)
 
 kind-test: test	## Run functional tests for SERVICE with AWS_ROLE_ARN


### PR DESCRIPTION
Issue N/A

Description of changes:

Add Github action job configuration to generate AWS service controllers
Initial list of generated services: 
- s3
- ecr
- sns
- sqs
- elasticache
- dynamodb
- apigatewayv2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
