### PR TITLE
fix issues with Get/SetAttributes Go code generation

### DIFF
--- a/pkg/generate/config/config.go
+++ b/pkg/generate/config/config.go
@@ -161,6 +161,13 @@ type UnpackAttributesMapConfig struct {
 	// information to the ACK service controller that is useful for determining
 	// observed versus desired state -- then do NOT list that attribute here.
 	Fields map[string]FieldConfig `json:"fields"`
+	// SetAttributesSingleAttribute indicates that the SetAttributes API call
+	// doesn't actually set multiple attributes but rather must be called
+	// multiple times, once for each attribute that needs to change. See SNS
+	// SetTopicAttributes API call, which can be compared to the "normal" SNS
+	// SetPlatformApplicationAttributes API call which accepts multiple
+	// attributes and replaces the supplied attributes map key/values...
+	SetAttributesSingleAttribute bool `json:"set_attributes_single_attribute"`
 }
 
 // FieldConfig contains instructions to the code generator about how
@@ -236,6 +243,22 @@ func (c *Config) UnpacksAttributesMap(resourceName string) bool {
 	}
 	resGenConfig, found := c.Resources[resourceName]
 	return found && resGenConfig.UnpackAttributesMapConfig != nil
+}
+
+// SetAttributesSingleAttribute returns true if the supplied resource name has
+// a SetAttributes operation that only actually changes a single attribute at a
+// time. See: SNS SetTopicAttributes API call, which is entirely different from
+// the SNS SetPlatformApplicationAttributes API call, which sets multiple
+// attributes at once. :shrug:
+func (c *Config) SetAttributesSingleAttribute(resourceName string) bool {
+	if c == nil {
+		return false
+	}
+	resGenConfig, found := c.Resources[resourceName]
+	if !found || resGenConfig.UnpackAttributesMapConfig == nil {
+		return false
+	}
+	return resGenConfig.UnpackAttributesMapConfig.SetAttributesSingleAttribute
 }
 
 // IsIgnoredShape returns true if the supplied shape name should be ignored by the

--- a/pkg/generate/dynamodb_test.go
+++ b/pkg/generate/dynamodb_test.go
@@ -431,6 +431,13 @@ func TestDynamoDB_Table(t *testing.T) {
 		}
 		ko.Status.SSEDescription = f14
 	}
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if resp.Table.TableArn != nil {
+		arn := ackv1alpha1.AWSResourceName(*resp.Table.TableArn)
+		ko.Status.ACKResourceMetadata.ARN = &arn
+	}
 	if resp.Table.TableId != nil {
 		ko.Status.TableID = resp.Table.TableId
 	}

--- a/pkg/generate/ecr_test.go
+++ b/pkg/generate/ecr_test.go
@@ -176,6 +176,13 @@ func TestECRRepository(t *testing.T) {
 	if resp.Repository.RegistryId != nil {
 		ko.Status.RegistryID = resp.Repository.RegistryId
 	}
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if resp.Repository.RepositoryArn != nil {
+		arn := ackv1alpha1.AWSResourceName(*resp.Repository.RepositoryArn)
+		ko.Status.ACKResourceMetadata.ARN = &arn
+	}
 	if resp.Repository.RepositoryUri != nil {
 		ko.Status.RepositoryURI = resp.Repository.RepositoryUri
 	}

--- a/pkg/generate/elasticache_test.go
+++ b/pkg/generate/elasticache_test.go
@@ -254,6 +254,13 @@ func TestElasticache_CacheCluster(t *testing.T) {
 	assert.Equal(expCreateInput, crd.GoCodeSetInput(model.OpTypeCreate, "r.ko", "res", 1))
 
 	expCreateOutput := `
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if resp.CacheCluster.ARN != nil {
+		arn := ackv1alpha1.AWSResourceName(*resp.CacheCluster.ARN)
+		ko.Status.ACKResourceMetadata.ARN = &arn
+	}
 	if resp.CacheCluster.AtRestEncryptionEnabled != nil {
 		ko.Status.AtRestEncryptionEnabled = resp.CacheCluster.AtRestEncryptionEnabled
 	}
@@ -651,7 +658,7 @@ func TestElasticache_Ignored_Resources(t *testing.T) {
 	require.Nil(crd)
 }
 
-func TestElasticache_Override_Values(t *testing.T)  {
+func TestElasticache_Override_Values(t *testing.T) {
 	require := require.New(t)
 
 	g := testutil.NewGeneratorForService(t, "elasticache")

--- a/pkg/generate/rds_test.go
+++ b/pkg/generate/rds_test.go
@@ -378,6 +378,13 @@ func TestRDS_DBInstance(t *testing.T) {
 	if resp.DBInstance.CACertificateIdentifier != nil {
 		ko.Status.CACertificateIdentifier = resp.DBInstance.CACertificateIdentifier
 	}
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if resp.DBInstance.DBInstanceArn != nil {
+		arn := ackv1alpha1.AWSResourceName(*resp.DBInstance.DBInstanceArn)
+		ko.Status.ACKResourceMetadata.ARN = &arn
+	}
 	if resp.DBInstance.DBInstanceStatus != nil {
 		ko.Status.DBInstanceStatus = resp.DBInstance.DBInstanceStatus
 	}

--- a/pkg/generate/sqs_test.go
+++ b/pkg/generate/sqs_test.go
@@ -165,11 +165,11 @@ func TestSQS_Queue(t *testing.T) {
 	// (and thus in the Spec fields). One of them is the resource's ARN which
 	// is handled specially.
 	expGetAttrsOutput := `
+	ko.Status.CreatedTimestamp = resp.Attributes["CreatedTimestamp"]
+	ko.Status.LastModifiedTimestamp = resp.Attributes["LastModifiedTimestamp"]
 	if ko.Status.ACKResourceMetadata == nil {
 		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
 	}
-	ko.Status.CreatedTimestamp = resp.Attributes["CreatedTimestamp"]
-	ko.Status.LastModifiedTimestamp = resp.Attributes["LastModifiedTimestamp"]
 	tmpARN := ackv1alpha1.AWSResourceName(*resp.Attributes["QueueArn"])
 	ko.Status.ACKResourceMetadata.ARN = &tmpARN
 `

--- a/pkg/generate/template.go
+++ b/pkg/generate/template.go
@@ -67,6 +67,9 @@ var (
 		"GoCodeGetAttributesSetInput": func(r *ackmodel.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
 			return r.GoCodeGetAttributesSetInput(sourceVarName, targetVarName, indentLevel)
 		},
+		"GoCodeSetAttributesSetInput": func(r *ackmodel.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
+			return r.GoCodeSetAttributesSetInput(sourceVarName, targetVarName, indentLevel)
+		},
 		"GoCodeGetAttributesSetOutput": func(r *ackmodel.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
 			return r.GoCodeGetAttributesSetOutput(sourceVarName, targetVarName, indentLevel)
 		},
@@ -93,6 +96,9 @@ var (
 		},
 		"GoCodeRequiredFieldsMissingFromGetAttributesInput": func(r *ackmodel.CRD, koVarName string, indentLevel int) string {
 			return r.GoCodeRequiredFieldsMissingFromShape(ackmodel.OpTypeGetAttributes, koVarName, indentLevel)
+		},
+		"GoCodeRequiredFieldsMissingFromSetAttributesInput": func(r *ackmodel.CRD, koVarName string, indentLevel int) string {
+			return r.GoCodeRequiredFieldsMissingFromShape(ackmodel.OpTypeSetAttributes, koVarName, indentLevel)
 		},
 	}
 )

--- a/pkg/generate/testdata/models/apis/sns/0000-00-00/generator.yaml
+++ b/pkg/generate/testdata/models/apis/sns/0000-00-00/generator.yaml
@@ -1,6 +1,7 @@
 resources:
   Topic:
     unpack_attributes_map:
+      set_attributes_single_attribute: true
       fields:
         DeliveryPolicy:
         DisplayName:

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -274,6 +274,15 @@ func (r *CRD) UnpacksAttributesMap() bool {
 	return r.genCfg.UnpacksAttributesMap(r.Names.Original)
 }
 
+// SetAttributesSingleAttribute returns true if the supplied resource name has
+// a SetAttributes operation that only actually changes a single attribute at a
+// time. See: SNS SetTopicAttributes API call, which is entirely different from
+// the SNS SetPlatformApplicationAttributes API call, which sets multiple
+// attributes at once. :shrug:
+func (r *CRD) SetAttributesSingleAttribute() bool {
+	return r.genCfg.SetAttributesSingleAttribute(r.Names.Original)
+}
+
 // UnpackAttributes grabs instructions about fields that are represented in the
 // AWS API as a `map[string]*string` but are actually real, schema'd fields and
 // adds CRDField definitions for those fields.
@@ -426,6 +435,8 @@ func (r *CRD) GoCodeRequiredFieldsMissingFromShape(
 		op = r.Ops.ReadOne
 	case OpTypeGetAttributes:
 		op = r.Ops.GetAttributes
+	case OpTypeSetAttributes:
+		op = r.Ops.SetAttributes
 	default:
 		return ""
 	}
@@ -454,6 +465,20 @@ func (r *CRD) goCodeRequiredFieldsMissingFromShape(
 	// corresponding resource Spec/Status values
 	missing := []string{}
 	for _, memberName := range shape.Required {
+		if r.UnpacksAttributesMap() {
+			// We set the Attributes field specially... depending on whether
+			// the SetAttributes API call uses the batch or single attribute
+			// flavor
+			if r.SetAttributesSingleAttribute() {
+				if memberName == "AttributeName" || memberName == "AttributeValue" {
+					continue
+				}
+			} else {
+				if memberName == "Attributes" {
+					continue
+				}
+			}
+		}
 		if r.IsPrimaryARNField(memberName) {
 			primaryARNCondition := fmt.Sprintf(
 				"(%s.Status.ACKResourceMetadata == nil || %s.Status.ACKResourceMetadata.ARN == nil)",
@@ -840,6 +865,11 @@ func (r *CRD) GoCodeGetAttributesSetInput(
 	if inputShape == nil {
 		return ""
 	}
+	if !r.UnpacksAttributesMap() {
+		// This is a bug in the code generation if this occurs...
+		msg := fmt.Sprintf("called GoCodeGetAttributesSetInput for a resource '%s' that doesn't unpack attributes map", r.Names.Original)
+		panic(msg)
+	}
 
 	out := "\n"
 	indent := strings.Repeat("\t", indentLevel)
@@ -873,6 +903,192 @@ func (r *CRD) GoCodeGetAttributesSetInput(
 			continue
 		}
 
+		cleanMemberNames := names.New(memberName)
+		cleanMemberName := cleanMemberNames.Camel
+
+		sourceVarPath := sourceVarName
+		field, found := r.SpecFields[memberName]
+		if found {
+			sourceVarPath = sourceVarName + ".Spec." + cleanMemberName
+		} else {
+			field, found = r.StatusFields[memberName]
+			if !found {
+				// If it isn't in our spec/status fields, just ignore it
+				continue
+			}
+			sourceVarPath = sourceVarPath + ".Status." + cleanMemberName
+		}
+		out += fmt.Sprintf(
+			"%sif %s != nil {\n",
+			indent, sourceVarPath,
+		)
+		out += r.goCodeSetInputForScalar(
+			memberName,
+			targetVarName,
+			inputShape.Type,
+			sourceVarPath,
+			field.ShapeRef,
+			indentLevel+1,
+		)
+		out += fmt.Sprintf(
+			"%s}\n", indent,
+		)
+	}
+	return out
+}
+
+// GoCodeSetAttributesSetInput returns the Go code that sets the Input shape for a
+// resource's SetAttributes operation.
+//
+// Unfortunately, the AWS SetAttributes API operations (even within the *same*
+// API) are inconsistent regarding whether the SetAttributes sets a batch of
+// attributes or a single attribute. We need to construct the method
+// differently depending on this behaviour. For example, the SNS
+// SetTopicAttributes API call actually only allows the caller to set a single
+// attribute, which needs to be specified in an AttributeName and
+// AttributeValue field in the Input shape. On the other hand, the SNS
+// SetPlatformApplicationAttributes API call's Input shape has an Attributes
+// field which is a map[string]string containing all the attribute key/value
+// pairs to replace. Your guess is as good as mine as to why these APIs are
+// different.
+//
+// The returned code looks something like this:
+//
+// attrMap := map[string]*string{}
+// if r.ko.Spec.DeliveryPolicy != nil {
+//     attrMap["DeliveryPolicy"] = r.ko.Spec.DeliveryPolicy
+// }
+// if r.ko.Spec.DisplayName != nil {
+//     attrMap["DisplayName"} = r.ko.Spec.DisplayName
+// }
+// if r.ko.Spec.KMSMasterKeyID != nil {
+//     attrMap["KmsMasterKeyId"] = r.ko.Spec.KMSMasterKeyID
+// }
+// if r.ko.Spec.Policy != nil {
+//     attrMap["Policy"] = r.ko.Spec.Policy
+// }
+// res.SetAttributes(attrMap)
+func (r *CRD) GoCodeSetAttributesSetInput(
+	// String representing the name of the variable that we will grab the Input
+	// shape from. This will likely be "r.ko" since in the templates that call
+	// this method, the "source variable" is the CRD struct which is used to
+	// populate the target variable, which is the Input shape
+	sourceVarName string,
+	// String representing the name of the variable that we will be **setting**
+	// with values we get from the Output shape. This will likely be
+	// "res" since that is the name of the "target variable" that the
+	// templates that call this method use for the Input shape.
+	targetVarName string,
+	// Number of levels of indentation to use
+	indentLevel int,
+) string {
+	op := r.Ops.SetAttributes
+	if op == nil {
+		return ""
+	}
+	inputShape := op.InputRef.Shape
+	if inputShape == nil {
+		return ""
+	}
+	if !r.UnpacksAttributesMap() {
+		// This is a bug in the code generation if this occurs...
+		msg := fmt.Sprintf("called GoCodeSetAttributesSetInput for a resource '%s' that doesn't unpack attributes map", r.Names.Original)
+		panic(msg)
+	}
+
+	if r.SetAttributesSingleAttribute() {
+		// TODO(jaypipes): For now, because these APIs require *multiple* calls
+		// to the backend, one for each attribute being set, we'll go ahead and
+		// rely on the CustomOperation functionality to write code for these...
+		return ""
+	}
+
+	out := "\n"
+	indent := strings.Repeat("\t", indentLevel)
+
+	for _, memberName := range inputShape.MemberNames() {
+		if r.IsPrimaryARNField(memberName) {
+			// if ko.Status.ACKResourceMetadata != nil && ko.Status.ACKResourceMetadata.ARN != nil {
+			//     res.SetTopicArn(string(*ko.Status.ACKResourceMetadata.ARN))
+			// } else {
+			//     res.SetTopicArn(rm.ARNFromName(*ko.Spec.Name))
+			// }
+			out += fmt.Sprintf(
+				"%sif %s.Status.ACKResourceMetadata != nil && %s.Status.ACKResourceMetadata.ARN != nil {\n",
+				indent, sourceVarName, sourceVarName,
+			)
+			out += fmt.Sprintf(
+				"%s\t%s.Set%s(string(*%s.Status.ACKResourceMetadata.ARN))\n",
+				indent, targetVarName, memberName, sourceVarName,
+			)
+			out += fmt.Sprintf(
+				"%s} else {\n", indent,
+			)
+			nameField := r.NameField()
+			out += fmt.Sprintf(
+				"%s\t%s.Set%s(rm.ARNFromName(*%s.Spec.%s))\n",
+				indent, targetVarName, memberName, sourceVarName, nameField,
+			)
+			out += fmt.Sprintf(
+				"%s}\n", indent,
+			)
+			continue
+		}
+		if memberName == "Attributes" {
+			// For APIs that use a pattern of a parameter called "Attributes" that
+			// is of type `map[string]*string` to represent real, schema'd fields,
+			// we need to set the input shape's "Attributes" member field to the
+			// re-constructed, packed set of fields.
+			//
+			// Therefore, we output here something like this (example from SNS
+			// Topic's Attributes map):
+			//
+			// attrMap := map[string]*string{}
+			// if r.ko.Spec.DeliveryPolicy != nil {
+			//     attrMap["DeliveryPolicy"] = r.ko.Spec.DeliveryPolicy
+			// }
+			// if r.ko.Spec.DisplayName != nil {
+			//     attrMap["DisplayName"} = r.ko.Spec.DisplayName
+			// }
+			// if r.ko.Spec.KMSMasterKeyID != nil {
+			//     attrMap["KmsMasterKeyId"] = r.ko.Spec.KMSMasterKeyID
+			// }
+			// if r.ko.Spec.Policy != nil {
+			//     attrMap["Policy"] = r.ko.Spec.Policy
+			// }
+			// res.SetAttributes(attrMap)
+			attrMapConfig := r.genCfg.Resources[r.Names.Original].UnpackAttributesMapConfig
+			out += fmt.Sprintf("%sattrMap := map[string]*string{}\n", indent)
+			sortedAttrFieldNames := []string{}
+			for fieldName := range attrMapConfig.Fields {
+				sortedAttrFieldNames = append(sortedAttrFieldNames, fieldName)
+			}
+			sort.Strings(sortedAttrFieldNames)
+			for _, fieldName := range sortedAttrFieldNames {
+				fieldConfig := attrMapConfig.Fields[fieldName]
+				fieldNames := names.New(fieldName)
+				if !fieldConfig.IsReadOnly {
+					sourceAdaptedVarName := sourceVarName + ".Spec." + fieldNames.Camel
+					out += fmt.Sprintf(
+						"%sif %s != nil {\n",
+						indent, sourceAdaptedVarName,
+					)
+					out += fmt.Sprintf(
+						"%s\tattrMap[\"%s\"] = %s\n",
+						indent, fieldName, sourceAdaptedVarName,
+					)
+					out += fmt.Sprintf(
+						"%s}\n", indent,
+					)
+				}
+			}
+			out += fmt.Sprintf("%s%s.SetAttributes(attrMap)\n", indent, targetVarName)
+			continue
+		}
+
+		// Handle setting any other Input shape fields that are not the ARN
+		// field or the Attributes unpacked map. The field value may come from
+		// either the Spec or the Status fields.
 		cleanMemberNames := names.New(memberName)
 		cleanMemberName := cleanMemberNames.Camel
 

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -98,12 +98,12 @@ func (r *reconciler) reconcile(req ctrlrt.Request) error {
 	acctID := r.getOwnerAccountID(res)
 	region := r.getRegion(res)
 
-	log := r.log.WithValues(
+	r.log = r.log.WithValues(
 		"account_id", acctID,
 		"region", region,
 		"kind", r.rd.GroupKind().String(),
 	)
-	log.V(1).Info("starting reconcilation")
+	r.log.V(1).Info("starting reconcilation")
 
 	rm, err := r.rmf.ManagerFor(r, acctID, region)
 	if err != nil {
@@ -153,7 +153,7 @@ func (r *reconciler) sync(
 		if err != nil {
 			return err
 		}
-		r.log.V(1).Info(
+		r.log.V(0).Info(
 			"reconciler.sync created new resource",
 			"arn", latest.Identifiers().ARN(),
 		)
@@ -174,7 +174,7 @@ func (r *reconciler) sync(
 		if err != nil {
 			return err
 		}
-		r.log.V(1).Info("reconciler.sync updated resource")
+		r.log.V(0).Info("reconciler.sync updated resource")
 	}
 	changedStatus, err := r.rd.UpdateCRStatus(latest)
 	if err != nil {
@@ -216,7 +216,7 @@ func (r *reconciler) cleanup(
 	if err = rm.Delete(ctx, observed); err != nil {
 		return err
 	}
-	r.log.V(1).Info("reconciler.cleanup deleted resource")
+	r.log.V(0).Info("reconciler.cleanup deleted resource")
 
 	// Now that external AWS service resources have been appropriately cleaned
 	// up, we remove the finalizer representing the CR is managed by ACK,

--- a/services/sns/config/rbac/cluster-role-binding.yaml
+++ b/services/sns/config/rbac/cluster-role-binding.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ack-controller-role
+  name: ack-controller
 subjects:
 - kind: ServiceAccount
   name: default

--- a/services/sns/generator.yaml
+++ b/services/sns/generator.yaml
@@ -1,6 +1,7 @@
 resources:
   Topic:
     unpack_attributes_map:
+      set_attributes_single_attribute: true
       fields:
         DeliveryPolicy:
         DisplayName:

--- a/services/sns/pkg/resource/platform_application/sdk.go
+++ b/services/sns/pkg/resource/platform_application/sdk.go
@@ -196,8 +196,91 @@ func (rm *resourceManager) sdkUpdate(
 	r *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
-	// TODO(jaypipes): Figure this out...
-	return nil, nil
+	// If any required fields in the input shape are missing, AWS resource is
+	// not created yet. And sdkUpdate should never be called if this is the
+	// case, and it's an error in the generated code if it is...
+	if rm.requiredFieldsMissingFromSetAttributesInput(r) {
+		panic("Required field in SetAttributes input shape missing!")
+	}
+
+	input, err := rm.newSetAttributesRequestPayload(r)
+	if err != nil {
+		return nil, err
+	}
+
+	// NOTE(jaypipes): SetAttributes calls return a response but they don't
+	// contain any useful information. Instead, below, we'll be returning a
+	// DeepCopy of the supplied desired state, which should be fine because
+	// that desired state has been constructed from a call to GetAttributes...
+	_, respErr := rm.sdkapi.SetPlatformApplicationAttributesWithContext(ctx, input)
+	if respErr != nil {
+		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFound" {
+			// Technically, this means someone deleted the backend resource in
+			// between the time we got a result back from sdkFind() and here...
+			return nil, ackerr.NotFound
+		}
+		return nil, respErr
+	}
+
+	// Merge in the information we read from the API call above to the copy of
+	// the original Kubernetes object we passed to the function
+	ko := r.ko.DeepCopy()
+	return &resource{ko}, nil
+}
+
+// requiredFieldsMissingFromSetAtttributesInput returns true if there are any
+// fields for the SetAttributes Input shape that are required by not present in
+// the resource's Spec or Status
+func (rm *resourceManager) requiredFieldsMissingFromSetAttributesInput(
+	r *resource,
+) bool {
+	return (r.ko.Status.ACKResourceMetadata == nil || r.ko.Status.ACKResourceMetadata.ARN == nil)
+
+}
+
+// newSetAttributesRequestPayload returns SDK-specific struct for the HTTP
+// request payload of the SetAttributes API call for the resource
+func (rm *resourceManager) newSetAttributesRequestPayload(
+	r *resource,
+) (*svcsdk.SetPlatformApplicationAttributesInput, error) {
+	res := &svcsdk.SetPlatformApplicationAttributesInput{}
+
+	attrMap := map[string]*string{}
+	if r.ko.Spec.EventDeliveryFailure != nil {
+		attrMap["EventDeliveryFailure"] = r.ko.Spec.EventDeliveryFailure
+	}
+	if r.ko.Spec.EventEndpointCreated != nil {
+		attrMap["EventEndpointCreated"] = r.ko.Spec.EventEndpointCreated
+	}
+	if r.ko.Spec.EventEndpointDeleted != nil {
+		attrMap["EventEndpointDeleted"] = r.ko.Spec.EventEndpointDeleted
+	}
+	if r.ko.Spec.EventEndpointUpdated != nil {
+		attrMap["EventEndpointUpdated"] = r.ko.Spec.EventEndpointUpdated
+	}
+	if r.ko.Spec.FailureFeedbackRoleARN != nil {
+		attrMap["FailureFeedbackRoleArn"] = r.ko.Spec.FailureFeedbackRoleARN
+	}
+	if r.ko.Spec.PlatformCredential != nil {
+		attrMap["PlatformCredential"] = r.ko.Spec.PlatformCredential
+	}
+	if r.ko.Spec.PlatformPrincipal != nil {
+		attrMap["PlatformPrincipal"] = r.ko.Spec.PlatformPrincipal
+	}
+	if r.ko.Spec.SuccessFeedbackRoleARN != nil {
+		attrMap["SuccessFeedbackRoleArn"] = r.ko.Spec.SuccessFeedbackRoleARN
+	}
+	if r.ko.Spec.SuccessFeedbackSampleRate != nil {
+		attrMap["SuccessFeedbackSampleRate"] = r.ko.Spec.SuccessFeedbackSampleRate
+	}
+	res.SetAttributes(attrMap)
+	if r.ko.Status.ACKResourceMetadata != nil && r.ko.Status.ACKResourceMetadata.ARN != nil {
+		res.SetPlatformApplicationArn(string(*r.ko.Status.ACKResourceMetadata.ARN))
+	} else {
+		res.SetPlatformApplicationArn(rm.ARNFromName(*r.ko.Spec.Name))
+	}
+
+	return res, nil
 }
 
 // sdkDelete deletes the supplied resource in the backend AWS service API

--- a/services/sns/pkg/resource/platform_endpoint/sdk.go
+++ b/services/sns/pkg/resource/platform_endpoint/sdk.go
@@ -72,7 +72,12 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.EndpointARN = resp.EndpointArn
 	}
 
-	ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{OwnerAccountID: &rm.awsAccountID}
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	return &resource{ko}, nil
 }

--- a/services/sns/pkg/resource/topic/sdk.go
+++ b/services/sns/pkg/resource/topic/sdk.go
@@ -201,8 +201,56 @@ func (rm *resourceManager) sdkUpdate(
 	r *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
-	// TODO(jaypipes): Figure this out...
-	return nil, nil
+	// If any required fields in the input shape are missing, AWS resource is
+	// not created yet. And sdkUpdate should never be called if this is the
+	// case, and it's an error in the generated code if it is...
+	if rm.requiredFieldsMissingFromSetAttributesInput(r) {
+		panic("Required field in SetAttributes input shape missing!")
+	}
+
+	input, err := rm.newSetAttributesRequestPayload(r)
+	if err != nil {
+		return nil, err
+	}
+
+	// NOTE(jaypipes): SetAttributes calls return a response but they don't
+	// contain any useful information. Instead, below, we'll be returning a
+	// DeepCopy of the supplied desired state, which should be fine because
+	// that desired state has been constructed from a call to GetAttributes...
+	_, respErr := rm.sdkapi.SetTopicAttributesWithContext(ctx, input)
+	if respErr != nil {
+		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFound" {
+			// Technically, this means someone deleted the backend resource in
+			// between the time we got a result back from sdkFind() and here...
+			return nil, ackerr.NotFound
+		}
+		return nil, respErr
+	}
+
+	// Merge in the information we read from the API call above to the copy of
+	// the original Kubernetes object we passed to the function
+	ko := r.ko.DeepCopy()
+	return &resource{ko}, nil
+}
+
+// requiredFieldsMissingFromSetAtttributesInput returns true if there are any
+// fields for the SetAttributes Input shape that are required by not present in
+// the resource's Spec or Status
+func (rm *resourceManager) requiredFieldsMissingFromSetAttributesInput(
+	r *resource,
+) bool {
+	return (r.ko.Status.ACKResourceMetadata == nil || r.ko.Status.ACKResourceMetadata.ARN == nil)
+
+}
+
+// newSetAttributesRequestPayload returns SDK-specific struct for the HTTP
+// request payload of the SetAttributes API call for the resource
+func (rm *resourceManager) newSetAttributesRequestPayload(
+	r *resource,
+) (*svcsdk.SetTopicAttributesInput, error) {
+	res := &svcsdk.SetTopicAttributesInput{}
+
+	return res, nil
 }
 
 // sdkDelete deletes the supplied resource in the backend AWS service API

--- a/services/sns/pkg/resource/topic/sdk.go
+++ b/services/sns/pkg/resource/topic/sdk.go
@@ -43,6 +43,13 @@ func (rm *resourceManager) sdkFind(
 	ctx context.Context,
 	r *resource,
 ) (*resource, error) {
+	// If any required fields in the input shape are missing, AWS resource is
+	// not created yet. Return NotFound here to indicate to callers that the
+	// resource isn't yet created.
+	if rm.requiredFieldsMissingFromGetAttributesInput(r) {
+		return nil, ackerr.NotFound
+	}
+
 	input, err := rm.newGetAttributesRequestPayload(r)
 	if err != nil {
 		return nil, err
@@ -60,10 +67,10 @@ func (rm *resourceManager) sdkFind(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 
+	ko.Status.EffectiveDeliveryPolicy = resp.Attributes["EffectiveDeliveryPolicy"]
 	if ko.Status.ACKResourceMetadata == nil {
 		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
 	}
-	ko.Status.EffectiveDeliveryPolicy = resp.Attributes["EffectiveDeliveryPolicy"]
 	tmpOwnerID := ackv1alpha1.AWSAccountID(*resp.Attributes["Owner"])
 	ko.Status.ACKResourceMetadata.OwnerAccountID = &tmpOwnerID
 	tmpARN := ackv1alpha1.AWSResourceName(*resp.Attributes["TopicArn"])
@@ -80,6 +87,16 @@ func (rm *resourceManager) newListRequestPayload(
 	res := &svcsdk.ListTopicsInput{}
 
 	return res, nil
+}
+
+// requiredFieldsMissingFromGetAtttributesInput returns true if there are any
+// fields for the GetAttributes Input shape that are required by not present in
+// the resource's Spec or Status
+func (rm *resourceManager) requiredFieldsMissingFromGetAttributesInput(
+	r *resource,
+) bool {
+	return (r.ko.Status.ACKResourceMetadata == nil || r.ko.Status.ACKResourceMetadata.ARN == nil)
+
 }
 
 // newGetAttributesRequestPayload returns SDK-specific struct for the HTTP
@@ -109,7 +126,7 @@ func (rm *resourceManager) sdkCreate(
 		return nil, err
 	}
 
-	_, respErr := rm.sdkapi.CreateTopicWithContext(ctx, input)
+	resp, respErr := rm.sdkapi.CreateTopicWithContext(ctx, input)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -117,7 +134,20 @@ func (rm *resourceManager) sdkCreate(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 
-	ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{OwnerAccountID: &rm.awsAccountID}
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if resp.TopicArn != nil {
+		arn := ackv1alpha1.AWSResourceName(*resp.TopicArn)
+		ko.Status.ACKResourceMetadata.ARN = &arn
+	}
+
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	return &resource{ko}, nil
 }

--- a/templates/pkg/crd_sdk.go.tpl
+++ b/templates/pkg/crd_sdk.go.tpl
@@ -254,6 +254,37 @@ func (rm *resourceManager) sdkUpdate(
 	rm.{{ $setOutputCustomMethodName }}(r, resp, ko)
 {{ end }}
 	return &resource{ko}, nil
+{{- else if .CRD.Ops.SetAttributes }}
+	// If any required fields in the input shape are missing, AWS resource is
+	// not created yet. And sdkUpdate should never be called if this is the
+	// case, and it's an error in the generated code if it is...
+	if rm.requiredFieldsMissingFromSetAttributesInput(r) {
+		panic("Required field in SetAttributes input shape missing!")
+	}
+
+	input, err := rm.newSetAttributesRequestPayload(r)
+	if err != nil {
+		return nil, err
+	}
+
+	// NOTE(jaypipes): SetAttributes calls return a response but they don't
+	// contain any useful information. Instead, below, we'll be returning a
+	// DeepCopy of the supplied desired state, which should be fine because
+	// that desired state has been constructed from a call to GetAttributes...
+	_, respErr := rm.sdkapi.{{ .CRD.Ops.SetAttributes.Name }}WithContext(ctx, input)
+	if respErr != nil {
+		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceExceptionCode .CRD 404 }}" {
+			// Technically, this means someone deleted the backend resource in
+			// between the time we got a result back from sdkFind() and here...
+			return nil, ackerr.NotFound
+		}
+		return nil, respErr
+	}
+
+	// Merge in the information we read from the API call above to the copy of
+	// the original Kubernetes object we passed to the function
+	ko := r.ko.DeepCopy()
+	return &resource{ko}, nil
 {{- else }}
 	// TODO(jaypipes): Figure this out...
 	return nil, nil
@@ -271,6 +302,27 @@ func (rm *resourceManager) newUpdateRequestPayload(
 	return res, nil
 }
 {{ end }}
+
+{{- if .CRD.Ops.SetAttributes }}
+// requiredFieldsMissingFromSetAtttributesInput returns true if there are any
+// fields for the SetAttributes Input shape that are required by not present in
+// the resource's Spec or Status
+func (rm *resourceManager) requiredFieldsMissingFromSetAttributesInput(
+	r *resource,
+) bool {
+{{ GoCodeRequiredFieldsMissingFromSetAttributesInput .CRD "r.ko" 1 }}
+}
+
+// newSetAttributesRequestPayload returns SDK-specific struct for the HTTP
+// request payload of the SetAttributes API call for the resource
+func (rm *resourceManager) newSetAttributesRequestPayload(
+	r *resource,
+) (*svcsdk.{{ .CRD.Ops.SetAttributes.InputRef.Shape.ShapeName }}, error) {
+	res := &svcsdk.{{ .CRD.Ops.SetAttributes.InputRef.Shape.ShapeName }}{}
+{{ GoCodeSetAttributesSetInput .CRD "r.ko" "res" 1 }}
+	return res, nil
+}
+{{- end }}
 
 // sdkDelete deletes the supplied resource in the backend AWS service API
 func (rm *resourceManager) sdkDelete(


### PR DESCRIPTION
This patch adds to the code generator for the SDK linkage for APIs that
use the SetAttributes-flavor of updating a resource. Previously, the
`sdk.go` files for these APIs had empty `sdkUpdate` operations with a
big TODO that ended up breaking the service controller (quite
predictably).

While implementing this patch, I stumbled upon yet another unexplainable
inconsistency between two SetAttributes operations within the SNS
service API. The SNS `SetPlatformApplicationAttributes` API call accepts a
field in its Input shape called `Attributes` that is a map of key/value
pairs for attributes to set on the platform application. Unfortunately,
the similarly-named SNS `SetTopicAttributes` API call apparently does
*NOT* work the same way. Instead, there is a single `AttributeName` and
`AttributeValue` field in the Input shape and you need to call the
`SetTopicAttributes` API call once for each modified attribute. :(

In fact, the [official documentation][0] for the SNS SetTopicAttributes
API call says that the `AttributeName` field in the Input shape is
actually a "*map* of attributes with their corresponding values". But
that isn't actually the case...

So, the code in this patch for now just contains a TODO in the
`CRD.GoCodeSetAttributesSetInput()` method for SetAttributes APIs that
can only operate on a single attribute at a time. We will use the
CustomOperation functionality as a temporary workaround for these APIs
while we come up with a more permanent code-generated solution.

There were a series of problems that I uncovered when investigating the
cause of Issue #296:

* The code returned from GoCodeGetAttributesForOutput was failing to set
  `Status.ACKResourceMetadata.ARN` and
  `Status.ACKResourceMetadata.OwnerAccountID` when the attribute fields
  corresponded to the primary resource ARN or the owner ID. This was the
  direct cause of Issue #296
* The code in `templates/pkg/crd_sdk.go.tpl` that ran at the end of the
  `sdkCreate()` call was inadvertently overwriting any setters of
  `Status.ACKResourceMetadata` that had previously executed
* The code returned from APIs with GetAttributes operations was *always*
  returning a nil-guard and constructor for the ACKResourceMetadata
  struct, even when no attribute fields actually set either ARN or
  OwnerAccountID. When I removed the check in the template for Status
  fields being required for the `resp` variable to be defined, this was
  causing `"resp" variable unused` compilation failures

Issue #296

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
