### PR TITLE
Using the Go official proxy in controllers Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ARG service_alias
 ARG work_dir=/github.com/aws/aws-controllers-k8s
 WORKDIR $work_dir
 # For building Go Module required
-ENV GOPROXY=direct
+ENV GOPROXY=https://proxy.golang.org,direct
 ENV GO111MODULE=on
 ENV GOARCH=amd64
 ENV GOOS=linux


### PR DESCRIPTION
Issue N/A

In the last 24hours building controllers images was failing with the following error:
```
------
 > [builder 5/7] RUN  go mod download:
#11 145.6 go: sigs.k8s.io/controller-runtime@v0.6.0 requires
#11 145.6       gomodules.xyz/jsonpatch/v2@v2.0.1: unrecognized import path "gomodules.xyz/jsonpatch/v2": reading https://gomodules.xyz/jsonpatch/v2?go-get=1: 404 Not Found
#11 145.6       server response: 404 page not found
------
```

Apparently there some networking issues with the domain `gomodules.xyz`. Using the Go official proxy is solving the issue.

Description of changes:
- Use `GOPROXY=https://proxy.golang.org` in controllers `Dockerfile`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
