### PR TITLE
the r option has an argument. specify colon to fix parsing

### DIFF
--- a/scripts/publish-controller-image.sh
+++ b/scripts/publish-controller-image.sh
@@ -30,7 +30,7 @@ Options:
 "
 
 # Process our input arguments
-while getopts "rs:i:" opt; do
+while getopts "r:s:i:" opt; do
   case ${opt} in
     q ) # Build image quietly
         QUIET=true


### PR DESCRIPTION
Issue #322 , if available:

Description of changes:

the r option has an argument. specify colon to fix parsing. Now you can specify a non-default different repository on the command line.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
