### PR TITLE
Updating Spec and Status from ReadOne & ReadMany calls

### DIFF
--- a/pkg/generate/apigwv2_test.go
+++ b/pkg/generate/apigwv2_test.go
@@ -222,11 +222,64 @@ func TestAPIGatewayV2_Route(t *testing.T) {
 	if resp.ApiGatewayManaged != nil {
 		ko.Status.APIGatewayManaged = resp.ApiGatewayManaged
 	}
+	if resp.ApiKeyRequired != nil {
+		ko.Spec.APIKeyRequired = resp.ApiKeyRequired
+	}
+	if resp.AuthorizationScopes != nil {
+		f2 := []*string{}
+		for _, f2iter := range resp.AuthorizationScopes {
+			var f2elem string
+			f2elem = *f2iter
+			f2 = append(f2, &f2elem)
+		}
+		ko.Spec.AuthorizationScopes = f2
+	}
+	if resp.AuthorizationType != nil {
+		ko.Spec.AuthorizationType = resp.AuthorizationType
+	}
+	if resp.AuthorizerId != nil {
+		ko.Spec.AuthorizerID = resp.AuthorizerId
+	}
+	if resp.ModelSelectionExpression != nil {
+		ko.Spec.ModelSelectionExpression = resp.ModelSelectionExpression
+	}
+	if resp.OperationName != nil {
+		ko.Spec.OperationName = resp.OperationName
+	}
+	if resp.RequestModels != nil {
+		f7 := map[string]*string{}
+		for f7key, f7valiter := range resp.RequestModels {
+			var f7val string
+			f7val = *f7valiter
+			f7[f7key] = &f7val
+		}
+		ko.Spec.RequestModels = f7
+	}
+	if resp.RequestParameters != nil {
+		f8 := map[string]*svcapitypes.ParameterConstraints{}
+		for f8key, f8valiter := range resp.RequestParameters {
+			f8val := &svcapitypes.ParameterConstraints{}
+			if f8valiter.Required != nil {
+				f8val.Required = f8valiter.Required
+			}
+			f8[f8key] = f8val
+		}
+		ko.Spec.RequestParameters = f8
+	}
 	if resp.RouteId != nil {
 		ko.Status.RouteID = resp.RouteId
 	}
+	if resp.RouteKey != nil {
+		ko.Spec.RouteKey = resp.RouteKey
+	}
+	if resp.RouteResponseSelectionExpression != nil {
+		ko.Spec.RouteResponseSelectionExpression = resp.RouteResponseSelectionExpression
+	}
+	if resp.Target != nil {
+		ko.Spec.Target = resp.Target
+	}
 `
-	assert.Equal(expCreateOutput, crd.GoCodeSetOutput(model.OpTypeCreate, "resp", "ko.Status", 1))
+	assert.Equal(expCreateOutput, crd.GoCodeSetOutput(model.OpTypeCreate, "resp", "ko", 1))
 
 	expRequiredFieldsCode := `
 	return r.ko.Spec.APIID == nil || r.ko.Status.RouteID == nil

--- a/pkg/generate/codedeploy_test.go
+++ b/pkg/generate/codedeploy_test.go
@@ -96,7 +96,7 @@ func TestCodeDeploy_Deployment(t *testing.T) {
 		ko.Status.DeploymentID = resp.DeploymentId
 	}
 `
-	assert.Equal(expCreateOutput, crd.GoCodeSetOutput(model.OpTypeCreate, "resp", "ko.Status", 1))
+	assert.Equal(expCreateOutput, crd.GoCodeSetOutput(model.OpTypeCreate, "resp", "ko", 1))
 
 	expStatusFieldCamel := []string{
 		// All of the fields in the Deployment resource's CreateDeploymentInput

--- a/pkg/generate/dynamodb_test.go
+++ b/pkg/generate/dynamodb_test.go
@@ -326,6 +326,20 @@ func TestDynamoDB_Table(t *testing.T) {
 		}
 		ko.Status.ArchivalSummary = f0
 	}
+	if resp.Table.AttributeDefinitions != nil {
+		f1 := []*svcapitypes.AttributeDefinition{}
+		for _, f1iter := range resp.Table.AttributeDefinitions {
+			f1elem := &svcapitypes.AttributeDefinition{}
+			if f1iter.AttributeName != nil {
+				f1elem.AttributeName = f1iter.AttributeName
+			}
+			if f1iter.AttributeType != nil {
+				f1elem.AttributeType = f1iter.AttributeType
+			}
+			f1 = append(f1, f1elem)
+		}
+		ko.Spec.AttributeDefinitions = f1
+	}
 	if resp.Table.BillingModeSummary != nil {
 		f2 := &svcapitypes.BillingModeSummary{}
 		if resp.Table.BillingModeSummary.BillingMode != nil {
@@ -339,17 +353,133 @@ func TestDynamoDB_Table(t *testing.T) {
 	if resp.Table.CreationDateTime != nil {
 		ko.Status.CreationDateTime = &metav1.Time{*resp.Table.CreationDateTime}
 	}
+	if resp.Table.GlobalSecondaryIndexes != nil {
+		f4 := []*svcapitypes.GlobalSecondaryIndex{}
+		for _, f4iter := range resp.Table.GlobalSecondaryIndexes {
+			f4elem := &svcapitypes.GlobalSecondaryIndex{}
+			if f4iter.IndexName != nil {
+				f4elem.IndexName = f4iter.IndexName
+			}
+			if f4iter.KeySchema != nil {
+				f4elemf6 := []*svcapitypes.KeySchemaElement{}
+				for _, f4elemf6iter := range f4iter.KeySchema {
+					f4elemf6elem := &svcapitypes.KeySchemaElement{}
+					if f4elemf6iter.AttributeName != nil {
+						f4elemf6elem.AttributeName = f4elemf6iter.AttributeName
+					}
+					if f4elemf6iter.KeyType != nil {
+						f4elemf6elem.KeyType = f4elemf6iter.KeyType
+					}
+					f4elemf6 = append(f4elemf6, f4elemf6elem)
+				}
+				f4elem.KeySchema = f4elemf6
+			}
+			if f4iter.Projection != nil {
+				f4elemf7 := &svcapitypes.Projection{}
+				if f4iter.Projection.NonKeyAttributes != nil {
+					f4elemf7f0 := []*string{}
+					for _, f4elemf7f0iter := range f4iter.Projection.NonKeyAttributes {
+						var f4elemf7f0elem string
+						f4elemf7f0elem = *f4elemf7f0iter
+						f4elemf7f0 = append(f4elemf7f0, &f4elemf7f0elem)
+					}
+					f4elemf7.NonKeyAttributes = f4elemf7f0
+				}
+				if f4iter.Projection.ProjectionType != nil {
+					f4elemf7.ProjectionType = f4iter.Projection.ProjectionType
+				}
+				f4elem.Projection = f4elemf7
+			}
+			if f4iter.ProvisionedThroughput != nil {
+				f4elemf8 := &svcapitypes.ProvisionedThroughput{}
+				if f4iter.ProvisionedThroughput.ReadCapacityUnits != nil {
+					f4elemf8.ReadCapacityUnits = f4iter.ProvisionedThroughput.ReadCapacityUnits
+				}
+				if f4iter.ProvisionedThroughput.WriteCapacityUnits != nil {
+					f4elemf8.WriteCapacityUnits = f4iter.ProvisionedThroughput.WriteCapacityUnits
+				}
+				f4elem.ProvisionedThroughput = f4elemf8
+			}
+			f4 = append(f4, f4elem)
+		}
+		ko.Spec.GlobalSecondaryIndexes = f4
+	}
 	if resp.Table.GlobalTableVersion != nil {
 		ko.Status.GlobalTableVersion = resp.Table.GlobalTableVersion
 	}
 	if resp.Table.ItemCount != nil {
 		ko.Status.ItemCount = resp.Table.ItemCount
 	}
+	if resp.Table.KeySchema != nil {
+		f7 := []*svcapitypes.KeySchemaElement{}
+		for _, f7iter := range resp.Table.KeySchema {
+			f7elem := &svcapitypes.KeySchemaElement{}
+			if f7iter.AttributeName != nil {
+				f7elem.AttributeName = f7iter.AttributeName
+			}
+			if f7iter.KeyType != nil {
+				f7elem.KeyType = f7iter.KeyType
+			}
+			f7 = append(f7, f7elem)
+		}
+		ko.Spec.KeySchema = f7
+	}
 	if resp.Table.LatestStreamArn != nil {
 		ko.Status.LatestStreamARN = resp.Table.LatestStreamArn
 	}
 	if resp.Table.LatestStreamLabel != nil {
 		ko.Status.LatestStreamLabel = resp.Table.LatestStreamLabel
+	}
+	if resp.Table.LocalSecondaryIndexes != nil {
+		f10 := []*svcapitypes.LocalSecondaryIndex{}
+		for _, f10iter := range resp.Table.LocalSecondaryIndexes {
+			f10elem := &svcapitypes.LocalSecondaryIndex{}
+			if f10iter.IndexName != nil {
+				f10elem.IndexName = f10iter.IndexName
+			}
+			if f10iter.KeySchema != nil {
+				f10elemf4 := []*svcapitypes.KeySchemaElement{}
+				for _, f10elemf4iter := range f10iter.KeySchema {
+					f10elemf4elem := &svcapitypes.KeySchemaElement{}
+					if f10elemf4iter.AttributeName != nil {
+						f10elemf4elem.AttributeName = f10elemf4iter.AttributeName
+					}
+					if f10elemf4iter.KeyType != nil {
+						f10elemf4elem.KeyType = f10elemf4iter.KeyType
+					}
+					f10elemf4 = append(f10elemf4, f10elemf4elem)
+				}
+				f10elem.KeySchema = f10elemf4
+			}
+			if f10iter.Projection != nil {
+				f10elemf5 := &svcapitypes.Projection{}
+				if f10iter.Projection.NonKeyAttributes != nil {
+					f10elemf5f0 := []*string{}
+					for _, f10elemf5f0iter := range f10iter.Projection.NonKeyAttributes {
+						var f10elemf5f0elem string
+						f10elemf5f0elem = *f10elemf5f0iter
+						f10elemf5f0 = append(f10elemf5f0, &f10elemf5f0elem)
+					}
+					f10elemf5.NonKeyAttributes = f10elemf5f0
+				}
+				if f10iter.Projection.ProjectionType != nil {
+					f10elemf5.ProjectionType = f10iter.Projection.ProjectionType
+				}
+				f10elem.Projection = f10elemf5
+			}
+			f10 = append(f10, f10elem)
+		}
+		ko.Spec.LocalSecondaryIndexes = f10
+	}
+	if resp.Table.ProvisionedThroughput != nil {
+		f11 := &svcapitypes.ProvisionedThroughput{}
+		if resp.Table.ProvisionedThroughput.ReadCapacityUnits != nil {
+			f11.ReadCapacityUnits = resp.Table.ProvisionedThroughput.ReadCapacityUnits
+		}
+		if resp.Table.ProvisionedThroughput.WriteCapacityUnits != nil {
+			f11.WriteCapacityUnits = resp.Table.ProvisionedThroughput.WriteCapacityUnits
+		}
+		ko.Spec.ProvisionedThroughput = f11
 	}
 	if resp.Table.Replicas != nil {
 		f12 := []*svcapitypes.ReplicaDescription{}
@@ -431,6 +561,16 @@ func TestDynamoDB_Table(t *testing.T) {
 		}
 		ko.Status.SSEDescription = f14
 	}
+	if resp.Table.StreamSpecification != nil {
+		f15 := &svcapitypes.StreamSpecification{}
+		if resp.Table.StreamSpecification.StreamEnabled != nil {
+			f15.StreamEnabled = resp.Table.StreamSpecification.StreamEnabled
+		}
+		if resp.Table.StreamSpecification.StreamViewType != nil {
+			f15.StreamViewType = resp.Table.StreamSpecification.StreamViewType
+		}
+		ko.Spec.StreamSpecification = f15
+	}
 	if ko.Status.ACKResourceMetadata == nil {
 		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
 	}
@@ -441,6 +581,9 @@ func TestDynamoDB_Table(t *testing.T) {
 	if resp.Table.TableId != nil {
 		ko.Status.TableID = resp.Table.TableId
 	}
+	if resp.Table.TableName != nil {
+		ko.Spec.TableName = resp.Table.TableName
+	}
 	if resp.Table.TableSizeBytes != nil {
 		ko.Status.TableSizeBytes = resp.Table.TableSizeBytes
 	}
@@ -448,5 +591,5 @@ func TestDynamoDB_Table(t *testing.T) {
 		ko.Status.TableStatus = resp.Table.TableStatus
 	}
 `
-	assert.Equal(expReadOneOutput, crd.GoCodeSetOutput(model.OpTypeGet, "resp", "ko.Status", 1))
+	assert.Equal(expReadOneOutput, crd.GoCodeSetOutput(model.OpTypeGet, "resp", "ko", 1))
 }

--- a/pkg/generate/ec2_test.go
+++ b/pkg/generate/ec2_test.go
@@ -492,6 +492,9 @@ func TestEC2_LaunchTemplate(t *testing.T) {
 	if resp.LaunchTemplate.LaunchTemplateId != nil {
 		ko.Status.LaunchTemplateID = resp.LaunchTemplate.LaunchTemplateId
 	}
+	if resp.LaunchTemplate.LaunchTemplateName != nil {
+		ko.Spec.LaunchTemplateName = resp.LaunchTemplate.LaunchTemplateName
+	}
 	if resp.LaunchTemplate.Tags != nil {
 		f6 := []*svcapitypes.Tag{}
 		for _, f6iter := range resp.LaunchTemplate.Tags {
@@ -507,7 +510,7 @@ func TestEC2_LaunchTemplate(t *testing.T) {
 		ko.Status.Tags = f6
 	}
 `
-	assert.Equal(expCreateOutput, crd.GoCodeSetOutput(model.OpTypeCreate, "resp", "ko.Status", 1))
+	assert.Equal(expCreateOutput, crd.GoCodeSetOutput(model.OpTypeCreate, "resp", "ko", 1))
 
 	// The EC2 LaunchTemplate API has a "normal" set of CUD operations:
 	//

--- a/pkg/generate/ecr_test.go
+++ b/pkg/generate/ecr_test.go
@@ -173,6 +173,16 @@ func TestECRRepository(t *testing.T) {
 	if resp.Repository.CreatedAt != nil {
 		ko.Status.CreatedAt = &metav1.Time{*resp.Repository.CreatedAt}
 	}
+	if resp.Repository.ImageScanningConfiguration != nil {
+		f1 := &svcapitypes.ImageScanningConfiguration{}
+		if resp.Repository.ImageScanningConfiguration.ScanOnPush != nil {
+			f1.ScanOnPush = resp.Repository.ImageScanningConfiguration.ScanOnPush
+		}
+		ko.Spec.ImageScanningConfiguration = f1
+	}
+	if resp.Repository.ImageTagMutability != nil {
+		ko.Spec.ImageTagMutability = resp.Repository.ImageTagMutability
+	}
 	if resp.Repository.RegistryId != nil {
 		ko.Status.RegistryID = resp.Repository.RegistryId
 	}
@@ -183,11 +193,14 @@ func TestECRRepository(t *testing.T) {
 		arn := ackv1alpha1.AWSResourceName(*resp.Repository.RepositoryArn)
 		ko.Status.ACKResourceMetadata.ARN = &arn
 	}
+	if resp.Repository.RepositoryName != nil {
+		ko.Spec.RepositoryName = resp.Repository.RepositoryName
+	}
 	if resp.Repository.RepositoryUri != nil {
 		ko.Status.RepositoryURI = resp.Repository.RepositoryUri
 	}
 `
-	assert.Equal(expCreateOutput, crd.GoCodeSetOutput(model.OpTypeCreate, "resp", "ko.Status", 1))
+	assert.Equal(expCreateOutput, crd.GoCodeSetOutput(model.OpTypeCreate, "resp", "ko", 1))
 
 	// Check that the DescribeRepositories output is filtered by the
 	// RepositoryName field of the CR's Spec, since there is no ReadOne

--- a/pkg/generate/elasticache_test.go
+++ b/pkg/generate/elasticache_test.go
@@ -270,11 +270,20 @@ func TestElasticache_CacheCluster(t *testing.T) {
 	if resp.CacheCluster.AuthTokenLastModifiedDate != nil {
 		ko.Status.AuthTokenLastModifiedDate = &metav1.Time{*resp.CacheCluster.AuthTokenLastModifiedDate}
 	}
+	if resp.CacheCluster.AutoMinorVersionUpgrade != nil {
+		ko.Spec.AutoMinorVersionUpgrade = resp.CacheCluster.AutoMinorVersionUpgrade
+	}
 	if resp.CacheCluster.CacheClusterCreateTime != nil {
 		ko.Status.CacheClusterCreateTime = &metav1.Time{*resp.CacheCluster.CacheClusterCreateTime}
 	}
+	if resp.CacheCluster.CacheClusterId != nil {
+		ko.Spec.CacheClusterID = resp.CacheCluster.CacheClusterId
+	}
 	if resp.CacheCluster.CacheClusterStatus != nil {
 		ko.Status.CacheClusterStatus = resp.CacheCluster.CacheClusterStatus
+	}
+	if resp.CacheCluster.CacheNodeType != nil {
+		ko.Spec.CacheNodeType = resp.CacheCluster.CacheNodeType
 	}
 	if resp.CacheCluster.CacheNodes != nil {
 		f9 := []*svcapitypes.CacheNode{}
@@ -345,6 +354,9 @@ func TestElasticache_CacheCluster(t *testing.T) {
 		}
 		ko.Status.CacheSecurityGroups = f11
 	}
+	if resp.CacheCluster.CacheSubnetGroupName != nil {
+		ko.Spec.CacheSubnetGroupName = resp.CacheCluster.CacheSubnetGroupName
+	}
 	if resp.CacheCluster.ClientDownloadLandingPage != nil {
 		ko.Status.ClientDownloadLandingPage = resp.CacheCluster.ClientDownloadLandingPage
 	}
@@ -358,6 +370,12 @@ func TestElasticache_CacheCluster(t *testing.T) {
 		}
 		ko.Status.ConfigurationEndpoint = f14
 	}
+	if resp.CacheCluster.Engine != nil {
+		ko.Spec.Engine = resp.CacheCluster.Engine
+	}
+	if resp.CacheCluster.EngineVersion != nil {
+		ko.Spec.EngineVersion = resp.CacheCluster.EngineVersion
+	}
 	if resp.CacheCluster.NotificationConfiguration != nil {
 		f17 := &svcapitypes.NotificationConfiguration{}
 		if resp.CacheCluster.NotificationConfiguration.TopicArn != nil {
@@ -367,6 +385,9 @@ func TestElasticache_CacheCluster(t *testing.T) {
 			f17.TopicStatus = resp.CacheCluster.NotificationConfiguration.TopicStatus
 		}
 		ko.Status.NotificationConfiguration = f17
+	}
+	if resp.CacheCluster.NumCacheNodes != nil {
+		ko.Spec.NumCacheNodes = resp.CacheCluster.NumCacheNodes
 	}
 	if resp.CacheCluster.PendingModifiedValues != nil {
 		f19 := &svcapitypes.PendingModifiedValues{}
@@ -393,6 +414,15 @@ func TestElasticache_CacheCluster(t *testing.T) {
 		}
 		ko.Status.PendingModifiedValues = f19
 	}
+	if resp.CacheCluster.PreferredAvailabilityZone != nil {
+		ko.Spec.PreferredAvailabilityZone = resp.CacheCluster.PreferredAvailabilityZone
+	}
+	if resp.CacheCluster.PreferredMaintenanceWindow != nil {
+		ko.Spec.PreferredMaintenanceWindow = resp.CacheCluster.PreferredMaintenanceWindow
+	}
+	if resp.CacheCluster.ReplicationGroupId != nil {
+		ko.Spec.ReplicationGroupID = resp.CacheCluster.ReplicationGroupId
+	}
 	if resp.CacheCluster.SecurityGroups != nil {
 		f23 := []*svcapitypes.SecurityGroupMembership{}
 		for _, f23iter := range resp.CacheCluster.SecurityGroups {
@@ -407,11 +437,17 @@ func TestElasticache_CacheCluster(t *testing.T) {
 		}
 		ko.Status.SecurityGroups = f23
 	}
+	if resp.CacheCluster.SnapshotRetentionLimit != nil {
+		ko.Spec.SnapshotRetentionLimit = resp.CacheCluster.SnapshotRetentionLimit
+	}
+	if resp.CacheCluster.SnapshotWindow != nil {
+		ko.Spec.SnapshotWindow = resp.CacheCluster.SnapshotWindow
+	}
 	if resp.CacheCluster.TransitEncryptionEnabled != nil {
 		ko.Status.TransitEncryptionEnabled = resp.CacheCluster.TransitEncryptionEnabled
 	}
 `
-	assert.Equal(expCreateOutput, crd.GoCodeSetOutput(model.OpTypeCreate, "resp", "ko.Status", 1))
+	assert.Equal(expCreateOutput, crd.GoCodeSetOutput(model.OpTypeCreate, "resp", "ko", 1))
 
 	// Elasticache doesn't have a ReadOne operation; only a List/ReadMany
 	// operation. Let's verify that the construction of the

--- a/pkg/generate/rds_test.go
+++ b/pkg/generate/rds_test.go
@@ -431,14 +431,6 @@ func TestRDS_DBInstance(t *testing.T) {
 		}
 		ko.Status.DBParameterGroups = f14
 	}
-	if resp.DBInstance.DBSecurityGroups != nil {
-		f15 := []*string{}
-		for _, f15iter := range resp.DBInstance.DBSecurityGroups {
-			var f15elem string
-			f15 = append(f15, f15elem)
-		}
-		ko.Spec.DBSecurityGroups = f15
-	}
 	if resp.DBInstance.DBSubnetGroup != nil {
 		f16 := &svcapitypes.DBSubnetGroup_SDK{}
 		if resp.DBInstance.DBSubnetGroup.DBSubnetGroupArn != nil {
@@ -875,14 +867,6 @@ func TestRDS_DBInstance(t *testing.T) {
 				f14 = append(f14, f14elem)
 			}
 			ko.Status.DBParameterGroups = f14
-		}
-		if elem.DBSecurityGroups != nil {
-			f15 := []*string{}
-			for _, f15iter := range elem.DBSecurityGroups {
-				var f15elem string
-				f15 = append(f15, f15elem)
-			}
-			ko.Spec.DBSecurityGroups = f15
 		}
 		if elem.DBSubnetGroup != nil {
 			f16 := &svcapitypes.DBSubnetGroup_SDK{}

--- a/pkg/generate/rds_test.go
+++ b/pkg/generate/rds_test.go
@@ -16,11 +16,10 @@ package generate_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/aws/aws-controllers-k8s/pkg/model"
 	"github.com/aws/aws-controllers-k8s/pkg/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRDS_DBInstance(t *testing.T) {
@@ -358,6 +357,9 @@ func TestRDS_DBInstance(t *testing.T) {
 	assert.Equal(expCreateInput, crd.GoCodeSetInput(model.OpTypeCreate, "r.ko", "res", 1))
 
 	expCreateOutput := `
+	if resp.DBInstance.AllocatedStorage != nil {
+		ko.Spec.AllocatedStorage = resp.DBInstance.AllocatedStorage
+	}
 	if resp.DBInstance.AssociatedRoles != nil {
 		f1 := []*svcapitypes.DBInstanceRole{}
 		for _, f1iter := range resp.DBInstance.AssociatedRoles {
@@ -375,8 +377,26 @@ func TestRDS_DBInstance(t *testing.T) {
 		}
 		ko.Status.AssociatedRoles = f1
 	}
+	if resp.DBInstance.AutoMinorVersionUpgrade != nil {
+		ko.Spec.AutoMinorVersionUpgrade = resp.DBInstance.AutoMinorVersionUpgrade
+	}
+	if resp.DBInstance.AvailabilityZone != nil {
+		ko.Spec.AvailabilityZone = resp.DBInstance.AvailabilityZone
+	}
+	if resp.DBInstance.BackupRetentionPeriod != nil {
+		ko.Spec.BackupRetentionPeriod = resp.DBInstance.BackupRetentionPeriod
+	}
 	if resp.DBInstance.CACertificateIdentifier != nil {
 		ko.Status.CACertificateIdentifier = resp.DBInstance.CACertificateIdentifier
+	}
+	if resp.DBInstance.CharacterSetName != nil {
+		ko.Spec.CharacterSetName = resp.DBInstance.CharacterSetName
+	}
+	if resp.DBInstance.CopyTagsToSnapshot != nil {
+		ko.Spec.CopyTagsToSnapshot = resp.DBInstance.CopyTagsToSnapshot
+	}
+	if resp.DBInstance.DBClusterIdentifier != nil {
+		ko.Spec.DBClusterIdentifier = resp.DBInstance.DBClusterIdentifier
 	}
 	if ko.Status.ACKResourceMetadata == nil {
 		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
@@ -385,8 +405,17 @@ func TestRDS_DBInstance(t *testing.T) {
 		arn := ackv1alpha1.AWSResourceName(*resp.DBInstance.DBInstanceArn)
 		ko.Status.ACKResourceMetadata.ARN = &arn
 	}
+	if resp.DBInstance.DBInstanceClass != nil {
+		ko.Spec.DBInstanceClass = resp.DBInstance.DBInstanceClass
+	}
+	if resp.DBInstance.DBInstanceIdentifier != nil {
+		ko.Spec.DBInstanceIdentifier = resp.DBInstance.DBInstanceIdentifier
+	}
 	if resp.DBInstance.DBInstanceStatus != nil {
 		ko.Status.DBInstanceStatus = resp.DBInstance.DBInstanceStatus
+	}
+	if resp.DBInstance.DBName != nil {
+		ko.Spec.DBName = resp.DBInstance.DBName
 	}
 	if resp.DBInstance.DBParameterGroups != nil {
 		f14 := []*svcapitypes.DBParameterGroupStatus_SDK{}
@@ -401,6 +430,14 @@ func TestRDS_DBInstance(t *testing.T) {
 			f14 = append(f14, f14elem)
 		}
 		ko.Status.DBParameterGroups = f14
+	}
+	if resp.DBInstance.DBSecurityGroups != nil {
+		f15 := []*string{}
+		for _, f15iter := range resp.DBInstance.DBSecurityGroups {
+			var f15elem string
+			f15 = append(f15, f15elem)
+		}
+		ko.Spec.DBSecurityGroups = f15
 	}
 	if resp.DBInstance.DBSubnetGroup != nil {
 		f16 := &svcapitypes.DBSubnetGroup_SDK{}
@@ -455,6 +492,9 @@ func TestRDS_DBInstance(t *testing.T) {
 	if resp.DBInstance.DbiResourceId != nil {
 		ko.Status.DBIResourceID = resp.DBInstance.DbiResourceId
 	}
+	if resp.DBInstance.DeletionProtection != nil {
+		ko.Spec.DeletionProtection = resp.DBInstance.DeletionProtection
+	}
 	if resp.DBInstance.DomainMemberships != nil {
 		f20 := []*svcapitypes.DomainMembership{}
 		for _, f20iter := range resp.DBInstance.DomainMemberships {
@@ -497,6 +537,12 @@ func TestRDS_DBInstance(t *testing.T) {
 		}
 		ko.Status.Endpoint = f22
 	}
+	if resp.DBInstance.Engine != nil {
+		ko.Spec.Engine = resp.DBInstance.Engine
+	}
+	if resp.DBInstance.EngineVersion != nil {
+		ko.Spec.EngineVersion = resp.DBInstance.EngineVersion
+	}
 	if resp.DBInstance.EnhancedMonitoringResourceArn != nil {
 		ko.Status.EnhancedMonitoringResourceARN = resp.DBInstance.EnhancedMonitoringResourceArn
 	}
@@ -506,8 +552,17 @@ func TestRDS_DBInstance(t *testing.T) {
 	if resp.DBInstance.InstanceCreateTime != nil {
 		ko.Status.InstanceCreateTime = &metav1.Time{*resp.DBInstance.InstanceCreateTime}
 	}
+	if resp.DBInstance.Iops != nil {
+		ko.Spec.IOPS = resp.DBInstance.Iops
+	}
+	if resp.DBInstance.KmsKeyId != nil {
+		ko.Spec.KMSKeyID = resp.DBInstance.KmsKeyId
+	}
 	if resp.DBInstance.LatestRestorableTime != nil {
 		ko.Status.LatestRestorableTime = &metav1.Time{*resp.DBInstance.LatestRestorableTime}
+	}
+	if resp.DBInstance.LicenseModel != nil {
+		ko.Spec.LicenseModel = resp.DBInstance.LicenseModel
 	}
 	if resp.DBInstance.ListenerEndpoint != nil {
 		f32 := &svcapitypes.Endpoint{}
@@ -521,6 +576,21 @@ func TestRDS_DBInstance(t *testing.T) {
 			f32.Port = resp.DBInstance.ListenerEndpoint.Port
 		}
 		ko.Status.ListenerEndpoint = f32
+	}
+	if resp.DBInstance.MasterUsername != nil {
+		ko.Spec.MasterUsername = resp.DBInstance.MasterUsername
+	}
+	if resp.DBInstance.MaxAllocatedStorage != nil {
+		ko.Spec.MaxAllocatedStorage = resp.DBInstance.MaxAllocatedStorage
+	}
+	if resp.DBInstance.MonitoringInterval != nil {
+		ko.Spec.MonitoringInterval = resp.DBInstance.MonitoringInterval
+	}
+	if resp.DBInstance.MonitoringRoleArn != nil {
+		ko.Spec.MonitoringRoleARN = resp.DBInstance.MonitoringRoleArn
+	}
+	if resp.DBInstance.MultiAZ != nil {
+		ko.Spec.MultiAZ = resp.DBInstance.MultiAZ
 	}
 	if resp.DBInstance.OptionGroupMemberships != nil {
 		f38 := []*svcapitypes.OptionGroupMembership{}
@@ -618,6 +688,38 @@ func TestRDS_DBInstance(t *testing.T) {
 	if resp.DBInstance.PerformanceInsightsEnabled != nil {
 		ko.Status.PerformanceInsightsEnabled = resp.DBInstance.PerformanceInsightsEnabled
 	}
+	if resp.DBInstance.PerformanceInsightsKMSKeyId != nil {
+		ko.Spec.PerformanceInsightsKMSKeyID = resp.DBInstance.PerformanceInsightsKMSKeyId
+	}
+	if resp.DBInstance.PerformanceInsightsRetentionPeriod != nil {
+		ko.Spec.PerformanceInsightsRetentionPeriod = resp.DBInstance.PerformanceInsightsRetentionPeriod
+	}
+	if resp.DBInstance.PreferredBackupWindow != nil {
+		ko.Spec.PreferredBackupWindow = resp.DBInstance.PreferredBackupWindow
+	}
+	if resp.DBInstance.PreferredMaintenanceWindow != nil {
+		ko.Spec.PreferredMaintenanceWindow = resp.DBInstance.PreferredMaintenanceWindow
+	}
+	if resp.DBInstance.ProcessorFeatures != nil {
+		f45 := []*svcapitypes.ProcessorFeature{}
+		for _, f45iter := range resp.DBInstance.ProcessorFeatures {
+			f45elem := &svcapitypes.ProcessorFeature{}
+			if f45iter.Name != nil {
+				f45elem.Name = f45iter.Name
+			}
+			if f45iter.Value != nil {
+				f45elem.Value = f45iter.Value
+			}
+			f45 = append(f45, f45elem)
+		}
+		ko.Spec.ProcessorFeatures = f45
+	}
+	if resp.DBInstance.PromotionTier != nil {
+		ko.Spec.PromotionTier = resp.DBInstance.PromotionTier
+	}
+	if resp.DBInstance.PubliclyAccessible != nil {
+		ko.Spec.PubliclyAccessible = resp.DBInstance.PubliclyAccessible
+	}
 	if resp.DBInstance.ReadReplicaDBClusterIdentifiers != nil {
 		f48 := []*string{}
 		for _, f48iter := range resp.DBInstance.ReadReplicaDBClusterIdentifiers {
@@ -662,6 +764,18 @@ func TestRDS_DBInstance(t *testing.T) {
 		}
 		ko.Status.StatusInfos = f52
 	}
+	if resp.DBInstance.StorageEncrypted != nil {
+		ko.Spec.StorageEncrypted = resp.DBInstance.StorageEncrypted
+	}
+	if resp.DBInstance.StorageType != nil {
+		ko.Spec.StorageType = resp.DBInstance.StorageType
+	}
+	if resp.DBInstance.TdeCredentialArn != nil {
+		ko.Spec.TDECredentialARN = resp.DBInstance.TdeCredentialArn
+	}
+	if resp.DBInstance.Timezone != nil {
+		ko.Spec.Timezone = resp.DBInstance.Timezone
+	}
 	if resp.DBInstance.VpcSecurityGroups != nil {
 		f57 := []*svcapitypes.VPCSecurityGroupMembership{}
 		for _, f57iter := range resp.DBInstance.VpcSecurityGroups {
@@ -677,7 +791,7 @@ func TestRDS_DBInstance(t *testing.T) {
 		ko.Status.VPCSecurityGroups = f57
 	}
 `
-	assert.Equal(expCreateOutput, crd.GoCodeSetOutput(model.OpTypeCreate, "resp", "ko.Status", 1))
+	assert.Equal(expCreateOutput, crd.GoCodeSetOutput(model.OpTypeCreate, "resp", "ko", 1))
 
 	// This asserts that the fields of the Spec and Status structs of the
 	// target variable are constructed with cleaned, renamed-friendly names
@@ -763,15 +877,9 @@ func TestRDS_DBInstance(t *testing.T) {
 			ko.Status.DBParameterGroups = f14
 		}
 		if elem.DBSecurityGroups != nil {
-			f15 := []*svcapitypes.DBSecurityGroupMembership{}
+			f15 := []*string{}
 			for _, f15iter := range elem.DBSecurityGroups {
-				f15elem := &svcapitypes.DBSecurityGroupMembership{}
-				if f15iter.DBSecurityGroupName != nil {
-					f15elem.DBSecurityGroupName = f15iter.DBSecurityGroupName
-				}
-				if f15iter.Status != nil {
-					f15elem.Status = f15iter.Status
-				}
+				var f15elem string
 				f15 = append(f15, f15elem)
 			}
 			ko.Spec.DBSecurityGroups = f15

--- a/pkg/generate/s3_test.go
+++ b/pkg/generate/s3_test.go
@@ -130,7 +130,7 @@ func TestS3_Bucket(t *testing.T) {
 		ko.Status.Location = resp.Location
 	}
 `
-	assert.Equal(expCreateOutput, crd.GoCodeSetOutput(model.OpTypeCreate, "resp", "ko.Status", 1))
+	assert.Equal(expCreateOutput, crd.GoCodeSetOutput(model.OpTypeCreate, "resp", "ko", 1))
 
 	expDeleteInput := `
 	if r.ko.Spec.Name != nil {

--- a/pkg/generate/sns_test.go
+++ b/pkg/generate/sns_test.go
@@ -182,7 +182,7 @@ func TestSNS_Topic(t *testing.T) {
 		ko.Status.ACKResourceMetadata.ARN = &arn
 	}
 `
-	assert.Equal(expCreateOutput, crd.GoCodeSetOutput(model.OpTypeCreate, "resp", "ko.Status", 1))
+	assert.Equal(expCreateOutput, crd.GoCodeSetOutput(model.OpTypeCreate, "resp", "ko", 1))
 
 	// The input shape for the GetAttributes operation has a single TopicArn
 	// field. This field represents the ARN of the primary resource (the Topic

--- a/pkg/generate/sqs_test.go
+++ b/pkg/generate/sqs_test.go
@@ -146,7 +146,7 @@ func TestSQS_Queue(t *testing.T) {
 		ko.Status.QueueURL = resp.QueueUrl
 	}
 `
-	assert.Equal(expCreateOutput, crd.GoCodeSetOutput(model.OpTypeCreate, "resp", "ko.Status", 1))
+	assert.Equal(expCreateOutput, crd.GoCodeSetOutput(model.OpTypeCreate, "resp", "ko", 1))
 
 	// The input shape for the GetAttributes operation technically has two
 	// fields in it: an AttributeNames list of attribute keys to file

--- a/pkg/generate/testdata/models/apis/rds/0000-00-00/generator.yaml
+++ b/pkg/generate/testdata/models/apis/rds/0000-00-00/generator.yaml
@@ -1,0 +1,3 @@
+ignore:
+  shape_names:
+    - DBSecurityGroupMembershipList

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -313,7 +313,6 @@ func (r *CRD) IsPrimaryARNField(fieldName string) bool {
 		strings.EqualFold(fieldName, r.Names.Original+"arn")
 }
 
-
 // SetOutputCustomMethodName returns custom set output operation as *string for
 // given operation on custom resource, if specified in generator config
 func (r *CRD) SetOutputCustomMethodName(
@@ -336,7 +335,7 @@ func (r *CRD) SetOutputCustomMethodName(
 // GetCustomImplementation returns custom implementation method name for the
 // supplied operation as specified in generator config
 func (r *CRD) GetCustomImplementation(
-// The type of operation
+	// The type of operation
 	op *awssdkmodel.Operation,
 ) string {
 	if op == nil || r.genCfg == nil {
@@ -1511,6 +1510,7 @@ func (r *CRD) GoCodeSetOutput(
 	// creating temporary variables, populating those temporary variables'
 	// fields with further-nested fields as needed
 	for memberIndex, memberName := range outputShape.MemberNames() {
+		//TODO: (vijat@) should these field be renamed before looking them up in spec?
 		sourceAdaptedVarName := sourceVarName + "." + memberName
 
 		// Handle the special case of ARN for primary resource identifier
@@ -1519,12 +1519,12 @@ func (r *CRD) GoCodeSetOutput(
 			//     ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
 			// }
 			out += fmt.Sprintf(
-				"%sif %s.ACKResourceMetadata == nil {\n",
+				"%sif %s.Status.ACKResourceMetadata == nil {\n",
 				indent,
 				targetVarName,
 			)
 			out += fmt.Sprintf(
-				"%s\t%s.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}\n",
+				"%s\t%s.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}\n",
 				indent,
 				targetVarName,
 			)
@@ -1544,7 +1544,7 @@ func (r *CRD) GoCodeSetOutput(
 				sourceAdaptedVarName,
 			)
 			out += fmt.Sprintf(
-				"%s\t%s.ACKResourceMetadata.ARN = &arn\n",
+				"%s\t%s.Status.ACKResourceMetadata.ARN = &arn\n",
 				indent,
 				targetVarName,
 			)
@@ -1552,8 +1552,8 @@ func (r *CRD) GoCodeSetOutput(
 			continue
 		}
 
-		memberShapeRef := outputShape.MemberRefs[memberName]
-		if memberShapeRef.Shape == nil {
+		sourceMemberShapeRef := outputShape.MemberRefs[memberName]
+		if sourceMemberShapeRef.Shape == nil {
 			// Technically this should not happen, so let's bail here if it
 			// does...
 			msg := fmt.Sprintf(
@@ -1563,21 +1563,29 @@ func (r *CRD) GoCodeSetOutput(
 			panic(msg)
 		}
 
-		memberShape := memberShapeRef.Shape
-		if r.genCfg.IsIgnoredShape(memberShape.ShapeName) {
+		sourceMemberShape := sourceMemberShapeRef.Shape
+		if r.genCfg.IsIgnoredShape(sourceMemberShape.ShapeName) {
 			continue
 		}
 
-		statusField, found := r.StatusFields[memberName]
-		if !found {
-			// Note that not all fields in the output shape will be in the
-			// Status fields collection of the CRD. If a same-named field is in
-			// the Spec, then that's where it stays. This function is only here
-			// to set the Status field values after getting a response via the
-			// aws-sdk-go for an API call...
-			continue
+		// Determine whether the input shape's field is in the Spec or the
+		// Status struct and set the source variable appropriately.
+		var crdField *CRDField
+		var found bool
+		var targetMemberShapeRef *awssdkmodel.ShapeRef
+		targetAdaptedVarName := targetVarName
+		crdField, found = r.SpecFields[memberName]
+		if found {
+			targetAdaptedVarName += ".Spec"
+		} else {
+			crdField, found = r.StatusFields[memberName]
+			if !found {
+				// TODO(jaypipes): check generator config for exceptions?
+				continue
+			}
+			targetAdaptedVarName += ".Status"
 		}
-
+		targetMemberShapeRef = crdField.ShapeRef
 		// fieldVarName is the name of the variable that is used for temporary
 		// storage of complex member field values
 		//
@@ -1610,36 +1618,38 @@ func (r *CRD) GoCodeSetOutput(
 		out += fmt.Sprintf(
 			"%sif %s != nil {\n", indent, sourceAdaptedVarName,
 		)
-		switch memberShape.Type {
+
+		switch sourceMemberShape.Type {
 		case "list", "structure", "map":
 			{
 				memberVarName := fmt.Sprintf("f%d", memberIndex)
 				out += r.goCodeVarEmptyConstructorK8sType(
 					memberVarName,
-					memberShape,
+					targetMemberShapeRef.Shape,
 					indentLevel+1,
 				)
 				out += r.goCodeSetOutputForContainer(
-					statusField.Names.Camel,
+					crdField.Names.Camel,
 					memberVarName,
+					targetMemberShapeRef,
 					sourceAdaptedVarName,
-					memberShapeRef,
+					sourceMemberShapeRef,
 					indentLevel+1,
 				)
 				out += r.goCodeSetOutputForScalar(
-					statusField.Names.Camel,
-					targetVarName,
+					crdField.Names.Camel,
+					targetAdaptedVarName,
 					memberVarName,
-					memberShapeRef,
+					sourceMemberShapeRef,
 					indentLevel+1,
 				)
 			}
 		default:
 			out += r.goCodeSetOutputForScalar(
-				statusField.Names.Camel,
-				targetVarName,
+				crdField.Names.Camel,
+				targetAdaptedVarName,
 				sourceAdaptedVarName,
-				memberShapeRef,
+				sourceMemberShapeRef,
 				indentLevel+1,
 			)
 		}
@@ -1720,7 +1730,7 @@ func (r *CRD) goCodeSetOutputReadMany(
 	indent := strings.Repeat("\t", indentLevel)
 
 	listShapeName := ""
-	var elemShape *awssdkmodel.Shape
+	var sourceElemShape *awssdkmodel.Shape
 
 	// Find the element in the output shape that contains the list of
 	// resources. This heuristic is simplistic (just look for the field with a
@@ -1729,7 +1739,7 @@ func (r *CRD) goCodeSetOutputReadMany(
 	for memberName, memberShapeRef := range outputShape.MemberRefs {
 		if memberShapeRef.Shape.Type == "list" {
 			listShapeName = memberName
-			elemShape = memberShapeRef.Shape.MemberRef.Shape
+			sourceElemShape = memberShapeRef.Shape.MemberRef.Shape
 			break
 		}
 	}
@@ -1760,10 +1770,10 @@ func (r *CRD) goCodeSetOutputReadMany(
 		"%sfor _, elem := range %s.%s {\n",
 		indent, sourceVarName, listShapeName,
 	)
-	for memberIndex, memberName := range elemShape.MemberNames() {
-		memberShapeRef := elemShape.MemberRefs[memberName]
-		memberShape := memberShapeRef.Shape
-		if r.genCfg.IsIgnoredShape(memberShape.ShapeName) {
+	for memberIndex, memberName := range sourceElemShape.MemberNames() {
+		sourceMemberShapeRef := sourceElemShape.MemberRefs[memberName]
+		sourceMemberShape := sourceMemberShapeRef.Shape
+		if r.genCfg.IsIgnoredShape(sourceMemberShape.ShapeName) {
 			continue
 		}
 		sourceAdaptedVarName := "elem." + memberName
@@ -1806,6 +1816,7 @@ func (r *CRD) goCodeSetOutputReadMany(
 		// Status struct and set the source variable appropriately.
 		var crdField *CRDField
 		var found bool
+		var targetMemberShapeRef *awssdkmodel.ShapeRef
 		targetAdaptedVarName := targetVarName
 		crdField, found = r.SpecFields[memberName]
 		if found {
@@ -1818,30 +1829,32 @@ func (r *CRD) goCodeSetOutputReadMany(
 			}
 			targetAdaptedVarName += ".Status"
 		}
+		targetMemberShapeRef = crdField.ShapeRef
 		out += fmt.Sprintf(
 			"%s\tif %s != nil {\n", indent, sourceAdaptedVarName,
 		)
-		switch memberShape.Type {
+		switch sourceMemberShape.Type {
 		case "list", "structure", "map":
 			{
 				memberVarName := fmt.Sprintf("f%d", memberIndex)
 				out += r.goCodeVarEmptyConstructorK8sType(
 					memberVarName,
-					memberShape,
+					targetMemberShapeRef.Shape,
 					indentLevel+2,
 				)
 				out += r.goCodeSetOutputForContainer(
 					crdField.Names.Camel,
 					memberVarName,
+					targetMemberShapeRef,
 					sourceAdaptedVarName,
-					memberShapeRef,
+					sourceMemberShapeRef,
 					indentLevel+2,
 				)
 				out += r.goCodeSetOutputForScalar(
 					crdField.Names.Camel,
 					targetAdaptedVarName,
 					memberVarName,
-					memberShapeRef,
+					sourceMemberShapeRef,
 					indentLevel+2,
 				)
 			}
@@ -1880,7 +1893,7 @@ func (r *CRD) goCodeSetOutputReadMany(
 				crdField.Names.Camel,
 				targetAdaptedVarName,
 				sourceAdaptedVarName,
-				memberShapeRef,
+				sourceMemberShapeRef,
 				indentLevel+2,
 			)
 		}
@@ -2062,22 +2075,29 @@ func (r *CRD) goCodeSetOutputForContainer(
 	targetFieldName string,
 	// The variable name that we want to set a value to
 	targetVarName string,
+	// Shape Ref of the target struct field
+	targetShapeRef *awssdkmodel.ShapeRef,
 	// The struct or struct field that we access our source value from
 	sourceVarName string,
-	// ShapeRef of the struct field
-	shapeRef *awssdkmodel.ShapeRef,
+	// ShapeRef of the source struct field
+	sourceShapeRef *awssdkmodel.ShapeRef,
 	indentLevel int,
 ) string {
 	out := ""
 	indent := strings.Repeat("\t", indentLevel)
-	shape := shapeRef.Shape
+	sourceShape := sourceShapeRef.Shape
+	targetShape := targetShapeRef.Shape
 
-	switch shape.Type {
+	switch sourceShape.Type {
 	case "structure":
 		{
-			for memberIndex, memberName := range shape.MemberNames() {
+			for memberIndex, memberName := range sourceShape.MemberNames() {
+				targetMemberShapeRef := targetShape.MemberRefs[memberName]
+				if targetMemberShapeRef == nil {
+					continue
+				}
 				memberVarName := fmt.Sprintf("%sf%d", targetVarName, memberIndex)
-				memberShapeRef := shape.MemberRefs[memberName]
+				memberShapeRef := sourceShape.MemberRefs[memberName]
 				memberShape := memberShapeRef.Shape
 				if r.genCfg.IsIgnoredShape(memberShape.ShapeName) {
 					continue
@@ -2092,12 +2112,13 @@ func (r *CRD) goCodeSetOutputForContainer(
 					{
 						out += r.goCodeVarEmptyConstructorK8sType(
 							memberVarName,
-							memberShape,
+							targetMemberShapeRef.Shape,
 							indentLevel+1,
 						)
 						out += r.goCodeSetOutputForContainer(
 							cleanNames.Camel,
 							memberVarName,
+							targetMemberShapeRef,
 							sourceAdaptedVarName,
 							memberShapeRef,
 							indentLevel+1,
@@ -2133,7 +2154,7 @@ func (r *CRD) goCodeSetOutputForContainer(
 			//		f0elem0 := &string{}
 			out += r.goCodeVarEmptyConstructorK8sType(
 				elemVarName,
-				shape.MemberRef.Shape,
+				targetShape.MemberRef.Shape,
 				indentLevel+1,
 			)
 			//  f0elem0 = *f0iter0
@@ -2142,18 +2163,19 @@ func (r *CRD) goCodeSetOutputForContainer(
 			//
 			//  f0elem0.SetMyField(*f0iter0)
 			containerFieldName := ""
-			if shape.MemberRef.Shape.Type == "structure" {
+			if sourceShape.MemberRef.Shape.Type == "structure" {
 				containerFieldName = targetFieldName
 			}
 			out += r.goCodeSetOutputForContainer(
 				containerFieldName,
 				elemVarName,
+				&targetShape.MemberRef,
 				iterVarName,
-				&shape.MemberRef,
+				&sourceShape.MemberRef,
 				indentLevel+1,
 			)
 			addressOfVar := ""
-			switch shape.MemberRef.Shape.Type {
+			switch sourceShape.MemberRef.Shape.Type {
 			case "structure", "list", "map":
 				break
 			default:
@@ -2173,23 +2195,24 @@ func (r *CRD) goCodeSetOutputForContainer(
 			//		f0elem := string{}
 			out += r.goCodeVarEmptyConstructorK8sType(
 				valVarName,
-				shape.ValueRef.Shape,
+				targetShape.ValueRef.Shape,
 				indentLevel+1,
 			)
 			//  f0val = *f0valiter
 			containerFieldName := ""
-			if shape.ValueRef.Shape.Type == "structure" {
+			if sourceShape.ValueRef.Shape.Type == "structure" {
 				containerFieldName = targetFieldName
 			}
 			out += r.goCodeSetOutputForContainer(
 				containerFieldName,
 				valVarName,
+				&targetShape.ValueRef,
 				valIterVarName,
-				&shape.ValueRef,
+				&sourceShape.ValueRef,
 				indentLevel+1,
 			)
 			addressOfVar := ""
-			switch shape.ValueRef.Shape.Type {
+			switch sourceShape.ValueRef.Shape.Type {
 			case "structure", "list", "map":
 				break
 			default:
@@ -2204,7 +2227,7 @@ func (r *CRD) goCodeSetOutputForContainer(
 			targetFieldName,
 			targetVarName,
 			sourceVarName,
-			shapeRef,
+			sourceShapeRef,
 			indentLevel,
 		)
 	}

--- a/services/apigatewayv2/config/controller/deployment.yaml
+++ b/services/apigatewayv2/config/controller/deployment.yaml
@@ -41,4 +41,9 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        env:
+        - name: K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       terminationGracePeriodSeconds: 10

--- a/services/apigatewayv2/pkg/resource/api/sdk.go
+++ b/services/apigatewayv2/pkg/resource/api/sdk.go
@@ -76,8 +76,66 @@ func (rm *resourceManager) sdkFind(
 	if resp.ApiId != nil {
 		ko.Status.APIID = resp.ApiId
 	}
+	if resp.ApiKeySelectionExpression != nil {
+		ko.Spec.APIKeySelectionExpression = resp.ApiKeySelectionExpression
+	}
+	if resp.CorsConfiguration != nil {
+		f4 := &svcapitypes.Cors{}
+		if resp.CorsConfiguration.AllowCredentials != nil {
+			f4.AllowCredentials = resp.CorsConfiguration.AllowCredentials
+		}
+		if resp.CorsConfiguration.AllowHeaders != nil {
+			f4f1 := []*string{}
+			for _, f4f1iter := range resp.CorsConfiguration.AllowHeaders {
+				var f4f1elem string
+				f4f1elem = *f4f1iter
+				f4f1 = append(f4f1, &f4f1elem)
+			}
+			f4.AllowHeaders = f4f1
+		}
+		if resp.CorsConfiguration.AllowMethods != nil {
+			f4f2 := []*string{}
+			for _, f4f2iter := range resp.CorsConfiguration.AllowMethods {
+				var f4f2elem string
+				f4f2elem = *f4f2iter
+				f4f2 = append(f4f2, &f4f2elem)
+			}
+			f4.AllowMethods = f4f2
+		}
+		if resp.CorsConfiguration.AllowOrigins != nil {
+			f4f3 := []*string{}
+			for _, f4f3iter := range resp.CorsConfiguration.AllowOrigins {
+				var f4f3elem string
+				f4f3elem = *f4f3iter
+				f4f3 = append(f4f3, &f4f3elem)
+			}
+			f4.AllowOrigins = f4f3
+		}
+		if resp.CorsConfiguration.ExposeHeaders != nil {
+			f4f4 := []*string{}
+			for _, f4f4iter := range resp.CorsConfiguration.ExposeHeaders {
+				var f4f4elem string
+				f4f4elem = *f4f4iter
+				f4f4 = append(f4f4, &f4f4elem)
+			}
+			f4.ExposeHeaders = f4f4
+		}
+		if resp.CorsConfiguration.MaxAge != nil {
+			f4.MaxAge = resp.CorsConfiguration.MaxAge
+		}
+		ko.Spec.CorsConfiguration = f4
+	}
 	if resp.CreatedDate != nil {
 		ko.Status.CreatedDate = &metav1.Time{*resp.CreatedDate}
+	}
+	if resp.Description != nil {
+		ko.Spec.Description = resp.Description
+	}
+	if resp.DisableExecuteApiEndpoint != nil {
+		ko.Spec.DisableExecuteAPIEndpoint = resp.DisableExecuteApiEndpoint
+	}
+	if resp.DisableSchemaValidation != nil {
+		ko.Spec.DisableSchemaValidation = resp.DisableSchemaValidation
 	}
 	if resp.ImportInfo != nil {
 		f9 := []*string{}
@@ -87,6 +145,27 @@ func (rm *resourceManager) sdkFind(
 			f9 = append(f9, &f9elem)
 		}
 		ko.Status.ImportInfo = f9
+	}
+	if resp.Name != nil {
+		ko.Spec.Name = resp.Name
+	}
+	if resp.ProtocolType != nil {
+		ko.Spec.ProtocolType = resp.ProtocolType
+	}
+	if resp.RouteSelectionExpression != nil {
+		ko.Spec.RouteSelectionExpression = resp.RouteSelectionExpression
+	}
+	if resp.Tags != nil {
+		f13 := map[string]*string{}
+		for f13key, f13valiter := range resp.Tags {
+			var f13val string
+			f13val = *f13valiter
+			f13[f13key] = &f13val
+		}
+		ko.Spec.Tags = f13
+	}
+	if resp.Version != nil {
+		ko.Spec.Version = resp.Version
 	}
 	if resp.Warnings != nil {
 		f15 := []*string{}
@@ -163,8 +242,66 @@ func (rm *resourceManager) sdkCreate(
 	if resp.ApiId != nil {
 		ko.Status.APIID = resp.ApiId
 	}
+	if resp.ApiKeySelectionExpression != nil {
+		ko.Spec.APIKeySelectionExpression = resp.ApiKeySelectionExpression
+	}
+	if resp.CorsConfiguration != nil {
+		f4 := &svcapitypes.Cors{}
+		if resp.CorsConfiguration.AllowCredentials != nil {
+			f4.AllowCredentials = resp.CorsConfiguration.AllowCredentials
+		}
+		if resp.CorsConfiguration.AllowHeaders != nil {
+			f4f1 := []*string{}
+			for _, f4f1iter := range resp.CorsConfiguration.AllowHeaders {
+				var f4f1elem string
+				f4f1elem = *f4f1iter
+				f4f1 = append(f4f1, &f4f1elem)
+			}
+			f4.AllowHeaders = f4f1
+		}
+		if resp.CorsConfiguration.AllowMethods != nil {
+			f4f2 := []*string{}
+			for _, f4f2iter := range resp.CorsConfiguration.AllowMethods {
+				var f4f2elem string
+				f4f2elem = *f4f2iter
+				f4f2 = append(f4f2, &f4f2elem)
+			}
+			f4.AllowMethods = f4f2
+		}
+		if resp.CorsConfiguration.AllowOrigins != nil {
+			f4f3 := []*string{}
+			for _, f4f3iter := range resp.CorsConfiguration.AllowOrigins {
+				var f4f3elem string
+				f4f3elem = *f4f3iter
+				f4f3 = append(f4f3, &f4f3elem)
+			}
+			f4.AllowOrigins = f4f3
+		}
+		if resp.CorsConfiguration.ExposeHeaders != nil {
+			f4f4 := []*string{}
+			for _, f4f4iter := range resp.CorsConfiguration.ExposeHeaders {
+				var f4f4elem string
+				f4f4elem = *f4f4iter
+				f4f4 = append(f4f4, &f4f4elem)
+			}
+			f4.ExposeHeaders = f4f4
+		}
+		if resp.CorsConfiguration.MaxAge != nil {
+			f4.MaxAge = resp.CorsConfiguration.MaxAge
+		}
+		ko.Spec.CorsConfiguration = f4
+	}
 	if resp.CreatedDate != nil {
 		ko.Status.CreatedDate = &metav1.Time{*resp.CreatedDate}
+	}
+	if resp.Description != nil {
+		ko.Spec.Description = resp.Description
+	}
+	if resp.DisableExecuteApiEndpoint != nil {
+		ko.Spec.DisableExecuteAPIEndpoint = resp.DisableExecuteApiEndpoint
+	}
+	if resp.DisableSchemaValidation != nil {
+		ko.Spec.DisableSchemaValidation = resp.DisableSchemaValidation
 	}
 	if resp.ImportInfo != nil {
 		f9 := []*string{}
@@ -174,6 +311,27 @@ func (rm *resourceManager) sdkCreate(
 			f9 = append(f9, &f9elem)
 		}
 		ko.Status.ImportInfo = f9
+	}
+	if resp.Name != nil {
+		ko.Spec.Name = resp.Name
+	}
+	if resp.ProtocolType != nil {
+		ko.Spec.ProtocolType = resp.ProtocolType
+	}
+	if resp.RouteSelectionExpression != nil {
+		ko.Spec.RouteSelectionExpression = resp.RouteSelectionExpression
+	}
+	if resp.Tags != nil {
+		f13 := map[string]*string{}
+		for f13key, f13valiter := range resp.Tags {
+			var f13val string
+			f13val = *f13valiter
+			f13[f13key] = &f13val
+		}
+		ko.Spec.Tags = f13
+	}
+	if resp.Version != nil {
+		ko.Spec.Version = resp.Version
 	}
 	if resp.Warnings != nil {
 		f15 := []*string{}
@@ -325,8 +483,66 @@ func (rm *resourceManager) sdkUpdate(
 	if resp.ApiId != nil {
 		ko.Status.APIID = resp.ApiId
 	}
+	if resp.ApiKeySelectionExpression != nil {
+		ko.Spec.APIKeySelectionExpression = resp.ApiKeySelectionExpression
+	}
+	if resp.CorsConfiguration != nil {
+		f4 := &svcapitypes.Cors{}
+		if resp.CorsConfiguration.AllowCredentials != nil {
+			f4.AllowCredentials = resp.CorsConfiguration.AllowCredentials
+		}
+		if resp.CorsConfiguration.AllowHeaders != nil {
+			f4f1 := []*string{}
+			for _, f4f1iter := range resp.CorsConfiguration.AllowHeaders {
+				var f4f1elem string
+				f4f1elem = *f4f1iter
+				f4f1 = append(f4f1, &f4f1elem)
+			}
+			f4.AllowHeaders = f4f1
+		}
+		if resp.CorsConfiguration.AllowMethods != nil {
+			f4f2 := []*string{}
+			for _, f4f2iter := range resp.CorsConfiguration.AllowMethods {
+				var f4f2elem string
+				f4f2elem = *f4f2iter
+				f4f2 = append(f4f2, &f4f2elem)
+			}
+			f4.AllowMethods = f4f2
+		}
+		if resp.CorsConfiguration.AllowOrigins != nil {
+			f4f3 := []*string{}
+			for _, f4f3iter := range resp.CorsConfiguration.AllowOrigins {
+				var f4f3elem string
+				f4f3elem = *f4f3iter
+				f4f3 = append(f4f3, &f4f3elem)
+			}
+			f4.AllowOrigins = f4f3
+		}
+		if resp.CorsConfiguration.ExposeHeaders != nil {
+			f4f4 := []*string{}
+			for _, f4f4iter := range resp.CorsConfiguration.ExposeHeaders {
+				var f4f4elem string
+				f4f4elem = *f4f4iter
+				f4f4 = append(f4f4, &f4f4elem)
+			}
+			f4.ExposeHeaders = f4f4
+		}
+		if resp.CorsConfiguration.MaxAge != nil {
+			f4.MaxAge = resp.CorsConfiguration.MaxAge
+		}
+		ko.Spec.CorsConfiguration = f4
+	}
 	if resp.CreatedDate != nil {
 		ko.Status.CreatedDate = &metav1.Time{*resp.CreatedDate}
+	}
+	if resp.Description != nil {
+		ko.Spec.Description = resp.Description
+	}
+	if resp.DisableExecuteApiEndpoint != nil {
+		ko.Spec.DisableExecuteAPIEndpoint = resp.DisableExecuteApiEndpoint
+	}
+	if resp.DisableSchemaValidation != nil {
+		ko.Spec.DisableSchemaValidation = resp.DisableSchemaValidation
 	}
 	if resp.ImportInfo != nil {
 		f9 := []*string{}
@@ -336,6 +552,27 @@ func (rm *resourceManager) sdkUpdate(
 			f9 = append(f9, &f9elem)
 		}
 		ko.Status.ImportInfo = f9
+	}
+	if resp.Name != nil {
+		ko.Spec.Name = resp.Name
+	}
+	if resp.ProtocolType != nil {
+		ko.Spec.ProtocolType = resp.ProtocolType
+	}
+	if resp.RouteSelectionExpression != nil {
+		ko.Spec.RouteSelectionExpression = resp.RouteSelectionExpression
+	}
+	if resp.Tags != nil {
+		f13 := map[string]*string{}
+		for f13key, f13valiter := range resp.Tags {
+			var f13val string
+			f13val = *f13valiter
+			f13[f13key] = &f13val
+		}
+		ko.Spec.Tags = f13
+	}
+	if resp.Version != nil {
+		ko.Spec.Version = resp.Version
 	}
 	if resp.Warnings != nil {
 		f15 := []*string{}

--- a/services/apigatewayv2/pkg/resource/api_mapping/sdk.go
+++ b/services/apigatewayv2/pkg/resource/api_mapping/sdk.go
@@ -67,8 +67,17 @@ func (rm *resourceManager) sdkFind(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 
+	if resp.ApiId != nil {
+		ko.Spec.APIID = resp.ApiId
+	}
 	if resp.ApiMappingId != nil {
 		ko.Status.APIMappingID = resp.ApiMappingId
+	}
+	if resp.ApiMappingKey != nil {
+		ko.Spec.APIMappingKey = resp.ApiMappingKey
+	}
+	if resp.Stage != nil {
+		ko.Spec.Stage = resp.Stage
 	}
 
 	return &resource{ko}, nil
@@ -134,8 +143,17 @@ func (rm *resourceManager) sdkCreate(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 
+	if resp.ApiId != nil {
+		ko.Spec.APIID = resp.ApiId
+	}
 	if resp.ApiMappingId != nil {
 		ko.Status.APIMappingID = resp.ApiMappingId
+	}
+	if resp.ApiMappingKey != nil {
+		ko.Spec.APIMappingKey = resp.ApiMappingKey
+	}
+	if resp.Stage != nil {
+		ko.Spec.Stage = resp.Stage
 	}
 
 	if ko.Status.ACKResourceMetadata == nil {
@@ -193,8 +211,17 @@ func (rm *resourceManager) sdkUpdate(
 	// the original Kubernetes object we passed to the function
 	ko := desired.ko.DeepCopy()
 
+	if resp.ApiId != nil {
+		ko.Spec.APIID = resp.ApiId
+	}
 	if resp.ApiMappingId != nil {
 		ko.Status.APIMappingID = resp.ApiMappingId
+	}
+	if resp.ApiMappingKey != nil {
+		ko.Spec.APIMappingKey = resp.ApiMappingKey
+	}
+	if resp.Stage != nil {
+		ko.Spec.Stage = resp.Stage
 	}
 
 	return &resource{ko}, nil

--- a/services/apigatewayv2/pkg/resource/authorizer/sdk.go
+++ b/services/apigatewayv2/pkg/resource/authorizer/sdk.go
@@ -67,8 +67,57 @@ func (rm *resourceManager) sdkFind(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 
+	if resp.AuthorizerCredentialsArn != nil {
+		ko.Spec.AuthorizerCredentialsARN = resp.AuthorizerCredentialsArn
+	}
 	if resp.AuthorizerId != nil {
 		ko.Status.AuthorizerID = resp.AuthorizerId
+	}
+	if resp.AuthorizerPayloadFormatVersion != nil {
+		ko.Spec.AuthorizerPayloadFormatVersion = resp.AuthorizerPayloadFormatVersion
+	}
+	if resp.AuthorizerResultTtlInSeconds != nil {
+		ko.Spec.AuthorizerResultTtlInSeconds = resp.AuthorizerResultTtlInSeconds
+	}
+	if resp.AuthorizerType != nil {
+		ko.Spec.AuthorizerType = resp.AuthorizerType
+	}
+	if resp.AuthorizerUri != nil {
+		ko.Spec.AuthorizerURI = resp.AuthorizerUri
+	}
+	if resp.EnableSimpleResponses != nil {
+		ko.Spec.EnableSimpleResponses = resp.EnableSimpleResponses
+	}
+	if resp.IdentitySource != nil {
+		f7 := []*string{}
+		for _, f7iter := range resp.IdentitySource {
+			var f7elem string
+			f7elem = *f7iter
+			f7 = append(f7, &f7elem)
+		}
+		ko.Spec.IDentitySource = f7
+	}
+	if resp.IdentityValidationExpression != nil {
+		ko.Spec.IDentityValidationExpression = resp.IdentityValidationExpression
+	}
+	if resp.JwtConfiguration != nil {
+		f9 := &svcapitypes.JWTConfiguration{}
+		if resp.JwtConfiguration.Audience != nil {
+			f9f0 := []*string{}
+			for _, f9f0iter := range resp.JwtConfiguration.Audience {
+				var f9f0elem string
+				f9f0elem = *f9f0iter
+				f9f0 = append(f9f0, &f9f0elem)
+			}
+			f9.Audience = f9f0
+		}
+		if resp.JwtConfiguration.Issuer != nil {
+			f9.Issuer = resp.JwtConfiguration.Issuer
+		}
+		ko.Spec.JWTConfiguration = f9
+	}
+	if resp.Name != nil {
+		ko.Spec.Name = resp.Name
 	}
 
 	return &resource{ko}, nil
@@ -134,8 +183,57 @@ func (rm *resourceManager) sdkCreate(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 
+	if resp.AuthorizerCredentialsArn != nil {
+		ko.Spec.AuthorizerCredentialsARN = resp.AuthorizerCredentialsArn
+	}
 	if resp.AuthorizerId != nil {
 		ko.Status.AuthorizerID = resp.AuthorizerId
+	}
+	if resp.AuthorizerPayloadFormatVersion != nil {
+		ko.Spec.AuthorizerPayloadFormatVersion = resp.AuthorizerPayloadFormatVersion
+	}
+	if resp.AuthorizerResultTtlInSeconds != nil {
+		ko.Spec.AuthorizerResultTtlInSeconds = resp.AuthorizerResultTtlInSeconds
+	}
+	if resp.AuthorizerType != nil {
+		ko.Spec.AuthorizerType = resp.AuthorizerType
+	}
+	if resp.AuthorizerUri != nil {
+		ko.Spec.AuthorizerURI = resp.AuthorizerUri
+	}
+	if resp.EnableSimpleResponses != nil {
+		ko.Spec.EnableSimpleResponses = resp.EnableSimpleResponses
+	}
+	if resp.IdentitySource != nil {
+		f7 := []*string{}
+		for _, f7iter := range resp.IdentitySource {
+			var f7elem string
+			f7elem = *f7iter
+			f7 = append(f7, &f7elem)
+		}
+		ko.Spec.IDentitySource = f7
+	}
+	if resp.IdentityValidationExpression != nil {
+		ko.Spec.IDentityValidationExpression = resp.IdentityValidationExpression
+	}
+	if resp.JwtConfiguration != nil {
+		f9 := &svcapitypes.JWTConfiguration{}
+		if resp.JwtConfiguration.Audience != nil {
+			f9f0 := []*string{}
+			for _, f9f0iter := range resp.JwtConfiguration.Audience {
+				var f9f0elem string
+				f9f0elem = *f9f0iter
+				f9f0 = append(f9f0, &f9f0elem)
+			}
+			f9.Audience = f9f0
+		}
+		if resp.JwtConfiguration.Issuer != nil {
+			f9.Issuer = resp.JwtConfiguration.Issuer
+		}
+		ko.Spec.JWTConfiguration = f9
+	}
+	if resp.Name != nil {
+		ko.Spec.Name = resp.Name
 	}
 
 	if ko.Status.ACKResourceMetadata == nil {
@@ -233,8 +331,57 @@ func (rm *resourceManager) sdkUpdate(
 	// the original Kubernetes object we passed to the function
 	ko := desired.ko.DeepCopy()
 
+	if resp.AuthorizerCredentialsArn != nil {
+		ko.Spec.AuthorizerCredentialsARN = resp.AuthorizerCredentialsArn
+	}
 	if resp.AuthorizerId != nil {
 		ko.Status.AuthorizerID = resp.AuthorizerId
+	}
+	if resp.AuthorizerPayloadFormatVersion != nil {
+		ko.Spec.AuthorizerPayloadFormatVersion = resp.AuthorizerPayloadFormatVersion
+	}
+	if resp.AuthorizerResultTtlInSeconds != nil {
+		ko.Spec.AuthorizerResultTtlInSeconds = resp.AuthorizerResultTtlInSeconds
+	}
+	if resp.AuthorizerType != nil {
+		ko.Spec.AuthorizerType = resp.AuthorizerType
+	}
+	if resp.AuthorizerUri != nil {
+		ko.Spec.AuthorizerURI = resp.AuthorizerUri
+	}
+	if resp.EnableSimpleResponses != nil {
+		ko.Spec.EnableSimpleResponses = resp.EnableSimpleResponses
+	}
+	if resp.IdentitySource != nil {
+		f7 := []*string{}
+		for _, f7iter := range resp.IdentitySource {
+			var f7elem string
+			f7elem = *f7iter
+			f7 = append(f7, &f7elem)
+		}
+		ko.Spec.IDentitySource = f7
+	}
+	if resp.IdentityValidationExpression != nil {
+		ko.Spec.IDentityValidationExpression = resp.IdentityValidationExpression
+	}
+	if resp.JwtConfiguration != nil {
+		f9 := &svcapitypes.JWTConfiguration{}
+		if resp.JwtConfiguration.Audience != nil {
+			f9f0 := []*string{}
+			for _, f9f0iter := range resp.JwtConfiguration.Audience {
+				var f9f0elem string
+				f9f0elem = *f9f0iter
+				f9f0 = append(f9f0, &f9f0elem)
+			}
+			f9.Audience = f9f0
+		}
+		if resp.JwtConfiguration.Issuer != nil {
+			f9.Issuer = resp.JwtConfiguration.Issuer
+		}
+		ko.Spec.JWTConfiguration = f9
+	}
+	if resp.Name != nil {
+		ko.Spec.Name = resp.Name
 	}
 
 	return &resource{ko}, nil

--- a/services/apigatewayv2/pkg/resource/deployment/sdk.go
+++ b/services/apigatewayv2/pkg/resource/deployment/sdk.go
@@ -82,6 +82,9 @@ func (rm *resourceManager) sdkFind(
 	if resp.DeploymentStatusMessage != nil {
 		ko.Status.DeploymentStatusMessage = resp.DeploymentStatusMessage
 	}
+	if resp.Description != nil {
+		ko.Spec.Description = resp.Description
+	}
 
 	return &resource{ko}, nil
 }
@@ -161,6 +164,9 @@ func (rm *resourceManager) sdkCreate(
 	if resp.DeploymentStatusMessage != nil {
 		ko.Status.DeploymentStatusMessage = resp.DeploymentStatusMessage
 	}
+	if resp.Description != nil {
+		ko.Spec.Description = resp.Description
+	}
 
 	if ko.Status.ACKResourceMetadata == nil {
 		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
@@ -228,6 +234,9 @@ func (rm *resourceManager) sdkUpdate(
 	}
 	if resp.DeploymentStatusMessage != nil {
 		ko.Status.DeploymentStatusMessage = resp.DeploymentStatusMessage
+	}
+	if resp.Description != nil {
+		ko.Spec.Description = resp.Description
 	}
 
 	return &resource{ko}, nil

--- a/services/apigatewayv2/pkg/resource/domain_name/sdk.go
+++ b/services/apigatewayv2/pkg/resource/domain_name/sdk.go
@@ -70,6 +70,63 @@ func (rm *resourceManager) sdkFind(
 	if resp.ApiMappingSelectionExpression != nil {
 		ko.Status.APIMappingSelectionExpression = resp.ApiMappingSelectionExpression
 	}
+	if resp.DomainName != nil {
+		ko.Spec.DomainName = resp.DomainName
+	}
+	if resp.DomainNameConfigurations != nil {
+		f2 := []*svcapitypes.DomainNameConfiguration{}
+		for _, f2iter := range resp.DomainNameConfigurations {
+			f2elem := &svcapitypes.DomainNameConfiguration{}
+			if f2iter.ApiGatewayDomainName != nil {
+				f2elem.APIGatewayDomainName = f2iter.ApiGatewayDomainName
+			}
+			if f2iter.CertificateArn != nil {
+				f2elem.CertificateARN = f2iter.CertificateArn
+			}
+			if f2iter.CertificateName != nil {
+				f2elem.CertificateName = f2iter.CertificateName
+			}
+			if f2iter.CertificateUploadDate != nil {
+				f2elem.CertificateUploadDate = &metav1.Time{*f2iter.CertificateUploadDate}
+			}
+			if f2iter.DomainNameStatus != nil {
+				f2elem.DomainNameStatus = f2iter.DomainNameStatus
+			}
+			if f2iter.DomainNameStatusMessage != nil {
+				f2elem.DomainNameStatusMessage = f2iter.DomainNameStatusMessage
+			}
+			if f2iter.EndpointType != nil {
+				f2elem.EndpointType = f2iter.EndpointType
+			}
+			if f2iter.HostedZoneId != nil {
+				f2elem.HostedZoneID = f2iter.HostedZoneId
+			}
+			if f2iter.SecurityPolicy != nil {
+				f2elem.SecurityPolicy = f2iter.SecurityPolicy
+			}
+			f2 = append(f2, f2elem)
+		}
+		ko.Spec.DomainNameConfigurations = f2
+	}
+	if resp.MutualTlsAuthentication != nil {
+		f3 := &svcapitypes.MutualTLSAuthenticationInput{}
+		if resp.MutualTlsAuthentication.TruststoreUri != nil {
+			f3.TruststoreURI = resp.MutualTlsAuthentication.TruststoreUri
+		}
+		if resp.MutualTlsAuthentication.TruststoreVersion != nil {
+			f3.TruststoreVersion = resp.MutualTlsAuthentication.TruststoreVersion
+		}
+		ko.Spec.MutualTLSAuthentication = f3
+	}
+	if resp.Tags != nil {
+		f4 := map[string]*string{}
+		for f4key, f4valiter := range resp.Tags {
+			var f4val string
+			f4val = *f4valiter
+			f4[f4key] = &f4val
+		}
+		ko.Spec.Tags = f4
+	}
 
 	return &resource{ko}, nil
 }
@@ -129,6 +186,63 @@ func (rm *resourceManager) sdkCreate(
 
 	if resp.ApiMappingSelectionExpression != nil {
 		ko.Status.APIMappingSelectionExpression = resp.ApiMappingSelectionExpression
+	}
+	if resp.DomainName != nil {
+		ko.Spec.DomainName = resp.DomainName
+	}
+	if resp.DomainNameConfigurations != nil {
+		f2 := []*svcapitypes.DomainNameConfiguration{}
+		for _, f2iter := range resp.DomainNameConfigurations {
+			f2elem := &svcapitypes.DomainNameConfiguration{}
+			if f2iter.ApiGatewayDomainName != nil {
+				f2elem.APIGatewayDomainName = f2iter.ApiGatewayDomainName
+			}
+			if f2iter.CertificateArn != nil {
+				f2elem.CertificateARN = f2iter.CertificateArn
+			}
+			if f2iter.CertificateName != nil {
+				f2elem.CertificateName = f2iter.CertificateName
+			}
+			if f2iter.CertificateUploadDate != nil {
+				f2elem.CertificateUploadDate = &metav1.Time{*f2iter.CertificateUploadDate}
+			}
+			if f2iter.DomainNameStatus != nil {
+				f2elem.DomainNameStatus = f2iter.DomainNameStatus
+			}
+			if f2iter.DomainNameStatusMessage != nil {
+				f2elem.DomainNameStatusMessage = f2iter.DomainNameStatusMessage
+			}
+			if f2iter.EndpointType != nil {
+				f2elem.EndpointType = f2iter.EndpointType
+			}
+			if f2iter.HostedZoneId != nil {
+				f2elem.HostedZoneID = f2iter.HostedZoneId
+			}
+			if f2iter.SecurityPolicy != nil {
+				f2elem.SecurityPolicy = f2iter.SecurityPolicy
+			}
+			f2 = append(f2, f2elem)
+		}
+		ko.Spec.DomainNameConfigurations = f2
+	}
+	if resp.MutualTlsAuthentication != nil {
+		f3 := &svcapitypes.MutualTLSAuthenticationInput{}
+		if resp.MutualTlsAuthentication.TruststoreUri != nil {
+			f3.TruststoreURI = resp.MutualTlsAuthentication.TruststoreUri
+		}
+		if resp.MutualTlsAuthentication.TruststoreVersion != nil {
+			f3.TruststoreVersion = resp.MutualTlsAuthentication.TruststoreVersion
+		}
+		ko.Spec.MutualTLSAuthentication = f3
+	}
+	if resp.Tags != nil {
+		f4 := map[string]*string{}
+		for f4key, f4valiter := range resp.Tags {
+			var f4val string
+			f4val = *f4valiter
+			f4[f4key] = &f4val
+		}
+		ko.Spec.Tags = f4
 	}
 
 	if ko.Status.ACKResourceMetadata == nil {
@@ -233,6 +347,63 @@ func (rm *resourceManager) sdkUpdate(
 
 	if resp.ApiMappingSelectionExpression != nil {
 		ko.Status.APIMappingSelectionExpression = resp.ApiMappingSelectionExpression
+	}
+	if resp.DomainName != nil {
+		ko.Spec.DomainName = resp.DomainName
+	}
+	if resp.DomainNameConfigurations != nil {
+		f2 := []*svcapitypes.DomainNameConfiguration{}
+		for _, f2iter := range resp.DomainNameConfigurations {
+			f2elem := &svcapitypes.DomainNameConfiguration{}
+			if f2iter.ApiGatewayDomainName != nil {
+				f2elem.APIGatewayDomainName = f2iter.ApiGatewayDomainName
+			}
+			if f2iter.CertificateArn != nil {
+				f2elem.CertificateARN = f2iter.CertificateArn
+			}
+			if f2iter.CertificateName != nil {
+				f2elem.CertificateName = f2iter.CertificateName
+			}
+			if f2iter.CertificateUploadDate != nil {
+				f2elem.CertificateUploadDate = &metav1.Time{*f2iter.CertificateUploadDate}
+			}
+			if f2iter.DomainNameStatus != nil {
+				f2elem.DomainNameStatus = f2iter.DomainNameStatus
+			}
+			if f2iter.DomainNameStatusMessage != nil {
+				f2elem.DomainNameStatusMessage = f2iter.DomainNameStatusMessage
+			}
+			if f2iter.EndpointType != nil {
+				f2elem.EndpointType = f2iter.EndpointType
+			}
+			if f2iter.HostedZoneId != nil {
+				f2elem.HostedZoneID = f2iter.HostedZoneId
+			}
+			if f2iter.SecurityPolicy != nil {
+				f2elem.SecurityPolicy = f2iter.SecurityPolicy
+			}
+			f2 = append(f2, f2elem)
+		}
+		ko.Spec.DomainNameConfigurations = f2
+	}
+	if resp.MutualTlsAuthentication != nil {
+		f3 := &svcapitypes.MutualTLSAuthenticationInput{}
+		if resp.MutualTlsAuthentication.TruststoreUri != nil {
+			f3.TruststoreURI = resp.MutualTlsAuthentication.TruststoreUri
+		}
+		if resp.MutualTlsAuthentication.TruststoreVersion != nil {
+			f3.TruststoreVersion = resp.MutualTlsAuthentication.TruststoreVersion
+		}
+		ko.Spec.MutualTLSAuthentication = f3
+	}
+	if resp.Tags != nil {
+		f4 := map[string]*string{}
+		for f4key, f4valiter := range resp.Tags {
+			var f4val string
+			f4val = *f4valiter
+			f4[f4key] = &f4val
+		}
+		ko.Spec.Tags = f4
 	}
 
 	return &resource{ko}, nil

--- a/services/apigatewayv2/pkg/resource/integration/sdk.go
+++ b/services/apigatewayv2/pkg/resource/integration/sdk.go
@@ -70,11 +70,75 @@ func (rm *resourceManager) sdkFind(
 	if resp.ApiGatewayManaged != nil {
 		ko.Status.APIGatewayManaged = resp.ApiGatewayManaged
 	}
+	if resp.ConnectionId != nil {
+		ko.Spec.ConnectionID = resp.ConnectionId
+	}
+	if resp.ConnectionType != nil {
+		ko.Spec.ConnectionType = resp.ConnectionType
+	}
+	if resp.ContentHandlingStrategy != nil {
+		ko.Spec.ContentHandlingStrategy = resp.ContentHandlingStrategy
+	}
+	if resp.CredentialsArn != nil {
+		ko.Spec.CredentialsARN = resp.CredentialsArn
+	}
+	if resp.Description != nil {
+		ko.Spec.Description = resp.Description
+	}
 	if resp.IntegrationId != nil {
 		ko.Status.IntegrationID = resp.IntegrationId
 	}
+	if resp.IntegrationMethod != nil {
+		ko.Spec.IntegrationMethod = resp.IntegrationMethod
+	}
 	if resp.IntegrationResponseSelectionExpression != nil {
 		ko.Status.IntegrationResponseSelectionExpression = resp.IntegrationResponseSelectionExpression
+	}
+	if resp.IntegrationSubtype != nil {
+		ko.Spec.IntegrationSubtype = resp.IntegrationSubtype
+	}
+	if resp.IntegrationType != nil {
+		ko.Spec.IntegrationType = resp.IntegrationType
+	}
+	if resp.IntegrationUri != nil {
+		ko.Spec.IntegrationURI = resp.IntegrationUri
+	}
+	if resp.PassthroughBehavior != nil {
+		ko.Spec.PassthroughBehavior = resp.PassthroughBehavior
+	}
+	if resp.PayloadFormatVersion != nil {
+		ko.Spec.PayloadFormatVersion = resp.PayloadFormatVersion
+	}
+	if resp.RequestParameters != nil {
+		f14 := map[string]*string{}
+		for f14key, f14valiter := range resp.RequestParameters {
+			var f14val string
+			f14val = *f14valiter
+			f14[f14key] = &f14val
+		}
+		ko.Spec.RequestParameters = f14
+	}
+	if resp.RequestTemplates != nil {
+		f15 := map[string]*string{}
+		for f15key, f15valiter := range resp.RequestTemplates {
+			var f15val string
+			f15val = *f15valiter
+			f15[f15key] = &f15val
+		}
+		ko.Spec.RequestTemplates = f15
+	}
+	if resp.TemplateSelectionExpression != nil {
+		ko.Spec.TemplateSelectionExpression = resp.TemplateSelectionExpression
+	}
+	if resp.TimeoutInMillis != nil {
+		ko.Spec.TimeoutInMillis = resp.TimeoutInMillis
+	}
+	if resp.TlsConfig != nil {
+		f18 := &svcapitypes.TLSConfigInput{}
+		if resp.TlsConfig.ServerNameToVerify != nil {
+			f18.ServerNameToVerify = resp.TlsConfig.ServerNameToVerify
+		}
+		ko.Spec.TLSConfig = f18
 	}
 
 	return &resource{ko}, nil
@@ -143,11 +207,75 @@ func (rm *resourceManager) sdkCreate(
 	if resp.ApiGatewayManaged != nil {
 		ko.Status.APIGatewayManaged = resp.ApiGatewayManaged
 	}
+	if resp.ConnectionId != nil {
+		ko.Spec.ConnectionID = resp.ConnectionId
+	}
+	if resp.ConnectionType != nil {
+		ko.Spec.ConnectionType = resp.ConnectionType
+	}
+	if resp.ContentHandlingStrategy != nil {
+		ko.Spec.ContentHandlingStrategy = resp.ContentHandlingStrategy
+	}
+	if resp.CredentialsArn != nil {
+		ko.Spec.CredentialsARN = resp.CredentialsArn
+	}
+	if resp.Description != nil {
+		ko.Spec.Description = resp.Description
+	}
 	if resp.IntegrationId != nil {
 		ko.Status.IntegrationID = resp.IntegrationId
 	}
+	if resp.IntegrationMethod != nil {
+		ko.Spec.IntegrationMethod = resp.IntegrationMethod
+	}
 	if resp.IntegrationResponseSelectionExpression != nil {
 		ko.Status.IntegrationResponseSelectionExpression = resp.IntegrationResponseSelectionExpression
+	}
+	if resp.IntegrationSubtype != nil {
+		ko.Spec.IntegrationSubtype = resp.IntegrationSubtype
+	}
+	if resp.IntegrationType != nil {
+		ko.Spec.IntegrationType = resp.IntegrationType
+	}
+	if resp.IntegrationUri != nil {
+		ko.Spec.IntegrationURI = resp.IntegrationUri
+	}
+	if resp.PassthroughBehavior != nil {
+		ko.Spec.PassthroughBehavior = resp.PassthroughBehavior
+	}
+	if resp.PayloadFormatVersion != nil {
+		ko.Spec.PayloadFormatVersion = resp.PayloadFormatVersion
+	}
+	if resp.RequestParameters != nil {
+		f14 := map[string]*string{}
+		for f14key, f14valiter := range resp.RequestParameters {
+			var f14val string
+			f14val = *f14valiter
+			f14[f14key] = &f14val
+		}
+		ko.Spec.RequestParameters = f14
+	}
+	if resp.RequestTemplates != nil {
+		f15 := map[string]*string{}
+		for f15key, f15valiter := range resp.RequestTemplates {
+			var f15val string
+			f15val = *f15valiter
+			f15[f15key] = &f15val
+		}
+		ko.Spec.RequestTemplates = f15
+	}
+	if resp.TemplateSelectionExpression != nil {
+		ko.Spec.TemplateSelectionExpression = resp.TemplateSelectionExpression
+	}
+	if resp.TimeoutInMillis != nil {
+		ko.Spec.TimeoutInMillis = resp.TimeoutInMillis
+	}
+	if resp.TlsConfig != nil {
+		f18 := &svcapitypes.TLSConfigInput{}
+		if resp.TlsConfig.ServerNameToVerify != nil {
+			f18.ServerNameToVerify = resp.TlsConfig.ServerNameToVerify
+		}
+		ko.Spec.TLSConfig = f18
 	}
 
 	if ko.Status.ACKResourceMetadata == nil {
@@ -263,11 +391,75 @@ func (rm *resourceManager) sdkUpdate(
 	if resp.ApiGatewayManaged != nil {
 		ko.Status.APIGatewayManaged = resp.ApiGatewayManaged
 	}
+	if resp.ConnectionId != nil {
+		ko.Spec.ConnectionID = resp.ConnectionId
+	}
+	if resp.ConnectionType != nil {
+		ko.Spec.ConnectionType = resp.ConnectionType
+	}
+	if resp.ContentHandlingStrategy != nil {
+		ko.Spec.ContentHandlingStrategy = resp.ContentHandlingStrategy
+	}
+	if resp.CredentialsArn != nil {
+		ko.Spec.CredentialsARN = resp.CredentialsArn
+	}
+	if resp.Description != nil {
+		ko.Spec.Description = resp.Description
+	}
 	if resp.IntegrationId != nil {
 		ko.Status.IntegrationID = resp.IntegrationId
 	}
+	if resp.IntegrationMethod != nil {
+		ko.Spec.IntegrationMethod = resp.IntegrationMethod
+	}
 	if resp.IntegrationResponseSelectionExpression != nil {
 		ko.Status.IntegrationResponseSelectionExpression = resp.IntegrationResponseSelectionExpression
+	}
+	if resp.IntegrationSubtype != nil {
+		ko.Spec.IntegrationSubtype = resp.IntegrationSubtype
+	}
+	if resp.IntegrationType != nil {
+		ko.Spec.IntegrationType = resp.IntegrationType
+	}
+	if resp.IntegrationUri != nil {
+		ko.Spec.IntegrationURI = resp.IntegrationUri
+	}
+	if resp.PassthroughBehavior != nil {
+		ko.Spec.PassthroughBehavior = resp.PassthroughBehavior
+	}
+	if resp.PayloadFormatVersion != nil {
+		ko.Spec.PayloadFormatVersion = resp.PayloadFormatVersion
+	}
+	if resp.RequestParameters != nil {
+		f14 := map[string]*string{}
+		for f14key, f14valiter := range resp.RequestParameters {
+			var f14val string
+			f14val = *f14valiter
+			f14[f14key] = &f14val
+		}
+		ko.Spec.RequestParameters = f14
+	}
+	if resp.RequestTemplates != nil {
+		f15 := map[string]*string{}
+		for f15key, f15valiter := range resp.RequestTemplates {
+			var f15val string
+			f15val = *f15valiter
+			f15[f15key] = &f15val
+		}
+		ko.Spec.RequestTemplates = f15
+	}
+	if resp.TemplateSelectionExpression != nil {
+		ko.Spec.TemplateSelectionExpression = resp.TemplateSelectionExpression
+	}
+	if resp.TimeoutInMillis != nil {
+		ko.Spec.TimeoutInMillis = resp.TimeoutInMillis
+	}
+	if resp.TlsConfig != nil {
+		f18 := &svcapitypes.TLSConfigInput{}
+		if resp.TlsConfig.ServerNameToVerify != nil {
+			f18.ServerNameToVerify = resp.TlsConfig.ServerNameToVerify
+		}
+		ko.Spec.TLSConfig = f18
 	}
 
 	return &resource{ko}, nil

--- a/services/apigatewayv2/pkg/resource/integration_response/sdk.go
+++ b/services/apigatewayv2/pkg/resource/integration_response/sdk.go
@@ -67,8 +67,35 @@ func (rm *resourceManager) sdkFind(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 
+	if resp.ContentHandlingStrategy != nil {
+		ko.Spec.ContentHandlingStrategy = resp.ContentHandlingStrategy
+	}
 	if resp.IntegrationResponseId != nil {
 		ko.Status.IntegrationResponseID = resp.IntegrationResponseId
+	}
+	if resp.IntegrationResponseKey != nil {
+		ko.Spec.IntegrationResponseKey = resp.IntegrationResponseKey
+	}
+	if resp.ResponseParameters != nil {
+		f3 := map[string]*string{}
+		for f3key, f3valiter := range resp.ResponseParameters {
+			var f3val string
+			f3val = *f3valiter
+			f3[f3key] = &f3val
+		}
+		ko.Spec.ResponseParameters = f3
+	}
+	if resp.ResponseTemplates != nil {
+		f4 := map[string]*string{}
+		for f4key, f4valiter := range resp.ResponseTemplates {
+			var f4val string
+			f4val = *f4valiter
+			f4[f4key] = &f4val
+		}
+		ko.Spec.ResponseTemplates = f4
+	}
+	if resp.TemplateSelectionExpression != nil {
+		ko.Spec.TemplateSelectionExpression = resp.TemplateSelectionExpression
 	}
 
 	return &resource{ko}, nil
@@ -140,8 +167,35 @@ func (rm *resourceManager) sdkCreate(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 
+	if resp.ContentHandlingStrategy != nil {
+		ko.Spec.ContentHandlingStrategy = resp.ContentHandlingStrategy
+	}
 	if resp.IntegrationResponseId != nil {
 		ko.Status.IntegrationResponseID = resp.IntegrationResponseId
+	}
+	if resp.IntegrationResponseKey != nil {
+		ko.Spec.IntegrationResponseKey = resp.IntegrationResponseKey
+	}
+	if resp.ResponseParameters != nil {
+		f3 := map[string]*string{}
+		for f3key, f3valiter := range resp.ResponseParameters {
+			var f3val string
+			f3val = *f3valiter
+			f3[f3key] = &f3val
+		}
+		ko.Spec.ResponseParameters = f3
+	}
+	if resp.ResponseTemplates != nil {
+		f4 := map[string]*string{}
+		for f4key, f4valiter := range resp.ResponseTemplates {
+			var f4val string
+			f4val = *f4valiter
+			f4[f4key] = &f4val
+		}
+		ko.Spec.ResponseTemplates = f4
+	}
+	if resp.TemplateSelectionExpression != nil {
+		ko.Spec.TemplateSelectionExpression = resp.TemplateSelectionExpression
 	}
 
 	if ko.Status.ACKResourceMetadata == nil {
@@ -220,8 +274,35 @@ func (rm *resourceManager) sdkUpdate(
 	// the original Kubernetes object we passed to the function
 	ko := desired.ko.DeepCopy()
 
+	if resp.ContentHandlingStrategy != nil {
+		ko.Spec.ContentHandlingStrategy = resp.ContentHandlingStrategy
+	}
 	if resp.IntegrationResponseId != nil {
 		ko.Status.IntegrationResponseID = resp.IntegrationResponseId
+	}
+	if resp.IntegrationResponseKey != nil {
+		ko.Spec.IntegrationResponseKey = resp.IntegrationResponseKey
+	}
+	if resp.ResponseParameters != nil {
+		f3 := map[string]*string{}
+		for f3key, f3valiter := range resp.ResponseParameters {
+			var f3val string
+			f3val = *f3valiter
+			f3[f3key] = &f3val
+		}
+		ko.Spec.ResponseParameters = f3
+	}
+	if resp.ResponseTemplates != nil {
+		f4 := map[string]*string{}
+		for f4key, f4valiter := range resp.ResponseTemplates {
+			var f4val string
+			f4val = *f4valiter
+			f4[f4key] = &f4val
+		}
+		ko.Spec.ResponseTemplates = f4
+	}
+	if resp.TemplateSelectionExpression != nil {
+		ko.Spec.TemplateSelectionExpression = resp.TemplateSelectionExpression
 	}
 
 	return &resource{ko}, nil

--- a/services/apigatewayv2/pkg/resource/model/sdk.go
+++ b/services/apigatewayv2/pkg/resource/model/sdk.go
@@ -67,8 +67,20 @@ func (rm *resourceManager) sdkFind(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 
+	if resp.ContentType != nil {
+		ko.Spec.ContentType = resp.ContentType
+	}
+	if resp.Description != nil {
+		ko.Spec.Description = resp.Description
+	}
 	if resp.ModelId != nil {
 		ko.Status.ModelID = resp.ModelId
+	}
+	if resp.Name != nil {
+		ko.Spec.Name = resp.Name
+	}
+	if resp.Schema != nil {
+		ko.Spec.Schema = resp.Schema
 	}
 
 	return &resource{ko}, nil
@@ -134,8 +146,20 @@ func (rm *resourceManager) sdkCreate(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 
+	if resp.ContentType != nil {
+		ko.Spec.ContentType = resp.ContentType
+	}
+	if resp.Description != nil {
+		ko.Spec.Description = resp.Description
+	}
 	if resp.ModelId != nil {
 		ko.Status.ModelID = resp.ModelId
+	}
+	if resp.Name != nil {
+		ko.Spec.Name = resp.Name
+	}
+	if resp.Schema != nil {
+		ko.Spec.Schema = resp.Schema
 	}
 
 	if ko.Status.ACKResourceMetadata == nil {
@@ -196,8 +220,20 @@ func (rm *resourceManager) sdkUpdate(
 	// the original Kubernetes object we passed to the function
 	ko := desired.ko.DeepCopy()
 
+	if resp.ContentType != nil {
+		ko.Spec.ContentType = resp.ContentType
+	}
+	if resp.Description != nil {
+		ko.Spec.Description = resp.Description
+	}
 	if resp.ModelId != nil {
 		ko.Status.ModelID = resp.ModelId
+	}
+	if resp.Name != nil {
+		ko.Spec.Name = resp.Name
+	}
+	if resp.Schema != nil {
+		ko.Spec.Schema = resp.Schema
 	}
 
 	return &resource{ko}, nil

--- a/services/apigatewayv2/pkg/resource/route/sdk.go
+++ b/services/apigatewayv2/pkg/resource/route/sdk.go
@@ -70,8 +70,61 @@ func (rm *resourceManager) sdkFind(
 	if resp.ApiGatewayManaged != nil {
 		ko.Status.APIGatewayManaged = resp.ApiGatewayManaged
 	}
+	if resp.ApiKeyRequired != nil {
+		ko.Spec.APIKeyRequired = resp.ApiKeyRequired
+	}
+	if resp.AuthorizationScopes != nil {
+		f2 := []*string{}
+		for _, f2iter := range resp.AuthorizationScopes {
+			var f2elem string
+			f2elem = *f2iter
+			f2 = append(f2, &f2elem)
+		}
+		ko.Spec.AuthorizationScopes = f2
+	}
+	if resp.AuthorizationType != nil {
+		ko.Spec.AuthorizationType = resp.AuthorizationType
+	}
+	if resp.AuthorizerId != nil {
+		ko.Spec.AuthorizerID = resp.AuthorizerId
+	}
+	if resp.ModelSelectionExpression != nil {
+		ko.Spec.ModelSelectionExpression = resp.ModelSelectionExpression
+	}
+	if resp.OperationName != nil {
+		ko.Spec.OperationName = resp.OperationName
+	}
+	if resp.RequestModels != nil {
+		f7 := map[string]*string{}
+		for f7key, f7valiter := range resp.RequestModels {
+			var f7val string
+			f7val = *f7valiter
+			f7[f7key] = &f7val
+		}
+		ko.Spec.RequestModels = f7
+	}
+	if resp.RequestParameters != nil {
+		f8 := map[string]*svcapitypes.ParameterConstraints{}
+		for f8key, f8valiter := range resp.RequestParameters {
+			f8val := &svcapitypes.ParameterConstraints{}
+			if f8valiter.Required != nil {
+				f8val.Required = f8valiter.Required
+			}
+			f8[f8key] = f8val
+		}
+		ko.Spec.RequestParameters = f8
+	}
 	if resp.RouteId != nil {
 		ko.Status.RouteID = resp.RouteId
+	}
+	if resp.RouteKey != nil {
+		ko.Spec.RouteKey = resp.RouteKey
+	}
+	if resp.RouteResponseSelectionExpression != nil {
+		ko.Spec.RouteResponseSelectionExpression = resp.RouteResponseSelectionExpression
+	}
+	if resp.Target != nil {
+		ko.Spec.Target = resp.Target
 	}
 
 	return &resource{ko}, nil
@@ -140,8 +193,61 @@ func (rm *resourceManager) sdkCreate(
 	if resp.ApiGatewayManaged != nil {
 		ko.Status.APIGatewayManaged = resp.ApiGatewayManaged
 	}
+	if resp.ApiKeyRequired != nil {
+		ko.Spec.APIKeyRequired = resp.ApiKeyRequired
+	}
+	if resp.AuthorizationScopes != nil {
+		f2 := []*string{}
+		for _, f2iter := range resp.AuthorizationScopes {
+			var f2elem string
+			f2elem = *f2iter
+			f2 = append(f2, &f2elem)
+		}
+		ko.Spec.AuthorizationScopes = f2
+	}
+	if resp.AuthorizationType != nil {
+		ko.Spec.AuthorizationType = resp.AuthorizationType
+	}
+	if resp.AuthorizerId != nil {
+		ko.Spec.AuthorizerID = resp.AuthorizerId
+	}
+	if resp.ModelSelectionExpression != nil {
+		ko.Spec.ModelSelectionExpression = resp.ModelSelectionExpression
+	}
+	if resp.OperationName != nil {
+		ko.Spec.OperationName = resp.OperationName
+	}
+	if resp.RequestModels != nil {
+		f7 := map[string]*string{}
+		for f7key, f7valiter := range resp.RequestModels {
+			var f7val string
+			f7val = *f7valiter
+			f7[f7key] = &f7val
+		}
+		ko.Spec.RequestModels = f7
+	}
+	if resp.RequestParameters != nil {
+		f8 := map[string]*svcapitypes.ParameterConstraints{}
+		for f8key, f8valiter := range resp.RequestParameters {
+			f8val := &svcapitypes.ParameterConstraints{}
+			if f8valiter.Required != nil {
+				f8val.Required = f8valiter.Required
+			}
+			f8[f8key] = f8val
+		}
+		ko.Spec.RequestParameters = f8
+	}
 	if resp.RouteId != nil {
 		ko.Status.RouteID = resp.RouteId
+	}
+	if resp.RouteKey != nil {
+		ko.Spec.RouteKey = resp.RouteKey
+	}
+	if resp.RouteResponseSelectionExpression != nil {
+		ko.Spec.RouteResponseSelectionExpression = resp.RouteResponseSelectionExpression
+	}
+	if resp.Target != nil {
+		ko.Spec.Target = resp.Target
 	}
 
 	if ko.Status.ACKResourceMetadata == nil {
@@ -246,8 +352,61 @@ func (rm *resourceManager) sdkUpdate(
 	if resp.ApiGatewayManaged != nil {
 		ko.Status.APIGatewayManaged = resp.ApiGatewayManaged
 	}
+	if resp.ApiKeyRequired != nil {
+		ko.Spec.APIKeyRequired = resp.ApiKeyRequired
+	}
+	if resp.AuthorizationScopes != nil {
+		f2 := []*string{}
+		for _, f2iter := range resp.AuthorizationScopes {
+			var f2elem string
+			f2elem = *f2iter
+			f2 = append(f2, &f2elem)
+		}
+		ko.Spec.AuthorizationScopes = f2
+	}
+	if resp.AuthorizationType != nil {
+		ko.Spec.AuthorizationType = resp.AuthorizationType
+	}
+	if resp.AuthorizerId != nil {
+		ko.Spec.AuthorizerID = resp.AuthorizerId
+	}
+	if resp.ModelSelectionExpression != nil {
+		ko.Spec.ModelSelectionExpression = resp.ModelSelectionExpression
+	}
+	if resp.OperationName != nil {
+		ko.Spec.OperationName = resp.OperationName
+	}
+	if resp.RequestModels != nil {
+		f7 := map[string]*string{}
+		for f7key, f7valiter := range resp.RequestModels {
+			var f7val string
+			f7val = *f7valiter
+			f7[f7key] = &f7val
+		}
+		ko.Spec.RequestModels = f7
+	}
+	if resp.RequestParameters != nil {
+		f8 := map[string]*svcapitypes.ParameterConstraints{}
+		for f8key, f8valiter := range resp.RequestParameters {
+			f8val := &svcapitypes.ParameterConstraints{}
+			if f8valiter.Required != nil {
+				f8val.Required = f8valiter.Required
+			}
+			f8[f8key] = f8val
+		}
+		ko.Spec.RequestParameters = f8
+	}
 	if resp.RouteId != nil {
 		ko.Status.RouteID = resp.RouteId
+	}
+	if resp.RouteKey != nil {
+		ko.Spec.RouteKey = resp.RouteKey
+	}
+	if resp.RouteResponseSelectionExpression != nil {
+		ko.Spec.RouteResponseSelectionExpression = resp.RouteResponseSelectionExpression
+	}
+	if resp.Target != nil {
+		ko.Spec.Target = resp.Target
 	}
 
 	return &resource{ko}, nil

--- a/services/apigatewayv2/pkg/resource/route_response/sdk.go
+++ b/services/apigatewayv2/pkg/resource/route_response/sdk.go
@@ -67,8 +67,34 @@ func (rm *resourceManager) sdkFind(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 
+	if resp.ModelSelectionExpression != nil {
+		ko.Spec.ModelSelectionExpression = resp.ModelSelectionExpression
+	}
+	if resp.ResponseModels != nil {
+		f1 := map[string]*string{}
+		for f1key, f1valiter := range resp.ResponseModels {
+			var f1val string
+			f1val = *f1valiter
+			f1[f1key] = &f1val
+		}
+		ko.Spec.ResponseModels = f1
+	}
+	if resp.ResponseParameters != nil {
+		f2 := map[string]*svcapitypes.ParameterConstraints{}
+		for f2key, f2valiter := range resp.ResponseParameters {
+			f2val := &svcapitypes.ParameterConstraints{}
+			if f2valiter.Required != nil {
+				f2val.Required = f2valiter.Required
+			}
+			f2[f2key] = f2val
+		}
+		ko.Spec.ResponseParameters = f2
+	}
 	if resp.RouteResponseId != nil {
 		ko.Status.RouteResponseID = resp.RouteResponseId
+	}
+	if resp.RouteResponseKey != nil {
+		ko.Spec.RouteResponseKey = resp.RouteResponseKey
 	}
 
 	return &resource{ko}, nil
@@ -140,8 +166,34 @@ func (rm *resourceManager) sdkCreate(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 
+	if resp.ModelSelectionExpression != nil {
+		ko.Spec.ModelSelectionExpression = resp.ModelSelectionExpression
+	}
+	if resp.ResponseModels != nil {
+		f1 := map[string]*string{}
+		for f1key, f1valiter := range resp.ResponseModels {
+			var f1val string
+			f1val = *f1valiter
+			f1[f1key] = &f1val
+		}
+		ko.Spec.ResponseModels = f1
+	}
+	if resp.ResponseParameters != nil {
+		f2 := map[string]*svcapitypes.ParameterConstraints{}
+		for f2key, f2valiter := range resp.ResponseParameters {
+			f2val := &svcapitypes.ParameterConstraints{}
+			if f2valiter.Required != nil {
+				f2val.Required = f2valiter.Required
+			}
+			f2[f2key] = f2val
+		}
+		ko.Spec.ResponseParameters = f2
+	}
 	if resp.RouteResponseId != nil {
 		ko.Status.RouteResponseID = resp.RouteResponseId
+	}
+	if resp.RouteResponseKey != nil {
+		ko.Spec.RouteResponseKey = resp.RouteResponseKey
 	}
 
 	if ko.Status.ACKResourceMetadata == nil {
@@ -219,8 +271,34 @@ func (rm *resourceManager) sdkUpdate(
 	// the original Kubernetes object we passed to the function
 	ko := desired.ko.DeepCopy()
 
+	if resp.ModelSelectionExpression != nil {
+		ko.Spec.ModelSelectionExpression = resp.ModelSelectionExpression
+	}
+	if resp.ResponseModels != nil {
+		f1 := map[string]*string{}
+		for f1key, f1valiter := range resp.ResponseModels {
+			var f1val string
+			f1val = *f1valiter
+			f1[f1key] = &f1val
+		}
+		ko.Spec.ResponseModels = f1
+	}
+	if resp.ResponseParameters != nil {
+		f2 := map[string]*svcapitypes.ParameterConstraints{}
+		for f2key, f2valiter := range resp.ResponseParameters {
+			f2val := &svcapitypes.ParameterConstraints{}
+			if f2valiter.Required != nil {
+				f2val.Required = f2valiter.Required
+			}
+			f2[f2key] = f2val
+		}
+		ko.Spec.ResponseParameters = f2
+	}
 	if resp.RouteResponseId != nil {
 		ko.Status.RouteResponseID = resp.RouteResponseId
+	}
+	if resp.RouteResponseKey != nil {
+		ko.Spec.RouteResponseKey = resp.RouteResponseKey
 	}
 
 	return &resource{ko}, nil

--- a/services/apigatewayv2/pkg/resource/stage/sdk.go
+++ b/services/apigatewayv2/pkg/resource/stage/sdk.go
@@ -67,17 +67,102 @@ func (rm *resourceManager) sdkFind(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 
+	if resp.AccessLogSettings != nil {
+		f0 := &svcapitypes.AccessLogSettings{}
+		if resp.AccessLogSettings.DestinationArn != nil {
+			f0.DestinationARN = resp.AccessLogSettings.DestinationArn
+		}
+		if resp.AccessLogSettings.Format != nil {
+			f0.Format = resp.AccessLogSettings.Format
+		}
+		ko.Spec.AccessLogSettings = f0
+	}
 	if resp.ApiGatewayManaged != nil {
 		ko.Status.APIGatewayManaged = resp.ApiGatewayManaged
 	}
+	if resp.AutoDeploy != nil {
+		ko.Spec.AutoDeploy = resp.AutoDeploy
+	}
+	if resp.ClientCertificateId != nil {
+		ko.Spec.ClientCertificateID = resp.ClientCertificateId
+	}
 	if resp.CreatedDate != nil {
 		ko.Status.CreatedDate = &metav1.Time{*resp.CreatedDate}
+	}
+	if resp.DefaultRouteSettings != nil {
+		f5 := &svcapitypes.RouteSettings{}
+		if resp.DefaultRouteSettings.DataTraceEnabled != nil {
+			f5.DataTraceEnabled = resp.DefaultRouteSettings.DataTraceEnabled
+		}
+		if resp.DefaultRouteSettings.DetailedMetricsEnabled != nil {
+			f5.DetailedMetricsEnabled = resp.DefaultRouteSettings.DetailedMetricsEnabled
+		}
+		if resp.DefaultRouteSettings.LoggingLevel != nil {
+			f5.LoggingLevel = resp.DefaultRouteSettings.LoggingLevel
+		}
+		if resp.DefaultRouteSettings.ThrottlingBurstLimit != nil {
+			f5.ThrottlingBurstLimit = resp.DefaultRouteSettings.ThrottlingBurstLimit
+		}
+		if resp.DefaultRouteSettings.ThrottlingRateLimit != nil {
+			f5.ThrottlingRateLimit = resp.DefaultRouteSettings.ThrottlingRateLimit
+		}
+		ko.Spec.DefaultRouteSettings = f5
+	}
+	if resp.DeploymentId != nil {
+		ko.Spec.DeploymentID = resp.DeploymentId
+	}
+	if resp.Description != nil {
+		ko.Spec.Description = resp.Description
 	}
 	if resp.LastDeploymentStatusMessage != nil {
 		ko.Status.LastDeploymentStatusMessage = resp.LastDeploymentStatusMessage
 	}
 	if resp.LastUpdatedDate != nil {
 		ko.Status.LastUpdatedDate = &metav1.Time{*resp.LastUpdatedDate}
+	}
+	if resp.RouteSettings != nil {
+		f10 := map[string]*svcapitypes.RouteSettings{}
+		for f10key, f10valiter := range resp.RouteSettings {
+			f10val := &svcapitypes.RouteSettings{}
+			if f10valiter.DataTraceEnabled != nil {
+				f10val.DataTraceEnabled = f10valiter.DataTraceEnabled
+			}
+			if f10valiter.DetailedMetricsEnabled != nil {
+				f10val.DetailedMetricsEnabled = f10valiter.DetailedMetricsEnabled
+			}
+			if f10valiter.LoggingLevel != nil {
+				f10val.LoggingLevel = f10valiter.LoggingLevel
+			}
+			if f10valiter.ThrottlingBurstLimit != nil {
+				f10val.ThrottlingBurstLimit = f10valiter.ThrottlingBurstLimit
+			}
+			if f10valiter.ThrottlingRateLimit != nil {
+				f10val.ThrottlingRateLimit = f10valiter.ThrottlingRateLimit
+			}
+			f10[f10key] = f10val
+		}
+		ko.Spec.RouteSettings = f10
+	}
+	if resp.StageName != nil {
+		ko.Spec.StageName = resp.StageName
+	}
+	if resp.StageVariables != nil {
+		f12 := map[string]*string{}
+		for f12key, f12valiter := range resp.StageVariables {
+			var f12val string
+			f12val = *f12valiter
+			f12[f12key] = &f12val
+		}
+		ko.Spec.StageVariables = f12
+	}
+	if resp.Tags != nil {
+		f13 := map[string]*string{}
+		for f13key, f13valiter := range resp.Tags {
+			var f13val string
+			f13val = *f13valiter
+			f13[f13key] = &f13val
+		}
+		ko.Spec.Tags = f13
 	}
 
 	return &resource{ko}, nil
@@ -143,17 +228,102 @@ func (rm *resourceManager) sdkCreate(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 
+	if resp.AccessLogSettings != nil {
+		f0 := &svcapitypes.AccessLogSettings{}
+		if resp.AccessLogSettings.DestinationArn != nil {
+			f0.DestinationARN = resp.AccessLogSettings.DestinationArn
+		}
+		if resp.AccessLogSettings.Format != nil {
+			f0.Format = resp.AccessLogSettings.Format
+		}
+		ko.Spec.AccessLogSettings = f0
+	}
 	if resp.ApiGatewayManaged != nil {
 		ko.Status.APIGatewayManaged = resp.ApiGatewayManaged
 	}
+	if resp.AutoDeploy != nil {
+		ko.Spec.AutoDeploy = resp.AutoDeploy
+	}
+	if resp.ClientCertificateId != nil {
+		ko.Spec.ClientCertificateID = resp.ClientCertificateId
+	}
 	if resp.CreatedDate != nil {
 		ko.Status.CreatedDate = &metav1.Time{*resp.CreatedDate}
+	}
+	if resp.DefaultRouteSettings != nil {
+		f5 := &svcapitypes.RouteSettings{}
+		if resp.DefaultRouteSettings.DataTraceEnabled != nil {
+			f5.DataTraceEnabled = resp.DefaultRouteSettings.DataTraceEnabled
+		}
+		if resp.DefaultRouteSettings.DetailedMetricsEnabled != nil {
+			f5.DetailedMetricsEnabled = resp.DefaultRouteSettings.DetailedMetricsEnabled
+		}
+		if resp.DefaultRouteSettings.LoggingLevel != nil {
+			f5.LoggingLevel = resp.DefaultRouteSettings.LoggingLevel
+		}
+		if resp.DefaultRouteSettings.ThrottlingBurstLimit != nil {
+			f5.ThrottlingBurstLimit = resp.DefaultRouteSettings.ThrottlingBurstLimit
+		}
+		if resp.DefaultRouteSettings.ThrottlingRateLimit != nil {
+			f5.ThrottlingRateLimit = resp.DefaultRouteSettings.ThrottlingRateLimit
+		}
+		ko.Spec.DefaultRouteSettings = f5
+	}
+	if resp.DeploymentId != nil {
+		ko.Spec.DeploymentID = resp.DeploymentId
+	}
+	if resp.Description != nil {
+		ko.Spec.Description = resp.Description
 	}
 	if resp.LastDeploymentStatusMessage != nil {
 		ko.Status.LastDeploymentStatusMessage = resp.LastDeploymentStatusMessage
 	}
 	if resp.LastUpdatedDate != nil {
 		ko.Status.LastUpdatedDate = &metav1.Time{*resp.LastUpdatedDate}
+	}
+	if resp.RouteSettings != nil {
+		f10 := map[string]*svcapitypes.RouteSettings{}
+		for f10key, f10valiter := range resp.RouteSettings {
+			f10val := &svcapitypes.RouteSettings{}
+			if f10valiter.DataTraceEnabled != nil {
+				f10val.DataTraceEnabled = f10valiter.DataTraceEnabled
+			}
+			if f10valiter.DetailedMetricsEnabled != nil {
+				f10val.DetailedMetricsEnabled = f10valiter.DetailedMetricsEnabled
+			}
+			if f10valiter.LoggingLevel != nil {
+				f10val.LoggingLevel = f10valiter.LoggingLevel
+			}
+			if f10valiter.ThrottlingBurstLimit != nil {
+				f10val.ThrottlingBurstLimit = f10valiter.ThrottlingBurstLimit
+			}
+			if f10valiter.ThrottlingRateLimit != nil {
+				f10val.ThrottlingRateLimit = f10valiter.ThrottlingRateLimit
+			}
+			f10[f10key] = f10val
+		}
+		ko.Spec.RouteSettings = f10
+	}
+	if resp.StageName != nil {
+		ko.Spec.StageName = resp.StageName
+	}
+	if resp.StageVariables != nil {
+		f12 := map[string]*string{}
+		for f12key, f12valiter := range resp.StageVariables {
+			var f12val string
+			f12val = *f12valiter
+			f12[f12key] = &f12val
+		}
+		ko.Spec.StageVariables = f12
+	}
+	if resp.Tags != nil {
+		f13 := map[string]*string{}
+		for f13key, f13valiter := range resp.Tags {
+			var f13val string
+			f13val = *f13valiter
+			f13[f13key] = &f13val
+		}
+		ko.Spec.Tags = f13
 	}
 
 	if ko.Status.ACKResourceMetadata == nil {
@@ -287,17 +457,102 @@ func (rm *resourceManager) sdkUpdate(
 	// the original Kubernetes object we passed to the function
 	ko := desired.ko.DeepCopy()
 
+	if resp.AccessLogSettings != nil {
+		f0 := &svcapitypes.AccessLogSettings{}
+		if resp.AccessLogSettings.DestinationArn != nil {
+			f0.DestinationARN = resp.AccessLogSettings.DestinationArn
+		}
+		if resp.AccessLogSettings.Format != nil {
+			f0.Format = resp.AccessLogSettings.Format
+		}
+		ko.Spec.AccessLogSettings = f0
+	}
 	if resp.ApiGatewayManaged != nil {
 		ko.Status.APIGatewayManaged = resp.ApiGatewayManaged
 	}
+	if resp.AutoDeploy != nil {
+		ko.Spec.AutoDeploy = resp.AutoDeploy
+	}
+	if resp.ClientCertificateId != nil {
+		ko.Spec.ClientCertificateID = resp.ClientCertificateId
+	}
 	if resp.CreatedDate != nil {
 		ko.Status.CreatedDate = &metav1.Time{*resp.CreatedDate}
+	}
+	if resp.DefaultRouteSettings != nil {
+		f5 := &svcapitypes.RouteSettings{}
+		if resp.DefaultRouteSettings.DataTraceEnabled != nil {
+			f5.DataTraceEnabled = resp.DefaultRouteSettings.DataTraceEnabled
+		}
+		if resp.DefaultRouteSettings.DetailedMetricsEnabled != nil {
+			f5.DetailedMetricsEnabled = resp.DefaultRouteSettings.DetailedMetricsEnabled
+		}
+		if resp.DefaultRouteSettings.LoggingLevel != nil {
+			f5.LoggingLevel = resp.DefaultRouteSettings.LoggingLevel
+		}
+		if resp.DefaultRouteSettings.ThrottlingBurstLimit != nil {
+			f5.ThrottlingBurstLimit = resp.DefaultRouteSettings.ThrottlingBurstLimit
+		}
+		if resp.DefaultRouteSettings.ThrottlingRateLimit != nil {
+			f5.ThrottlingRateLimit = resp.DefaultRouteSettings.ThrottlingRateLimit
+		}
+		ko.Spec.DefaultRouteSettings = f5
+	}
+	if resp.DeploymentId != nil {
+		ko.Spec.DeploymentID = resp.DeploymentId
+	}
+	if resp.Description != nil {
+		ko.Spec.Description = resp.Description
 	}
 	if resp.LastDeploymentStatusMessage != nil {
 		ko.Status.LastDeploymentStatusMessage = resp.LastDeploymentStatusMessage
 	}
 	if resp.LastUpdatedDate != nil {
 		ko.Status.LastUpdatedDate = &metav1.Time{*resp.LastUpdatedDate}
+	}
+	if resp.RouteSettings != nil {
+		f10 := map[string]*svcapitypes.RouteSettings{}
+		for f10key, f10valiter := range resp.RouteSettings {
+			f10val := &svcapitypes.RouteSettings{}
+			if f10valiter.DataTraceEnabled != nil {
+				f10val.DataTraceEnabled = f10valiter.DataTraceEnabled
+			}
+			if f10valiter.DetailedMetricsEnabled != nil {
+				f10val.DetailedMetricsEnabled = f10valiter.DetailedMetricsEnabled
+			}
+			if f10valiter.LoggingLevel != nil {
+				f10val.LoggingLevel = f10valiter.LoggingLevel
+			}
+			if f10valiter.ThrottlingBurstLimit != nil {
+				f10val.ThrottlingBurstLimit = f10valiter.ThrottlingBurstLimit
+			}
+			if f10valiter.ThrottlingRateLimit != nil {
+				f10val.ThrottlingRateLimit = f10valiter.ThrottlingRateLimit
+			}
+			f10[f10key] = f10val
+		}
+		ko.Spec.RouteSettings = f10
+	}
+	if resp.StageName != nil {
+		ko.Spec.StageName = resp.StageName
+	}
+	if resp.StageVariables != nil {
+		f12 := map[string]*string{}
+		for f12key, f12valiter := range resp.StageVariables {
+			var f12val string
+			f12val = *f12valiter
+			f12[f12key] = &f12val
+		}
+		ko.Spec.StageVariables = f12
+	}
+	if resp.Tags != nil {
+		f13 := map[string]*string{}
+		for f13key, f13valiter := range resp.Tags {
+			var f13val string
+			f13val = *f13valiter
+			f13[f13key] = &f13val
+		}
+		ko.Spec.Tags = f13
 	}
 
 	return &resource{ko}, nil

--- a/services/apigatewayv2/pkg/resource/vpc_link/sdk.go
+++ b/services/apigatewayv2/pkg/resource/vpc_link/sdk.go
@@ -70,6 +70,36 @@ func (rm *resourceManager) sdkFind(
 	if resp.CreatedDate != nil {
 		ko.Status.CreatedDate = &metav1.Time{*resp.CreatedDate}
 	}
+	if resp.Name != nil {
+		ko.Spec.Name = resp.Name
+	}
+	if resp.SecurityGroupIds != nil {
+		f2 := []*string{}
+		for _, f2iter := range resp.SecurityGroupIds {
+			var f2elem string
+			f2elem = *f2iter
+			f2 = append(f2, &f2elem)
+		}
+		ko.Spec.SecurityGroupIDs = f2
+	}
+	if resp.SubnetIds != nil {
+		f3 := []*string{}
+		for _, f3iter := range resp.SubnetIds {
+			var f3elem string
+			f3elem = *f3iter
+			f3 = append(f3, &f3elem)
+		}
+		ko.Spec.SubnetIDs = f3
+	}
+	if resp.Tags != nil {
+		f4 := map[string]*string{}
+		for f4key, f4valiter := range resp.Tags {
+			var f4val string
+			f4val = *f4valiter
+			f4[f4key] = &f4val
+		}
+		ko.Spec.Tags = f4
+	}
 	if resp.VpcLinkId != nil {
 		ko.Status.VPCLinkID = resp.VpcLinkId
 	}
@@ -141,6 +171,36 @@ func (rm *resourceManager) sdkCreate(
 
 	if resp.CreatedDate != nil {
 		ko.Status.CreatedDate = &metav1.Time{*resp.CreatedDate}
+	}
+	if resp.Name != nil {
+		ko.Spec.Name = resp.Name
+	}
+	if resp.SecurityGroupIds != nil {
+		f2 := []*string{}
+		for _, f2iter := range resp.SecurityGroupIds {
+			var f2elem string
+			f2elem = *f2iter
+			f2 = append(f2, &f2elem)
+		}
+		ko.Spec.SecurityGroupIDs = f2
+	}
+	if resp.SubnetIds != nil {
+		f3 := []*string{}
+		for _, f3iter := range resp.SubnetIds {
+			var f3elem string
+			f3elem = *f3iter
+			f3 = append(f3, &f3elem)
+		}
+		ko.Spec.SubnetIDs = f3
+	}
+	if resp.Tags != nil {
+		f4 := map[string]*string{}
+		for f4key, f4valiter := range resp.Tags {
+			var f4val string
+			f4val = *f4valiter
+			f4[f4key] = &f4val
+		}
+		ko.Spec.Tags = f4
 	}
 	if resp.VpcLinkId != nil {
 		ko.Status.VPCLinkID = resp.VpcLinkId
@@ -230,6 +290,36 @@ func (rm *resourceManager) sdkUpdate(
 
 	if resp.CreatedDate != nil {
 		ko.Status.CreatedDate = &metav1.Time{*resp.CreatedDate}
+	}
+	if resp.Name != nil {
+		ko.Spec.Name = resp.Name
+	}
+	if resp.SecurityGroupIds != nil {
+		f2 := []*string{}
+		for _, f2iter := range resp.SecurityGroupIds {
+			var f2elem string
+			f2elem = *f2iter
+			f2 = append(f2, &f2elem)
+		}
+		ko.Spec.SecurityGroupIDs = f2
+	}
+	if resp.SubnetIds != nil {
+		f3 := []*string{}
+		for _, f3iter := range resp.SubnetIds {
+			var f3elem string
+			f3elem = *f3iter
+			f3 = append(f3, &f3elem)
+		}
+		ko.Spec.SubnetIDs = f3
+	}
+	if resp.Tags != nil {
+		f4 := map[string]*string{}
+		for f4key, f4valiter := range resp.Tags {
+			var f4val string
+			f4val = *f4valiter
+			f4[f4key] = &f4val
+		}
+		ko.Spec.Tags = f4
 	}
 	if resp.VpcLinkId != nil {
 		ko.Status.VPCLinkID = resp.VpcLinkId

--- a/services/ecr/config/controller/deployment.yaml
+++ b/services/ecr/config/controller/deployment.yaml
@@ -41,4 +41,9 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        env:
+        - name: K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       terminationGracePeriodSeconds: 10

--- a/services/ecr/pkg/resource/repository/sdk.go
+++ b/services/ecr/pkg/resource/repository/sdk.go
@@ -155,6 +155,26 @@ func (rm *resourceManager) sdkCreate(
 	if resp.Repository.CreatedAt != nil {
 		ko.Status.CreatedAt = &metav1.Time{*resp.Repository.CreatedAt}
 	}
+	if resp.Repository.EncryptionConfiguration != nil {
+		f1 := &svcapitypes.EncryptionConfiguration{}
+		if resp.Repository.EncryptionConfiguration.EncryptionType != nil {
+			f1.EncryptionType = resp.Repository.EncryptionConfiguration.EncryptionType
+		}
+		if resp.Repository.EncryptionConfiguration.KmsKey != nil {
+			f1.KMSKey = resp.Repository.EncryptionConfiguration.KmsKey
+		}
+		ko.Spec.EncryptionConfiguration = f1
+	}
+	if resp.Repository.ImageScanningConfiguration != nil {
+		f2 := &svcapitypes.ImageScanningConfiguration{}
+		if resp.Repository.ImageScanningConfiguration.ScanOnPush != nil {
+			f2.ScanOnPush = resp.Repository.ImageScanningConfiguration.ScanOnPush
+		}
+		ko.Spec.ImageScanningConfiguration = f2
+	}
+	if resp.Repository.ImageTagMutability != nil {
+		ko.Spec.ImageTagMutability = resp.Repository.ImageTagMutability
+	}
 	if resp.Repository.RegistryId != nil {
 		ko.Status.RegistryID = resp.Repository.RegistryId
 	}
@@ -164,6 +184,9 @@ func (rm *resourceManager) sdkCreate(
 	if resp.Repository.RepositoryArn != nil {
 		arn := ackv1alpha1.AWSResourceName(*resp.Repository.RepositoryArn)
 		ko.Status.ACKResourceMetadata.ARN = &arn
+	}
+	if resp.Repository.RepositoryName != nil {
+		ko.Spec.RepositoryName = resp.Repository.RepositoryName
 	}
 	if resp.Repository.RepositoryUri != nil {
 		ko.Status.RepositoryURI = resp.Repository.RepositoryUri

--- a/services/elasticache/config/controller/deployment.yaml
+++ b/services/elasticache/config/controller/deployment.yaml
@@ -41,4 +41,9 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        env:
+        - name: K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       terminationGracePeriodSeconds: 10

--- a/services/elasticache/pkg/resource/cache_subnet_group/sdk.go
+++ b/services/elasticache/pkg/resource/cache_subnet_group/sdk.go
@@ -149,6 +149,12 @@ func (rm *resourceManager) sdkCreate(
 		arn := ackv1alpha1.AWSResourceName(*resp.CacheSubnetGroup.ARN)
 		ko.Status.ACKResourceMetadata.ARN = &arn
 	}
+	if resp.CacheSubnetGroup.CacheSubnetGroupDescription != nil {
+		ko.Spec.CacheSubnetGroupDescription = resp.CacheSubnetGroup.CacheSubnetGroupDescription
+	}
+	if resp.CacheSubnetGroup.CacheSubnetGroupName != nil {
+		ko.Spec.CacheSubnetGroupName = resp.CacheSubnetGroup.CacheSubnetGroupName
+	}
 	if resp.CacheSubnetGroup.Subnets != nil {
 		f3 := []*svcapitypes.Subnet{}
 		for _, f3iter := range resp.CacheSubnetGroup.Subnets {
@@ -235,6 +241,12 @@ func (rm *resourceManager) sdkUpdate(
 	if resp.CacheSubnetGroup.ARN != nil {
 		arn := ackv1alpha1.AWSResourceName(*resp.CacheSubnetGroup.ARN)
 		ko.Status.ACKResourceMetadata.ARN = &arn
+	}
+	if resp.CacheSubnetGroup.CacheSubnetGroupDescription != nil {
+		ko.Spec.CacheSubnetGroupDescription = resp.CacheSubnetGroup.CacheSubnetGroupDescription
+	}
+	if resp.CacheSubnetGroup.CacheSubnetGroupName != nil {
+		ko.Spec.CacheSubnetGroupName = resp.CacheSubnetGroup.CacheSubnetGroupName
 	}
 	if resp.CacheSubnetGroup.Subnets != nil {
 		f3 := []*svcapitypes.Subnet{}

--- a/services/elasticache/pkg/resource/replication_group/sdk.go
+++ b/services/elasticache/pkg/resource/replication_group/sdk.go
@@ -290,6 +290,9 @@ func (rm *resourceManager) sdkCreate(
 		arn := ackv1alpha1.AWSResourceName(*resp.ReplicationGroup.ARN)
 		ko.Status.ACKResourceMetadata.ARN = &arn
 	}
+	if resp.ReplicationGroup.AtRestEncryptionEnabled != nil {
+		ko.Spec.AtRestEncryptionEnabled = resp.ReplicationGroup.AtRestEncryptionEnabled
+	}
 	if resp.ReplicationGroup.AuthTokenEnabled != nil {
 		ko.Status.AuthTokenEnabled = resp.ReplicationGroup.AuthTokenEnabled
 	}
@@ -298,6 +301,9 @@ func (rm *resourceManager) sdkCreate(
 	}
 	if resp.ReplicationGroup.AutomaticFailover != nil {
 		ko.Status.AutomaticFailover = resp.ReplicationGroup.AutomaticFailover
+	}
+	if resp.ReplicationGroup.CacheNodeType != nil {
+		ko.Spec.CacheNodeType = resp.ReplicationGroup.CacheNodeType
 	}
 	if resp.ReplicationGroup.ClusterEnabled != nil {
 		ko.Status.ClusterEnabled = resp.ReplicationGroup.ClusterEnabled
@@ -324,6 +330,9 @@ func (rm *resourceManager) sdkCreate(
 			f9.GlobalReplicationGroupMemberRole = resp.ReplicationGroup.GlobalReplicationGroupInfo.GlobalReplicationGroupMemberRole
 		}
 		ko.Status.GlobalReplicationGroupInfo = f9
+	}
+	if resp.ReplicationGroup.KmsKeyId != nil {
+		ko.Spec.KMSKeyID = resp.ReplicationGroup.KmsKeyId
 	}
 	if resp.ReplicationGroup.MemberClusters != nil {
 		f11 := []*string{}
@@ -428,11 +437,23 @@ func (rm *resourceManager) sdkCreate(
 		}
 		ko.Status.PendingModifiedValues = f14
 	}
+	if resp.ReplicationGroup.ReplicationGroupId != nil {
+		ko.Spec.ReplicationGroupID = resp.ReplicationGroup.ReplicationGroupId
+	}
+	if resp.ReplicationGroup.SnapshotRetentionLimit != nil {
+		ko.Spec.SnapshotRetentionLimit = resp.ReplicationGroup.SnapshotRetentionLimit
+	}
+	if resp.ReplicationGroup.SnapshotWindow != nil {
+		ko.Spec.SnapshotWindow = resp.ReplicationGroup.SnapshotWindow
+	}
 	if resp.ReplicationGroup.SnapshottingClusterId != nil {
 		ko.Status.SnapshottingClusterID = resp.ReplicationGroup.SnapshottingClusterId
 	}
 	if resp.ReplicationGroup.Status != nil {
 		ko.Status.Status = resp.ReplicationGroup.Status
+	}
+	if resp.ReplicationGroup.TransitEncryptionEnabled != nil {
+		ko.Spec.TransitEncryptionEnabled = resp.ReplicationGroup.TransitEncryptionEnabled
 	}
 
 	// custom set output from response
@@ -647,6 +668,9 @@ func (rm *resourceManager) sdkUpdate(
 		arn := ackv1alpha1.AWSResourceName(*resp.ReplicationGroup.ARN)
 		ko.Status.ACKResourceMetadata.ARN = &arn
 	}
+	if resp.ReplicationGroup.AtRestEncryptionEnabled != nil {
+		ko.Spec.AtRestEncryptionEnabled = resp.ReplicationGroup.AtRestEncryptionEnabled
+	}
 	if resp.ReplicationGroup.AuthTokenEnabled != nil {
 		ko.Status.AuthTokenEnabled = resp.ReplicationGroup.AuthTokenEnabled
 	}
@@ -655,6 +679,9 @@ func (rm *resourceManager) sdkUpdate(
 	}
 	if resp.ReplicationGroup.AutomaticFailover != nil {
 		ko.Status.AutomaticFailover = resp.ReplicationGroup.AutomaticFailover
+	}
+	if resp.ReplicationGroup.CacheNodeType != nil {
+		ko.Spec.CacheNodeType = resp.ReplicationGroup.CacheNodeType
 	}
 	if resp.ReplicationGroup.ClusterEnabled != nil {
 		ko.Status.ClusterEnabled = resp.ReplicationGroup.ClusterEnabled
@@ -681,6 +708,9 @@ func (rm *resourceManager) sdkUpdate(
 			f9.GlobalReplicationGroupMemberRole = resp.ReplicationGroup.GlobalReplicationGroupInfo.GlobalReplicationGroupMemberRole
 		}
 		ko.Status.GlobalReplicationGroupInfo = f9
+	}
+	if resp.ReplicationGroup.KmsKeyId != nil {
+		ko.Spec.KMSKeyID = resp.ReplicationGroup.KmsKeyId
 	}
 	if resp.ReplicationGroup.MemberClusters != nil {
 		f11 := []*string{}
@@ -785,11 +815,23 @@ func (rm *resourceManager) sdkUpdate(
 		}
 		ko.Status.PendingModifiedValues = f14
 	}
+	if resp.ReplicationGroup.ReplicationGroupId != nil {
+		ko.Spec.ReplicationGroupID = resp.ReplicationGroup.ReplicationGroupId
+	}
+	if resp.ReplicationGroup.SnapshotRetentionLimit != nil {
+		ko.Spec.SnapshotRetentionLimit = resp.ReplicationGroup.SnapshotRetentionLimit
+	}
+	if resp.ReplicationGroup.SnapshotWindow != nil {
+		ko.Spec.SnapshotWindow = resp.ReplicationGroup.SnapshotWindow
+	}
 	if resp.ReplicationGroup.SnapshottingClusterId != nil {
 		ko.Status.SnapshottingClusterID = resp.ReplicationGroup.SnapshottingClusterId
 	}
 	if resp.ReplicationGroup.Status != nil {
 		ko.Status.Status = resp.ReplicationGroup.Status
+	}
+	if resp.ReplicationGroup.TransitEncryptionEnabled != nil {
+		ko.Spec.TransitEncryptionEnabled = resp.ReplicationGroup.TransitEncryptionEnabled
 	}
 
 	// custom set output from response

--- a/services/s3/config/controller/deployment.yaml
+++ b/services/s3/config/controller/deployment.yaml
@@ -41,4 +41,9 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        env:
+        - name: K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       terminationGracePeriodSeconds: 10

--- a/services/sns/config/controller/deployment.yaml
+++ b/services/sns/config/controller/deployment.yaml
@@ -41,4 +41,9 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        env:
+        - name: K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
       terminationGracePeriodSeconds: 10

--- a/templates/pkg/crd_sdk.go.tpl
+++ b/templates/pkg/crd_sdk.go.tpl
@@ -48,7 +48,7 @@ func (rm *resourceManager) sdkFind(
 	if err != nil {
 		return nil, err
 	}
-{{ $setCode := GoCodeSetReadOneOutput .CRD "resp" "ko.Status" 1 }}
+{{ $setCode := GoCodeSetReadOneOutput .CRD "resp" "ko" 1 }}
 	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.ReadOne.Name }}WithContext(ctx, input)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceExceptionCode .CRD 404 }}" {
@@ -183,7 +183,7 @@ func (rm *resourceManager) sdkCreate(
 	if err != nil {
 		return nil, err
 	}
-{{ $createCode := GoCodeSetCreateOutput .CRD "resp" "ko.Status" 1 }}
+{{ $createCode := GoCodeSetCreateOutput .CRD "resp" "ko" 1 }}
 	{{ if not ( Empty $createCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.Create.Name }}WithContext(ctx, input)
 	if respErr != nil {
 		return nil, respErr
@@ -239,7 +239,7 @@ func (rm *resourceManager) sdkUpdate(
 		return nil, err
 	}
 
-{{ $setCode := GoCodeSetUpdateOutput .CRD "resp" "ko.Status" 1 }}
+{{ $setCode := GoCodeSetUpdateOutput .CRD "resp" "ko" 1 }}
 	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.Update.Name }}WithContext(ctx, input)
 	if respErr != nil {
 		return nil, respErr


### PR DESCRIPTION
"Updating Spec and Status from ReadOne & ReadMany calls, using shapes used to construct Spec and Status."

Issue #, if available:

Description of changes:
* modified all tests
* Added a todo to consider renamed spec fields
* generated new controller code for all services
* tested that updates are working now for apigatewayv2
* updated rds test to ignore DBSecurityGroup field because the shape for same field name is different in Create, ReadMany outputs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
