### PR TITLE
Handle case when supplied alias is named differently in aws-sdk-go/models/apis

### DIFF
--- a/cmd/ack-generate/command/apis.go
+++ b/cmd/ack-generate/command/apis.go
@@ -80,7 +80,14 @@ func generateAPIs(cmd *cobra.Command, args []string) error {
 	sdkHelper := model.NewSDKHelper(sdkDir)
 	sdkAPI, err := sdkHelper.API(svcAlias)
 	if err != nil {
-		return err
+		newSvcAlias, err := FallBackFindServiceID(sdkDir, svcAlias)
+		if err != nil {
+			return err
+		}
+		sdkAPI, err = sdkHelper.API(newSvcAlias) // retry with serviceID
+		if err != nil {
+			return err
+		}
 	}
 	g, err := generate.New(
 		sdkAPI, optGenVersion, optGeneratorConfigPath, optTemplatesDir,

--- a/cmd/ack-generate/command/controller.go
+++ b/cmd/ack-generate/command/controller.go
@@ -14,9 +14,12 @@
 package command
 
 import (
+	"bufio"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -74,7 +77,14 @@ func generateController(cmd *cobra.Command, args []string) error {
 	sdkHelper := ackmodel.NewSDKHelper(sdkDir)
 	sdkAPI, err := sdkHelper.API(svcAlias)
 	if err != nil {
-		return err
+		newSvcAlias, err := FallBackFindServiceID(sdkDir, svcAlias)
+		if err != nil {
+			return err
+		}
+		sdkAPI, err = sdkHelper.API(newSvcAlias) // retry with serviceID
+		if err != nil {
+			return err
+		}
 	}
 	latestAPIVersion, err = getLatestAPIVersion()
 	if err != nil {
@@ -225,4 +235,44 @@ func getLatestAPIVersion() (string, error) {
 		return k8sversion.CompareKubeAwareVersionStrings(versions[i], versions[j]) < 0
 	})
 	return versions[len(versions)-1], nil
+}
+
+// FallBackFindServiceID reads through aws-sdk-go/models/apis/*/*/api-2.json
+// Returns ServiceID (as newSuppliedAlias) if supplied service Alias matches with serviceID in api-2.json
+// If not a match, return the supllied alias.
+func FallBackFindServiceID(sdkDir, svcAlias string) (string, error) {
+	basePath := filepath.Join(sdkDir, "models", "apis")
+	var files []string
+	err := filepath.Walk(basePath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		files = append(files, path)
+		return nil
+	})
+	if err != nil {
+		return svcAlias, err
+	}
+	for _, file := range files {
+		if strings.Contains(file, "api-2.json") {
+			f, err := os.Open(file)
+			if err != nil {
+				return svcAlias, err
+			}
+			defer f.Close()
+			scanner := bufio.NewScanner(f)
+			for scanner.Scan() {
+				if strings.Contains(scanner.Text(), "serviceId") {
+					getServiceID := strings.Split(scanner.Text(), ":")
+					re := regexp.MustCompile(`[," \t]`)
+					svcID := strings.ToLower(re.ReplaceAllString(getServiceID[1], ``))
+					if svcAlias == svcID {
+						getNewSvcAlias := strings.Split(file, string(os.PathSeparator))
+						return getNewSvcAlias[len(getNewSvcAlias)-3], nil
+					}
+				}
+			}
+		}
+	}
+	return svcAlias, nil
 }


### PR DESCRIPTION
Handle the case where the supplied alias is named differently in `aws-sdk-go/models/apis`. However, the same supplied alias exists in `...aws-sdk-go/models/apis/*/*/api-2.json` (`serviceId field`).

Issue #, if available: #199 

Description of changes:
- Created a Function, that walks through into `aws-sdk-go/models/apis/`
- Reads `api-2.json` for each `service/version` 
- Matches `serviceId` field in `api-2.json` against supplied Service Alias
- If a match, return the dir name just under `aws-sdk-go/models/apis/`. For Example, returns `states` from `~/.cache/aws-sdk-go/models/apis/states/2016-11-23/api-2.json`
- updated `controller` and `apis` to call this Function when, supplied alias returns a **Not found Error in aws-sdk-go/models/apis**
```
$ aws-controllers-k8s git:(sulabh) ✗ ./scripts/build-controller.sh sfn
Building Kubernetes API objects for sfn
Generating deepcopy code for sfn
Generating custom resource definitions for sfn
Building service controller for sfn
Generating RBAC manifests for sfn
Running gofmt against generated code for sfn
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
