### PR TITLE
Added e2e tests in workflow

### DIFF
--- a/.github/workflows/on.pull-request.main.yaml
+++ b/.github/workflows/on.pull-request.main.yaml
@@ -45,3 +45,37 @@ jobs:
           make build-controller SERVICE=$SERVICE
         env:
           SERVICE: ${{ matrix.service }}
+
+  test-controllers:
+    name: test controllers
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+         - s3
+         - ecr
+         - sns
+         - sqs
+         - elasticache
+         - dynamodb
+         - apigatewayv2
+    runs-on: self-hosted
+    steps:
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.15
+        id: go
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: execute e2e tests
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          export ACK_TEST_IAM_ROLE=Admin-K8s
+          export ACK_TEST_PRINCIPAL_ARN=$(aws sts get-caller-identity --query 'Arn' --output text)
+          export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
+          export AWS_ROLE_ARN=arn:aws:iam::${AWS_ACCOUNT_ID}:role/${ACK_TEST_IAM_ROLE}
+          make build-controller SERVICE=$SERVICE
+          make kind-test SERVICE=$SERVICE
+        env:
+          SERVICE: ${{ matrix.service }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 SHELL := /bin/bash # Use bash syntax
+
+# Set up variables
 GO111MODULE=on
 
 DOCKER_REPOSITORY ?= amazon/aws-controllers-k8s


### PR DESCRIPTION
Issue #, if available: #327 

Description of changes:
- Modified the workflow to use `self-hosted` runners
- Included e2e tests in the workflow
- Removed the default mockery version install
   - The default version throws error - #265 and #326 
   - The runner has `v1.0.1` installed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
