### PR TITLE
Use the same aws-sdk-go version mentionned in the go.mod file to generate code

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -31,6 +31,7 @@ License version 2.0, we include the full text of the package's License below.
 * `github.com/spf13/cobra`
 * `github.com/spf13/pflag`
 * `github.com/stretchr/testify`
+* `golang.org/x/mod`
 * `k8s.io/api`
 * `k8s.io/apimachinery`
 * `k8s.io/client-go`
@@ -549,6 +550,41 @@ SOFTWARE.
 #### gopkg.in/yaml.v3
 
 Apache License version 2.0
+
+### golang.org/x/mod
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Subdependencies:
+* `golang.org/x/crypto`
+* `golang.org/x/tools`
+* `golang.org/x/xerrors`
 
 ### k8s.io/api
 

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1
 	go.uber.org/zap v1.10.0
+	golang.org/x/mod v0.2.0
 	k8s.io/api v0.18.2
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v0.18.2


### PR DESCRIPTION
Issue #321

Description of changes:
- Add `getSDKVersion` function to extract the aws-sdk-go version to use
- Remove `--depth=1` flag from the `git pull` command to allow easier switches between versions/tags
- Use `git checkout` instead of `git pull`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
