### PR TITLE
An extra space after EOF should be removed

### DIFF
--- a/docs/contents/dev-docs/testing.md
+++ b/docs/contents/dev-docs/testing.md
@@ -151,7 +151,7 @@ cat > trust-policy.json << EOF
 		"Action": "sts:AssumeRole"
 	}
 }
-EOF 
+EOF
 ```
 
 Using above trust policy, we can now create the IAM role:


### PR DESCRIPTION
heredoc cannot end with extra space after EOF.
So, how about removing this extra space?

