### PR TITLE
Avoid creating directories if a service is not found in aws-sdk-go cache

### DIFF
--- a/cmd/ack-generate/command/apis.go
+++ b/cmd/ack-generate/command/apis.go
@@ -68,12 +68,6 @@ func generateAPIs(cmd *cobra.Command, args []string) error {
 	if optAPIsOutputPath == "" {
 		optAPIsOutputPath = filepath.Join(optServicesDir)
 	}
-	if !optDryRun {
-		apisVersionPath = filepath.Join(optAPIsOutputPath, svcAlias, "apis", optGenVersion)
-		if _, err := ensureDir(apisVersionPath); err != nil {
-			return err
-		}
-	}
 	if err := ensureSDKRepo(optCacheDir); err != nil {
 		return err
 	}
@@ -86,6 +80,12 @@ func generateAPIs(cmd *cobra.Command, args []string) error {
 		}
 		sdkAPI, err = sdkHelper.API(newSvcAlias) // retry with serviceID
 		if err != nil {
+			return fmt.Errorf("service %s not found", svcAlias)
+		}
+	}
+	if !optDryRun {
+		apisVersionPath = filepath.Join(optAPIsOutputPath, svcAlias, "apis", optGenVersion)
+		if _, err := ensureDir(apisVersionPath); err != nil {
 			return err
 		}
 	}

--- a/cmd/ack-generate/command/controller.go
+++ b/cmd/ack-generate/command/controller.go
@@ -60,17 +60,6 @@ func generateController(cmd *cobra.Command, args []string) error {
 		optControllerOutputPath = filepath.Join(optServicesDir, svcAlias)
 	}
 
-	if !optDryRun {
-		cmdControllerPath = filepath.Join(optControllerOutputPath, "cmd", "controller")
-		if _, err := ensureDir(cmdControllerPath); err != nil {
-			return err
-		}
-		pkgResourcePath = filepath.Join(optControllerOutputPath, "pkg", "resource")
-		if _, err := ensureDir(pkgResourcePath); err != nil {
-			return err
-		}
-	}
-
 	if err := ensureSDKRepo(optCacheDir); err != nil {
 		return err
 	}
@@ -83,7 +72,7 @@ func generateController(cmd *cobra.Command, args []string) error {
 		}
 		sdkAPI, err = sdkHelper.API(newSvcAlias) // retry with serviceID
 		if err != nil {
-			return err
+			return fmt.Errorf("service %s not found", svcAlias)
 		}
 	}
 	latestAPIVersion, err = getLatestAPIVersion()
@@ -102,6 +91,16 @@ func generateController(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if !optDryRun {
+		cmdControllerPath = filepath.Join(optControllerOutputPath, "cmd", "controller")
+		if _, err := ensureDir(cmdControllerPath); err != nil {
+			return err
+		}
+		pkgResourcePath = filepath.Join(optControllerOutputPath, "pkg", "resource")
+		if _, err := ensureDir(pkgResourcePath); err != nil {
+			return err
+		}
+	}
 	if err = writeControllerMainGo(g, crds); err != nil {
 		return err
 	}

--- a/cmd/ack-generate/command/root.go
+++ b/cmd/ack-generate/command/root.go
@@ -47,9 +47,10 @@ var (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   appName,
-	Short: appShortDesc,
-	Long:  appLongDesc,
+	Use:          appName,
+	Short:        appShortDesc,
+	Long:         appLongDesc,
+	SilenceUsage: true,
 }
 
 func init() {
@@ -123,7 +124,6 @@ func Execute(v string, bh string, bd string) {
 	buildDate = bd
 
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Issue N/A

Description of changes:
- Avoid creating directories if a service is not found in aws-sdk-go cache
- Clarify error message when service is not found in aws-sdk-go cache
- Silence usage when user enter correct flags and arguments but command exit with an error
- Avoid double printing the same error, cobra commands already do when use `RunE`: https://github.com/spf13/cobra/blob/master/command.go#L940-L943

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
