### PR TITLE
allow total override of Update op

### DIFF
--- a/pkg/generate/config/config.go
+++ b/pkg/generate/config/config.go
@@ -37,8 +37,8 @@ type Config struct {
 // OperationConfig represents instructions to the ACK code generator to
 // specify the overriding values for API operation parameters and its custom implementation.
 type OperationConfig struct {
-	CustomImplementation string `json:"custom_implementation,omitempty"`
-	OverrideValues map[string]string `json:"override_values"`
+	CustomImplementation string            `json:"custom_implementation,omitempty"`
+	OverrideValues       map[string]string `json:"override_values"`
 	// SetOutputCustomMethodName provides the name of the custom method on the
 	// `resourceManager` struct that will set fields on a `resource` struct
 	// depending on the output of the operation.
@@ -90,6 +90,17 @@ type ResourceConfig struct {
 	// filter the results of these List operations from within the generated
 	// code in sdk.go's sdkFind().
 	ListOperation *ListOperationConfig `json:"list_operation,omitempty"`
+	// UpdateOperation contains instructions for the code generator to generate
+	// Go code for the update operation for the resource. For some APIs, the
+	// way that a resource's attributes are updated after creation is, well,
+	// very odd. Some APIs have separate API calls for each attribute or set of
+	// related attributes of the resource. For example, the ECR API has
+	// separate API calls for PutImageScanningConfiguration,
+	// PutImageTagMutability, PutLifecyclePolicy and SetRepositoryPolicy. FOr
+	// these APIs, we basically need to revert to custom code because there's
+	// very little consistency to the APIs that we can use to instruct the code
+	// generator :(
+	UpdateOperation *UpdateOperationConfig `json:"update_operation,omitempty"`
 }
 
 // UnpackAttributesMapConfig informs the code generator that the API follows a
@@ -203,6 +214,15 @@ type ListOperationConfig struct {
 	// MatchFields lists the names of fields in the Shape of the
 	// list element in the List Operation's Output shape.
 	MatchFields []string `json:"match_fields"`
+}
+
+// UpdateOperationConfig contains instructions for the code generator to handle
+// Update operations for service APIs that have resources that have
+// difficult-to-standardize update operations.
+type UpdateOperationConfig struct {
+	// CustomMethodName is a string for the method name to replace the
+	// sdkUpdate() method implementation for this resource
+	CustomMethodName string `json:"custom_method_name"`
 }
 
 // IsIgnoredOperation returns true if Operation Name is configured to be ignored

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -1134,6 +1134,22 @@ func (r *CRD) NameField() string {
 	return "???"
 }
 
+// CustomUpdateMethodName returns the name of the custom resourceManager method
+// for updating the resource state, if any has been specified in the generator
+// config
+func (r *CRD) CustomUpdateMethodName() string {
+	if r.genCfg == nil {
+		return ""
+	}
+	rConfig, found := r.genCfg.Resources[r.Names.Original]
+	if found {
+		if rConfig.UpdateOperation != nil {
+			return rConfig.UpdateOperation.CustomMethodName
+		}
+	}
+	return ""
+}
+
 func (r *CRD) goCodeSetInputForContainer(
 	// The name of the SDK Input shape member we're outputting for
 	targetFieldName string,

--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -97,5 +97,5 @@ aws_account_id() {
 daws() {
     aws_cli_img_version=${ACK_AWS_CLI_IMAGE_VERSION:-$DEFAULT_AWS_CLI_VERSION}
     aws_cli_img="amazon/aws-cli:$aws_cli_img_version"
-    docker run --rm -it -v ~/.aws:/root/.aws "$aws_cli_img" "$@"
+    docker run --rm -v ~/.aws:/root/.aws "$aws_cli_img" "$@"
 }

--- a/scripts/lib/aws/ecr.sh
+++ b/scripts/lib/aws/ecr.sh
@@ -17,3 +17,10 @@ ecr_repo_exists() {
         return 0
     fi
 }
+
+ecr_repo_jq() {
+    __repo_name="$1"
+    __jq_query="$2"
+    json=$( daws ecr describe-repositories --repository-names "$__repo_name" --output json || exit 1 )
+    echo "$json" | jq --raw-output $__jq_query
+}

--- a/services/ecr/generator.yaml
+++ b/services/ecr/generator.yaml
@@ -6,3 +6,5 @@ resources:
     list_operation:
       match_fields:
         - RepositoryName
+    update_operation:
+      custom_method_name: customUpdateRepository

--- a/services/ecr/pkg/resource/repository/custom_update_api.go
+++ b/services/ecr/pkg/resource/repository/custom_update_api.go
@@ -1,0 +1,154 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package repository
+
+import (
+	"context"
+
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	"github.com/aws/aws-sdk-go/aws"
+	svcsdk "github.com/aws/aws-sdk-go/service/ecr"
+)
+
+var (
+	defaultImageScanningConfig = svcsdk.ImageScanningConfiguration{
+		ScanOnPush: aws.Bool(false),
+	}
+	defaultImageTagMutability = svcsdk.ImageTagMutabilityMutable
+)
+
+// customUpdateRepository implements specialized logic for handling Repository
+// resource updates. The ECR API has 4 separate API calls to update a
+// Repository, depending on the Repository attribute that has changed:
+//
+// * PutImageScanningConfiguration for when the
+//   Repository.imageScanningConfiguration struct changed
+// * PutImageTagMutability for when the Repository.imageTagMutability attribute
+//   changed
+// * PutLifecyclePolicy for when the Repository.lifecyclePolicy changed
+// * SetRepositoryPolicy for when the Repository.policy changed (yes, it uses
+//   "Set" and not "Put"... no idea why this is inconsistent)
+func (rm *resourceManager) customUpdateRepository(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+	diffReporter *ackcompare.Reporter,
+) (*resource, error) {
+	var err error
+	var updated *resource
+	updated = desired
+	if imageScanningConfigurationChanged(desired, latest) {
+		updated, err = rm.updateImageScanningConfiguration(ctx, updated)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if imageTagMutabilityChanged(desired, latest) {
+		updated, err = rm.updateImageTagMutability(ctx, updated)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return updated, nil
+}
+
+// imageScanningConfigurationChanged returns true if the image scanning
+// configuration of the supplied desired and latest Repository resources is
+// different
+func imageScanningConfigurationChanged(
+	desired *resource,
+	latest *resource,
+) bool {
+	dspec := desired.ko.Spec
+	lspec := latest.ko.Spec
+	if dspec.ImageScanningConfiguration == nil {
+		return lspec.ImageScanningConfiguration != nil
+	}
+	if lspec.ImageScanningConfiguration == nil {
+		return true
+	}
+	dval := *dspec.ImageScanningConfiguration.ScanOnPush
+	lval := *lspec.ImageScanningConfiguration.ScanOnPush
+	return dval != lval
+}
+
+// updateImageScanningConfiguration calls the PutImageScanningConfiguration ECR
+// API call for a specific repository
+func (rm *resourceManager) updateImageScanningConfiguration(
+	ctx context.Context,
+	desired *resource,
+) (*resource, error) {
+	dspec := desired.ko.Spec
+	input := &svcsdk.PutImageScanningConfigurationInput{
+		RepositoryName: aws.String(*dspec.RepositoryName),
+	}
+	if dspec.ImageScanningConfiguration == nil {
+		// There isn't any "reset" behaviour and the image scanning
+		// configuration field should always be set...
+		input.SetImageScanningConfiguration(&defaultImageScanningConfig)
+	} else {
+		isc := svcsdk.ImageScanningConfiguration{
+			ScanOnPush: dspec.ImageScanningConfiguration.ScanOnPush,
+		}
+		input.SetImageScanningConfiguration(&isc)
+	}
+	_, err := rm.sdkapi.PutImageScanningConfigurationWithContext(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return desired, nil
+}
+
+// imageTagMutabilityChanged returns true if the image tag mutability of the
+// supplied desired and latest Repository resources is different
+func imageTagMutabilityChanged(
+	desired *resource,
+	latest *resource,
+) bool {
+	dspec := desired.ko.Spec
+	lspec := latest.ko.Spec
+	if dspec.ImageTagMutability == nil {
+		return lspec.ImageTagMutability != nil
+	}
+	if lspec.ImageTagMutability == nil {
+		return true
+	}
+	dval := *dspec.ImageTagMutability
+	lval := *lspec.ImageTagMutability
+	return dval != lval
+}
+
+// updateImageTagMutability calls the PutImageTagMutability ECR API call for a
+// specific repository
+func (rm *resourceManager) updateImageTagMutability(
+	ctx context.Context,
+	desired *resource,
+) (*resource, error) {
+	dspec := desired.ko.Spec
+	input := &svcsdk.PutImageTagMutabilityInput{
+		RepositoryName: aws.String(*dspec.RepositoryName),
+	}
+	if dspec.ImageTagMutability == nil {
+		// There isn't any "reset" behaviour and the image scanning
+		// configuration field should always be set...
+		input.SetImageTagMutability(defaultImageTagMutability)
+	} else {
+		input.SetImageTagMutability(*dspec.ImageTagMutability)
+	}
+	_, err := rm.sdkapi.PutImageTagMutabilityWithContext(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	return desired, nil
+}

--- a/services/ecr/pkg/resource/repository/sdk.go
+++ b/services/ecr/pkg/resource/repository/sdk.go
@@ -235,8 +235,7 @@ func (rm *resourceManager) sdkUpdate(
 	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
-	// TODO(jaypipes): Figure this out...
-	return nil, nil
+	return rm.customUpdateRepository(ctx, desired, latest, diffReporter)
 }
 
 // sdkDelete deletes the supplied resource in the backend AWS service API

--- a/templates/pkg/crd_sdk.go.tpl
+++ b/templates/pkg/crd_sdk.go.tpl
@@ -224,7 +224,9 @@ func (rm *resourceManager) sdkUpdate(
 	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
-{{- if .CRD.Ops.Update }}
+{{- if .CRD.CustomUpdateMethodName }}
+    return rm.{{ .CRD.CustomUpdateMethodName }}(ctx, desired, latest, diffReporter)
+{{- else if .CRD.Ops.Update }}
 
 {{ $customMethod := .CRD.GetCustomImplementation .CRD.Ops.Update }}
 {{ if $customMethod }}


### PR DESCRIPTION
Some APIs, like ECR, have no Update operation at all for some resources
(like Repository). Instead, there are a series of API calls like
`PutImageScanningConfiguration`, `PutImageTagMutability`, or
`SetRepositoryPolicy` that set individual attributes for a particular
resource.

This patch adds the ability to override the implementation of
`sdkUpdate` **entirely** to a custom method name of the resourceManager
struct, thereby allowing total control over the various update
operations. This fixes a bug where, for the ECR sdk.go file, the
sdkUpdate method was empty and returning `(nil, nil)` which was causing
segfaults in the service controller.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
