### PR TITLE
Fix a bug where K/V log pairs were being multiplied at each reconcile call

### DIFF
--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -107,12 +107,11 @@ func (r *reconciler) reconcile(req ctrlrt.Request) error {
 	acctID := r.getOwnerAccountID(res)
 	region := r.getRegion(res)
 
-	r.log = r.log.WithValues(
+	r.log.WithValues(
 		"account_id", acctID,
 		"region", region,
 		"kind", r.rd.GroupKind().String(),
-	)
-	r.log.V(1).Info("starting reconcilation")
+	).V(1).Info("starting reconcilation")
 
 	rm, err := r.rmf.ManagerFor(r, acctID, region)
 	if err != nil {


### PR DESCRIPTION
Fixes #343

Description of changes:
Fix a bug where K/V log pairs were being multiplied at each reconcile call

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
