### PR TITLE
use aws CLI in Docker within e2e tests

### DIFF
--- a/scripts/lib/aws/ecr.sh
+++ b/scripts/lib/aws/ecr.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# ecr_repo_exists() returns 0 if an ECR Repository with the supplied name
+# exists, 1 otherwise.
+#
+# Usage:
+#
+#   if ! ecr_repo_exists "$repo_name"; then
+#       echo "Repo $repo_name does not exist!"
+#   fi
+ecr_repo_exists() {
+    __repo_name="$1"
+    daws ecr describe-repositories --repository-names "$__repo_name" --output json >/dev/null 2>&1
+    if [[ $? -eq 254 ]]; then
+        return 1
+    else
+        return 0
+    fi
+}


### PR DESCRIPTION
The AWS CLI tool version 1.x does not support a variety of more recent
AWS API calls. Case in point: the ECR DescribeRepositories API call does
not return information about the image scanning configuration.

In order to ensure that we have modern versions of the AWS CLI tool
usable in our e2e tests, I've added a `daws` (for Docker AWS) Bash
function that can be used to execute a specific version of the AWS CLI
tool within a Docker container.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
