### PR TITLE
ACK service controllers RBAC issue fixed

### DIFF
--- a/services/apigatewayv2/config/rbac/role.yaml
+++ b/services/apigatewayv2/config/rbac/role.yaml
@@ -7,6 +7,22 @@ metadata:
   name: ack-controller
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - apigatewayv2.services.k8s.aws
   resources:
   - apimappings

--- a/services/apigatewayv2/pkg/resource/api/manager.go
+++ b/services/apigatewayv2/pkg/resource/api/manager.go
@@ -30,6 +30,8 @@ import (
 
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=apis,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=apis/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.

--- a/services/apigatewayv2/pkg/resource/api_mapping/manager.go
+++ b/services/apigatewayv2/pkg/resource/api_mapping/manager.go
@@ -30,6 +30,8 @@ import (
 
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=apimappings,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=apimappings/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.

--- a/services/apigatewayv2/pkg/resource/authorizer/manager.go
+++ b/services/apigatewayv2/pkg/resource/authorizer/manager.go
@@ -30,6 +30,8 @@ import (
 
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=authorizers,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=authorizers/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.

--- a/services/apigatewayv2/pkg/resource/deployment/manager.go
+++ b/services/apigatewayv2/pkg/resource/deployment/manager.go
@@ -30,6 +30,8 @@ import (
 
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=deployments/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.

--- a/services/apigatewayv2/pkg/resource/domain_name/manager.go
+++ b/services/apigatewayv2/pkg/resource/domain_name/manager.go
@@ -30,6 +30,8 @@ import (
 
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=domainnames,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=domainnames/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.

--- a/services/apigatewayv2/pkg/resource/integration/manager.go
+++ b/services/apigatewayv2/pkg/resource/integration/manager.go
@@ -30,6 +30,8 @@ import (
 
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=integrations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=integrations/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.

--- a/services/apigatewayv2/pkg/resource/integration_response/manager.go
+++ b/services/apigatewayv2/pkg/resource/integration_response/manager.go
@@ -30,6 +30,8 @@ import (
 
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=integrationresponses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=integrationresponses/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.

--- a/services/apigatewayv2/pkg/resource/model/manager.go
+++ b/services/apigatewayv2/pkg/resource/model/manager.go
@@ -30,6 +30,8 @@ import (
 
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=models,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=models/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.

--- a/services/apigatewayv2/pkg/resource/route/manager.go
+++ b/services/apigatewayv2/pkg/resource/route/manager.go
@@ -30,6 +30,8 @@ import (
 
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=routes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=routes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.

--- a/services/apigatewayv2/pkg/resource/route_response/manager.go
+++ b/services/apigatewayv2/pkg/resource/route_response/manager.go
@@ -30,6 +30,8 @@ import (
 
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=routeresponses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=routeresponses/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.

--- a/services/apigatewayv2/pkg/resource/stage/manager.go
+++ b/services/apigatewayv2/pkg/resource/stage/manager.go
@@ -30,6 +30,8 @@ import (
 
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=stages,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=stages/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.

--- a/services/apigatewayv2/pkg/resource/vpc_link/manager.go
+++ b/services/apigatewayv2/pkg/resource/vpc_link/manager.go
@@ -30,6 +30,8 @@ import (
 
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=vpclinks,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apigatewayv2.services.k8s.aws,resources=vpclinks/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.

--- a/services/ecr/config/rbac/role.yaml
+++ b/services/ecr/config/rbac/role.yaml
@@ -7,6 +7,22 @@ metadata:
   name: ack-controller
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ecr.services.k8s.aws
   resources:
   - repositories

--- a/services/ecr/pkg/resource/repository/manager.go
+++ b/services/ecr/pkg/resource/repository/manager.go
@@ -30,6 +30,8 @@ import (
 
 // +kubebuilder:rbac:groups=ecr.services.k8s.aws,resources=repositories,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ecr.services.k8s.aws,resources=repositories/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.

--- a/services/elasticache/config/rbac/role.yaml
+++ b/services/elasticache/config/rbac/role.yaml
@@ -7,6 +7,22 @@ metadata:
   name: ack-controller
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - elasticache.services.k8s.aws
   resources:
   - cachesubnetgroups

--- a/services/elasticache/pkg/resource/cache_subnet_group/manager.go
+++ b/services/elasticache/pkg/resource/cache_subnet_group/manager.go
@@ -30,6 +30,8 @@ import (
 
 // +kubebuilder:rbac:groups=elasticache.services.k8s.aws,resources=cachesubnetgroups,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=elasticache.services.k8s.aws,resources=cachesubnetgroups/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.

--- a/services/elasticache/pkg/resource/replication_group/manager.go
+++ b/services/elasticache/pkg/resource/replication_group/manager.go
@@ -30,6 +30,8 @@ import (
 
 // +kubebuilder:rbac:groups=elasticache.services.k8s.aws,resources=replicationgroups,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=elasticache.services.k8s.aws,resources=replicationgroups/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.

--- a/services/s3/config/rbac/role.yaml
+++ b/services/s3/config/rbac/role.yaml
@@ -7,6 +7,22 @@ metadata:
   name: ack-controller
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - s3.services.k8s.aws
   resources:
   - buckets

--- a/services/s3/pkg/resource/bucket/manager.go
+++ b/services/s3/pkg/resource/bucket/manager.go
@@ -30,6 +30,8 @@ import (
 
 // +kubebuilder:rbac:groups=s3.services.k8s.aws,resources=buckets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=s3.services.k8s.aws,resources=buckets/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.

--- a/services/sns/config/rbac/role.yaml
+++ b/services/sns/config/rbac/role.yaml
@@ -7,6 +7,22 @@ metadata:
   name: ack-controller
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - sns.services.k8s.aws
   resources:
   - platformapplications

--- a/services/sns/pkg/resource/platform_application/manager.go
+++ b/services/sns/pkg/resource/platform_application/manager.go
@@ -30,6 +30,8 @@ import (
 
 // +kubebuilder:rbac:groups=sns.services.k8s.aws,resources=platformapplications,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=sns.services.k8s.aws,resources=platformapplications/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.

--- a/services/sns/pkg/resource/platform_endpoint/manager.go
+++ b/services/sns/pkg/resource/platform_endpoint/manager.go
@@ -30,6 +30,8 @@ import (
 
 // +kubebuilder:rbac:groups=sns.services.k8s.aws,resources=platformendpoints,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=sns.services.k8s.aws,resources=platformendpoints/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.

--- a/services/sns/pkg/resource/topic/manager.go
+++ b/services/sns/pkg/resource/topic/manager.go
@@ -30,6 +30,8 @@ import (
 
 // +kubebuilder:rbac:groups=sns.services.k8s.aws,resources=topics,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=sns.services.k8s.aws,resources=topics/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.

--- a/templates/pkg/crd_manager.go.tpl
+++ b/templates/pkg/crd_manager.go.tpl
@@ -17,6 +17,8 @@ import (
 
 // +kubebuilder:rbac:groups={{ .APIGroup }},resources={{ ToLower .CRD.Plural }},verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups={{ .APIGroup }},resources={{ ToLower .CRD.Plural }}/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.

--- a/test/e2e/s3/cross-account.sh
+++ b/test/e2e/s3/cross-account.sh
@@ -48,7 +48,6 @@ cat <<EOF | kubectl apply -f -
 apiVersion: s3.services.k8s.aws/v1alpha1
 kind: Bucket
 metadata:
-  namespace: testing
   name: $bucket_name
   annotations:
     services.k8s.aws/default-region: $AWS_REGION_ALT


### PR DESCRIPTION
Issue #353 

Description of changes:
As per the description, I have updated the file with instruction for the controller-gen RBAC command to create the role permissions to allow reads from ConfigMap and Namespace resources. 

Also regenerated controller for following services. 
- s3
- sns
- apigatewayv2
- elasticache
- ecr


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
