### PR TITLE
add basic Metrics struct for recording API calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.0.0
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,104 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package metrics
+
+import (
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	outboundAPIRequestsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ack_outbound_api_requests_total",
+			Help: "Total number of outbound AWS API requests made by the controller.",
+		},
+		[]string{
+			"service",
+			"op_type",
+			"op_id",
+		},
+	)
+	outboundAPIRequestsErrorTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "ack_outbound_api_requests_error_total",
+			Help: "Total number of outbound AWS API requests made by the controller that resulted in a 4XX or 5XX HTTP status code.",
+		},
+		[]string{
+			"service",
+			"op_id",
+			"status_code",
+		},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(outboundAPIRequestsTotal)
+	prometheus.MustRegister(outboundAPIRequestsErrorTotal)
+}
+
+// Metrics contains the set of Prometheus metric objects used to store counter
+// and histograms for a variety of data points
+type Metrics struct {
+	// serviceID is the ID of the AWS service the controller is managing
+	serviceID string
+	// obAPIRequestTotal contains the total number of outbound AWS API requests
+	// made by the service controller
+	obAPIRequestTotal *prometheus.CounterVec
+	// obAPIRequestErrorTotal contains the total number of outbound AWS API
+	// requests made by the service controller that resulted in an HTTP 4XX or
+	// 5XX status code
+	obAPIRequestErrorTotal *prometheus.CounterVec
+}
+
+// RecordAPICall increments appropriate metrics tracking the count and duration
+// of a supplied outbound AWS API call
+func (m *Metrics) RecordAPICall(
+	// The type of API operation, e.g. "CREATE" or "READ_ONE"
+	opType string,
+	// The name of the AWS API call, e.g. "CreateTopic"
+	opID string,
+	// The HTTP status code returned from the AWS API call
+	statusCode int,
+	// Any error that was returned from the aws-sdk-go client call
+	err error,
+) {
+	m.obAPIRequestTotal.With(
+		prometheus.Labels{
+			"service": m.serviceID,
+			"op_type": string(opType),
+			"op_id":   opID,
+		},
+	).Inc()
+	if statusCode >= 400 && statusCode < 600 {
+		m.obAPIRequestErrorTotal.With(
+			prometheus.Labels{
+				"service":     m.serviceID,
+				"op_id":       opID,
+				"status_code": strconv.Itoa(statusCode),
+			},
+		).Inc()
+	}
+}
+
+// NewMetrics returns a pointer to a Metrics struct that can be used to collect
+// and expose various Prometheus metrics
+func NewMetrics(serviceID string) *Metrics {
+	return &Metrics{
+		serviceID:              serviceID,
+		obAPIRequestTotal:      outboundAPIRequestsTotal,
+		obAPIRequestErrorTotal: outboundAPIRequestsErrorTotal,
+	}
+}

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -27,6 +27,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	"github.com/aws/aws-controllers-k8s/pkg/requeue"
 	ackrtcache "github.com/aws/aws-controllers-k8s/pkg/runtime/cache"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
@@ -40,12 +41,13 @@ import (
 // controller-runtime.Controller objects (each containing a single reconciler
 // object)s and sharing watch and informer queues across those controllers.
 type reconciler struct {
-	kc    client.Client
-	rmf   acktypes.AWSResourceManagerFactory
-	rd    acktypes.AWSResourceDescriptor
-	log   logr.Logger
-	cfg   Config
-	cache ackrtcache.Caches
+	kc      client.Client
+	rmf     acktypes.AWSResourceManagerFactory
+	rd      acktypes.AWSResourceDescriptor
+	log     logr.Logger
+	cfg     Config
+	cache   ackrtcache.Caches
+	metrics *ackmetrics.Metrics
 }
 
 // GroupKind returns the string containing the API group and kind reconciled by
@@ -402,11 +404,13 @@ func NewReconciler(
 	rmf acktypes.AWSResourceManagerFactory,
 	log logr.Logger,
 	cfg Config,
+	metrics *ackmetrics.Metrics,
 ) acktypes.AWSResourceReconciler {
 	return &reconciler{
-		rmf: rmf,
-		rd:  rmf.ResourceDescriptor(),
-		log: log,
-		cfg: cfg,
+		rmf:     rmf,
+		rd:      rmf.ResourceDescriptor(),
+		log:     log,
+		cfg:     cfg,
+		metrics: metrics,
 	}
 }


### PR DESCRIPTION
Adds in a `pkg.metrics/Metrics` struct that contains a set of Prometheus
metric objects used to store data points for things we're interested in
tracking/instrumenting about the service controller's reconciler loop
and outbound AWS API calls.

Issue #355

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
