### PR TITLE
Adds cleanup GH action workflow for hosted runners

### DIFF
--- a/.github/workflows/cleanup-self-hosted.yml
+++ b/.github/workflows/cleanup-self-hosted.yml
@@ -1,0 +1,19 @@
+name: cleanup self-hosted runner state
+
+on:
+  # Manual trigger...
+  workflow_dispatch:
+
+jobs:
+  clean:
+    name: delete all kind clusters
+    runs-on: self-hosted
+    steps:
+      # Give us access to the make targets...
+      - uses: actions/checkout@v2
+      - run: |
+        echo "============== Cleaning up self-hosted runner ============================="
+        hostnamectl
+        echo "Initiated by: ${{ .github.actor }}"
+        echo "==========================================================================="
+      - run: make delete-all-kind-clusters


### PR DESCRIPTION
Instead of manually SSH'ing into self-hosted runners, allow users to
manually execute cleanup workflow to delete kind clusters on the runner.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
