### PR TITLE
remove hostnamectl from cleanup action

### DIFF
--- a/.github/workflows/cleanup-self-hosted.yml
+++ b/.github/workflows/cleanup-self-hosted.yml
@@ -13,7 +13,6 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
         echo "============== Cleaning up self-hosted runner ============================="
-        hostnamectl
         echo "Initiated by: ${{ .github.actor }}"
         echo "==========================================================================="
       - run: make delete-all-kind-clusters


### PR DESCRIPTION
Apparently you cannot treat the `run:` part of GH action workflow's
steps as an actual shell. :(

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
