### PR TITLE
ensure kind is installed in cleanup

### DIFF
--- a/.github/workflows/cleanup-self-hosted.yml
+++ b/.github/workflows/cleanup-self-hosted.yml
@@ -11,8 +11,12 @@ jobs:
     steps:
       # Give us access to the make targets...
       - uses: actions/checkout@v2
-      - run: |
+      - name: info
+        run: |
           echo "============== Cleaning up self-hosted runner ============================="
           echo "Initiated by: ${{ github.actor }}"
           echo "==========================================================================="
-      - run: make delete-all-kind-clusters
+      - name: ensure kind
+        run: bash scripts/install-kind.sh
+      - name: delete kind clusters
+        run: make delete-all-kind-clusters

--- a/scripts/install-kind.sh
+++ b/scripts/install-kind.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# A script that ensures the KinD tool is installed
+
+set -Eo pipefail
+
+SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
+ROOT_DIR="$SCRIPTS_DIR/.."
+
+source "$SCRIPTS_DIR/lib/kind.sh"
+
+ensure_kind

--- a/scripts/lib/kind.sh
+++ b/scripts/lib/kind.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-DEFAULT_KIND_VERSION="0.8.1"
+DEFAULT_KIND_VERSION="0.9.0"
 
 # ensure_kind [<kind version>]
 #
@@ -8,12 +8,16 @@ DEFAULT_KIND_VERSION="0.8.1"
 # KinD to install. Defaults to the value of the environment variable
 # "KIND_VERSION" and if that is not set, the value of the DEFAULT_KIND_VERSION
 # variable.
+#
+# NOTE: uses `sudo mv` to relocate a downloaded binary to /usr/local/bin/kind
 ensure_kind() {
     local __kind_version="$1"
     if [ "x$__kind_version" == "x" ]; then
         __kind_version=${KIND_VERSION:-$DEFAULT_KIND_VERSION}
     fi
     if ! is_installed kind; then
-        go get "sigs.k8s.io/kind@v$__kind_version"
+        curl -Lo ./kind https://kind.sigs.k8s.io/dl/v${__kind_version}/kind-linux-amd64
+        chmod +x ./kind
+        sudo mv kind /usr/local/bin/kind
     fi
 }


### PR DESCRIPTION
changes the way we install KinD to use binary install instead of `go
get`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
