### PR TITLE
separate out e2e tests into new GH workflow

### DIFF
--- a/.github/workflows/build-unit-test.yaml
+++ b/.github/workflows/build-unit-test.yaml
@@ -1,0 +1,47 @@
+name: build-unit-test
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**.go'
+      - Makefile
+      - '**.tpl'
+      - go.mod
+      - go.sum
+
+jobs:
+  build:
+    name: make test
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: install mockery
+        run: ./scripts/install_mockery.sh
+      - name: make test
+        run: make test
+
+  build-controllers:
+    name: build service
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+         - s3
+         - ecr
+         - sns
+         - sqs
+         - elasticache
+         - dynamodb
+         - apigatewayv2
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: build service controller
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          make build-controller SERVICE=$SERVICE
+        env:
+          SERVICE: ${{ matrix.service }}

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -1,5 +1,7 @@
-name: on.pull-request.main
+name: e2e-test
 on:
+  # Allow manual trigger of e2e tests
+  workflow_dispatch:
   pull_request:
     branches:
       - main
@@ -11,41 +13,6 @@ on:
       - go.sum
 
 jobs:
-  build:
-    name: make test
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout code
-        uses: actions/checkout@v2
-      - name: install mockery
-        run: ./scripts/install_mockery.sh
-      - name: make test
-        run: make test
-
-  build-controllers:
-    name: build service
-    strategy:
-      fail-fast: false
-      matrix:
-        service:
-         - s3
-         - ecr
-         - sns
-         - sqs
-         - elasticache
-         - dynamodb
-         - apigatewayv2
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout code
-        uses: actions/checkout@v2
-      - name: build service controller
-        run: |
-          export PATH=$PATH:$(go env GOPATH)/bin
-          make build-controller SERVICE=$SERVICE
-        env:
-          SERVICE: ${{ matrix.service }}
-
   test-controllers:
     name: test controllers
     strategy:
@@ -59,6 +26,8 @@ jobs:
          - elasticache
          - dynamodb
          - apigatewayv2
+      # The number of self-hosted runners...
+      max-parallel: 3
     runs-on: self-hosted
     steps:
       - name: Set up Go 1.15
@@ -79,6 +48,5 @@ jobs:
           export AWS_ROLE_ARN=arn:aws:iam::${AWS_ACCOUNT_ID}:role/${ACK_TEST_IAM_ROLE}
           make build-controller SERVICE=$SERVICE
           make kind-test SERVICE=$SERVICE
-          make delete-all-kind-clusters
         env:
           SERVICE: ${{ matrix.service }}


### PR DESCRIPTION
Separates out the e2e test runs into a separate GH action workflow. Also
sets the max-parallel value for the e2e tests to 3, which is the number
of self-hosted runners we have, and allow the e2e workflow to be
manually triggered.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
