### PR TITLE
force run e2e tests serially

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -26,8 +26,8 @@ jobs:
          - elasticache
          - dynamodb
          - apigatewayv2
-      # The number of self-hosted runners...
-      max-parallel: 3
+      # Need to run e2e tests serially (on each runner) for now...
+      max-parallel: 1
     runs-on: self-hosted
     steps:
       - name: Set up Go 1.15


### PR DESCRIPTION
Something is causing the kind clusters to either be deleted or for the
e2e testing to be executed multiple times simulataneously on the
runners. Set the max-parallel to 1 to try and figure out what is being
hosed here...

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
