### PR TITLE
control e2e test job more finely

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -37,16 +37,16 @@ jobs:
         id: go
       - name: checkout code
         uses: actions/checkout@v2
-      - name: install mockery
-        run: ./scripts/install_mockery.sh
+      - name: build ack-generate
+        run: make build-ack-generate
+      - name: build controller
+        run: ./scripts/build-controller.sh $SERVICE
       - name: execute e2e tests
         run: |
-          export PATH=$PATH:$(go env GOPATH)/bin
           export ACK_TEST_IAM_ROLE=Admin-K8s
           export ACK_TEST_PRINCIPAL_ARN=$(aws sts get-caller-identity --query 'Arn' --output text)
           export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
           export AWS_ROLE_ARN=arn:aws:iam::${AWS_ACCOUNT_ID}:role/${ACK_TEST_IAM_ROLE}
-          make build-controller SERVICE=$SERVICE
-          make kind-test SERVICE=$SERVICE
+          ./scripts/kind-build-test.sh -s $SERVICE -r $AWS_ROLE_ARN
         env:
           SERVICE: ${{ matrix.service }}


### PR DESCRIPTION
* Removes the unit testing from the e2e test by calling the
  `scripts/kind-build-test.sh` script directly instead of
  `make kind-test`
* Removes the preservation of the KinD cluster by removing the `-p`
  argument from the call to `scripts/kind-build-test.sh`
* Builds the ack-generate and service controller in separate steps in
  the e2e-test GH Actions workflow, allowing us to control these steps
  separately.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
