### PR TITLE
regenerate all controllers for c-g 0.4.0

### DIFF
--- a/services/README.md
+++ b/services/README.md
@@ -1,0 +1,20 @@
+# ACK service controllers
+
+This directory contains the individual ACK service controllers, contained in
+subdirectories named for the alias of the AWS service (e.g. `s3` or
+`elasticache`).
+
+The majority of the code in these subdirectories is **generated** using the
+`ack-generate` CLI tool. Therefore, before making changes to any code or
+configuration file in a particular service controller directory, please check
+with the ACK contributors either on Kubernetes Slack community (#provider-aws
+channel) or by submitting a Github Issue with your thoughts on what you'd like
+to change about a particular service controller.
+
+## Supported services
+
+See the [documentation](https://aws.github.io/aws-controllers-k8s/services) for a list of supported services.
+
+### Adding a service controller
+
+See our [contributors guide](../CONTRIBUTING.md) for information on adding a new service controller.

--- a/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_apimappings.yaml
+++ b/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_apimappings.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200716001835-4a903ddb7005
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: apimappings.apigatewayv2.services.k8s.aws
 spec:
@@ -15,109 +15,109 @@ spec:
     plural: apimappings
     singular: apimapping
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: APIMapping is the Schema for the APIMappings API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: APIMappingSpec defines the desired state of APIMapping
-          properties:
-            apiID:
-              type: string
-            apiMappingKey:
-              type: string
-            domainName:
-              type: string
-            stage:
-              type: string
-          type: object
-        status:
-          description: APIMappingStatus defines the observed state of APIMapping
-          properties:
-            ackResourceMetadata:
-              description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
-                member that is used to contain resource sync state, account ownership,
-                constructed ARN for the resource
-              properties:
-                arn:
-                  description: 'ARN is the Amazon Resource Name for the resource.
-                    This is a globally-unique identifier and is set only by the ACK
-                    service controller once the controller has orchestrated the creation
-                    of the resource OR when it has verified that an "adopted" resource
-                    (a resource where the ARN annotation was set by the Kubernetes
-                    user on the CR) exists and matches the supplied CR''s Spec field
-                    values. TODO(vijat@): Find a better strategy for resources that
-                    do not have ARN in CreateOutputResponse https://github.com/aws/aws-controllers-k8s/issues/270'
-                  type: string
-                ownerAccountID:
-                  description: OwnerAccountID is the AWS Account ID of the account
-                    that owns the backend AWS service API resource.
-                  type: string
-              required:
-              - ownerAccountID
-              type: object
-            apiMappingID:
-              type: string
-            conditions:
-              description: All CRS managed by ACK have a common `Status.Conditions`
-                member that contains a collection of `ackv1alpha1.Condition` objects
-                that describe the various terminal states of the CR and its backend
-                AWS service API resource
-              items:
-                description: Condition is the common struct used by all CRDs managed
-                  by ACK service controllers to indicate terminal states  of the CR
-                  and its backend AWS service API resource
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the Condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-          required:
-          - ackResourceMetadata
-          - conditions
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: APIMapping is the Schema for the APIMappings API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: APIMappingSpec defines the desired state of APIMapping
+            properties:
+              apiID:
+                type: string
+              apiMappingKey:
+                type: string
+              domainName:
+                type: string
+              stage:
+                type: string
+            type: object
+          status:
+            description: APIMappingStatus defines the observed state of APIMapping
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              apiMappingID:
+                type: string
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []

--- a/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_apis.yaml
+++ b/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_apis.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200716001835-4a903ddb7005
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: apis.apigatewayv2.services.k8s.aws
 spec:
@@ -15,166 +15,166 @@ spec:
     plural: apis
     singular: api
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: API is the Schema for the APIS API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: APISpec defines the desired state of API
-          properties:
-            apiKeySelectionExpression:
-              type: string
-            corsConfiguration:
-              properties:
-                allowCredentials:
-                  type: boolean
-                allowHeaders:
-                  items:
-                    type: string
-                  type: array
-                allowMethods:
-                  items:
-                    type: string
-                  type: array
-                allowOrigins:
-                  items:
-                    type: string
-                  type: array
-                exposeHeaders:
-                  items:
-                    type: string
-                  type: array
-                maxAge:
-                  format: int64
-                  type: integer
-              type: object
-            credentialsARN:
-              type: string
-            description:
-              type: string
-            disableExecuteAPIEndpoint:
-              type: boolean
-            disableSchemaValidation:
-              type: boolean
-            name:
-              type: string
-            protocolType:
-              type: string
-            routeKey:
-              type: string
-            routeSelectionExpression:
-              type: string
-            tags:
-              additionalProperties:
-                type: string
-              type: object
-            target:
-              type: string
-            version:
-              type: string
-          type: object
-        status:
-          description: APIStatus defines the observed state of API
-          properties:
-            ackResourceMetadata:
-              description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
-                member that is used to contain resource sync state, account ownership,
-                constructed ARN for the resource
-              properties:
-                arn:
-                  description: 'ARN is the Amazon Resource Name for the resource.
-                    This is a globally-unique identifier and is set only by the ACK
-                    service controller once the controller has orchestrated the creation
-                    of the resource OR when it has verified that an "adopted" resource
-                    (a resource where the ARN annotation was set by the Kubernetes
-                    user on the CR) exists and matches the supplied CR''s Spec field
-                    values. TODO(vijat@): Find a better strategy for resources that
-                    do not have ARN in CreateOutputResponse https://github.com/aws/aws-controllers-k8s/issues/270'
-                  type: string
-                ownerAccountID:
-                  description: OwnerAccountID is the AWS Account ID of the account
-                    that owns the backend AWS service API resource.
-                  type: string
-              required:
-              - ownerAccountID
-              type: object
-            apiEndpoint:
-              type: string
-            apiGatewayManaged:
-              type: boolean
-            apiID:
-              type: string
-            conditions:
-              description: All CRS managed by ACK have a common `Status.Conditions`
-                member that contains a collection of `ackv1alpha1.Condition` objects
-                that describe the various terminal states of the CR and its backend
-                AWS service API resource
-              items:
-                description: Condition is the common struct used by all CRDs managed
-                  by ACK service controllers to indicate terminal states  of the CR
-                  and its backend AWS service API resource
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the Condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            createdDate:
-              format: date-time
-              type: string
-            importInfo:
-              items:
-                type: string
-              type: array
-            warnings:
-              items:
-                type: string
-              type: array
-          required:
-          - ackResourceMetadata
-          - conditions
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: API is the Schema for the APIS API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: APISpec defines the desired state of API
+            properties:
+              apiKeySelectionExpression:
+                type: string
+              corsConfiguration:
+                properties:
+                  allowCredentials:
+                    type: boolean
+                  allowHeaders:
+                    items:
+                      type: string
+                    type: array
+                  allowMethods:
+                    items:
+                      type: string
+                    type: array
+                  allowOrigins:
+                    items:
+                      type: string
+                    type: array
+                  exposeHeaders:
+                    items:
+                      type: string
+                    type: array
+                  maxAge:
+                    format: int64
+                    type: integer
+                type: object
+              credentialsARN:
+                type: string
+              description:
+                type: string
+              disableExecuteAPIEndpoint:
+                type: boolean
+              disableSchemaValidation:
+                type: boolean
+              name:
+                type: string
+              protocolType:
+                type: string
+              routeKey:
+                type: string
+              routeSelectionExpression:
+                type: string
+              tags:
+                additionalProperties:
+                  type: string
+                type: object
+              target:
+                type: string
+              version:
+                type: string
+            type: object
+          status:
+            description: APIStatus defines the observed state of API
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              apiEndpoint:
+                type: string
+              apiGatewayManaged:
+                type: boolean
+              apiID:
+                type: string
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              createdDate:
+                format: date-time
+                type: string
+              importInfo:
+                items:
+                  type: string
+                type: array
+              warnings:
+                items:
+                  type: string
+                type: array
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []

--- a/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_authorizers.yaml
+++ b/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_authorizers.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200716001835-4a903ddb7005
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: authorizers.apigatewayv2.services.k8s.aws
 spec:
@@ -15,133 +15,133 @@ spec:
     plural: authorizers
     singular: authorizer
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Authorizer is the Schema for the Authorizers API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: AuthorizerSpec defines the desired state of Authorizer
-          properties:
-            apiID:
-              type: string
-            authorizerCredentialsARN:
-              type: string
-            authorizerPayloadFormatVersion:
-              type: string
-            authorizerResultTtlInSeconds:
-              format: int64
-              type: integer
-            authorizerType:
-              type: string
-            authorizerURI:
-              type: string
-            enableSimpleResponses:
-              type: boolean
-            identitySource:
-              items:
-                type: string
-              type: array
-            identityValidationExpression:
-              type: string
-            jwtConfiguration:
-              properties:
-                audience:
-                  items:
-                    type: string
-                  type: array
-                issuer:
-                  type: string
-              type: object
-            name:
-              type: string
-          type: object
-        status:
-          description: AuthorizerStatus defines the observed state of Authorizer
-          properties:
-            ackResourceMetadata:
-              description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
-                member that is used to contain resource sync state, account ownership,
-                constructed ARN for the resource
-              properties:
-                arn:
-                  description: 'ARN is the Amazon Resource Name for the resource.
-                    This is a globally-unique identifier and is set only by the ACK
-                    service controller once the controller has orchestrated the creation
-                    of the resource OR when it has verified that an "adopted" resource
-                    (a resource where the ARN annotation was set by the Kubernetes
-                    user on the CR) exists and matches the supplied CR''s Spec field
-                    values. TODO(vijat@): Find a better strategy for resources that
-                    do not have ARN in CreateOutputResponse https://github.com/aws/aws-controllers-k8s/issues/270'
-                  type: string
-                ownerAccountID:
-                  description: OwnerAccountID is the AWS Account ID of the account
-                    that owns the backend AWS service API resource.
-                  type: string
-              required:
-              - ownerAccountID
-              type: object
-            authorizerID:
-              type: string
-            conditions:
-              description: All CRS managed by ACK have a common `Status.Conditions`
-                member that contains a collection of `ackv1alpha1.Condition` objects
-                that describe the various terminal states of the CR and its backend
-                AWS service API resource
-              items:
-                description: Condition is the common struct used by all CRDs managed
-                  by ACK service controllers to indicate terminal states  of the CR
-                  and its backend AWS service API resource
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the Condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-          required:
-          - ackResourceMetadata
-          - conditions
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Authorizer is the Schema for the Authorizers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AuthorizerSpec defines the desired state of Authorizer
+            properties:
+              apiID:
+                type: string
+              authorizerCredentialsARN:
+                type: string
+              authorizerPayloadFormatVersion:
+                type: string
+              authorizerResultTtlInSeconds:
+                format: int64
+                type: integer
+              authorizerType:
+                type: string
+              authorizerURI:
+                type: string
+              enableSimpleResponses:
+                type: boolean
+              identitySource:
+                items:
+                  type: string
+                type: array
+              identityValidationExpression:
+                type: string
+              jwtConfiguration:
+                properties:
+                  audience:
+                    items:
+                      type: string
+                    type: array
+                  issuer:
+                    type: string
+                type: object
+              name:
+                type: string
+            type: object
+          status:
+            description: AuthorizerStatus defines the observed state of Authorizer
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              authorizerID:
+                type: string
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []

--- a/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_deployments.yaml
+++ b/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_deployments.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200716001835-4a903ddb7005
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: deployments.apigatewayv2.services.k8s.aws
 spec:
@@ -15,116 +15,116 @@ spec:
     plural: deployments
     singular: deployment
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Deployment is the Schema for the Deployments API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: DeploymentSpec defines the desired state of Deployment
-          properties:
-            apiID:
-              type: string
-            description:
-              type: string
-            stageName:
-              type: string
-          type: object
-        status:
-          description: DeploymentStatus defines the observed state of Deployment
-          properties:
-            ackResourceMetadata:
-              description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
-                member that is used to contain resource sync state, account ownership,
-                constructed ARN for the resource
-              properties:
-                arn:
-                  description: 'ARN is the Amazon Resource Name for the resource.
-                    This is a globally-unique identifier and is set only by the ACK
-                    service controller once the controller has orchestrated the creation
-                    of the resource OR when it has verified that an "adopted" resource
-                    (a resource where the ARN annotation was set by the Kubernetes
-                    user on the CR) exists and matches the supplied CR''s Spec field
-                    values. TODO(vijat@): Find a better strategy for resources that
-                    do not have ARN in CreateOutputResponse https://github.com/aws/aws-controllers-k8s/issues/270'
-                  type: string
-                ownerAccountID:
-                  description: OwnerAccountID is the AWS Account ID of the account
-                    that owns the backend AWS service API resource.
-                  type: string
-              required:
-              - ownerAccountID
-              type: object
-            autoDeployed:
-              type: boolean
-            conditions:
-              description: All CRS managed by ACK have a common `Status.Conditions`
-                member that contains a collection of `ackv1alpha1.Condition` objects
-                that describe the various terminal states of the CR and its backend
-                AWS service API resource
-              items:
-                description: Condition is the common struct used by all CRDs managed
-                  by ACK service controllers to indicate terminal states  of the CR
-                  and its backend AWS service API resource
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the Condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            createdDate:
-              format: date-time
-              type: string
-            deploymentID:
-              type: string
-            deploymentStatus:
-              type: string
-            deploymentStatusMessage:
-              type: string
-          required:
-          - ackResourceMetadata
-          - conditions
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Deployment is the Schema for the Deployments API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DeploymentSpec defines the desired state of Deployment
+            properties:
+              apiID:
+                type: string
+              description:
+                type: string
+              stageName:
+                type: string
+            type: object
+          status:
+            description: DeploymentStatus defines the observed state of Deployment
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              autoDeployed:
+                type: boolean
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              createdDate:
+                format: date-time
+                type: string
+              deploymentID:
+                type: string
+              deploymentStatus:
+                type: string
+              deploymentStatusMessage:
+                type: string
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []

--- a/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_domainnames.yaml
+++ b/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_domainnames.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200716001835-4a903ddb7005
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: domainnames.apigatewayv2.services.k8s.aws
 spec:
@@ -15,138 +15,138 @@ spec:
     plural: domainnames
     singular: domainname
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: DomainName is the Schema for the DomainNames API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: DomainNameSpec defines the desired state of DomainName
-          properties:
-            domainName:
-              type: string
-            domainNameConfigurations:
-              items:
-                properties:
-                  apiGatewayDomainName:
-                    type: string
-                  certificateARN:
-                    type: string
-                  certificateName:
-                    type: string
-                  certificateUploadDate:
-                    format: date-time
-                    type: string
-                  domainNameStatus:
-                    type: string
-                  domainNameStatusMessage:
-                    type: string
-                  endpointType:
-                    type: string
-                  hostedZoneID:
-                    type: string
-                  securityPolicy:
-                    type: string
-                type: object
-              type: array
-            mutualTLSAuthentication:
-              properties:
-                truststoreURI:
-                  type: string
-                truststoreVersion:
-                  type: string
-              type: object
-            tags:
-              additionalProperties:
-                type: string
-              type: object
-          type: object
-        status:
-          description: DomainNameStatus defines the observed state of DomainName
-          properties:
-            ackResourceMetadata:
-              description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
-                member that is used to contain resource sync state, account ownership,
-                constructed ARN for the resource
-              properties:
-                arn:
-                  description: 'ARN is the Amazon Resource Name for the resource.
-                    This is a globally-unique identifier and is set only by the ACK
-                    service controller once the controller has orchestrated the creation
-                    of the resource OR when it has verified that an "adopted" resource
-                    (a resource where the ARN annotation was set by the Kubernetes
-                    user on the CR) exists and matches the supplied CR''s Spec field
-                    values. TODO(vijat@): Find a better strategy for resources that
-                    do not have ARN in CreateOutputResponse https://github.com/aws/aws-controllers-k8s/issues/270'
-                  type: string
-                ownerAccountID:
-                  description: OwnerAccountID is the AWS Account ID of the account
-                    that owns the backend AWS service API resource.
-                  type: string
-              required:
-              - ownerAccountID
-              type: object
-            apiMappingSelectionExpression:
-              type: string
-            conditions:
-              description: All CRS managed by ACK have a common `Status.Conditions`
-                member that contains a collection of `ackv1alpha1.Condition` objects
-                that describe the various terminal states of the CR and its backend
-                AWS service API resource
-              items:
-                description: Condition is the common struct used by all CRDs managed
-                  by ACK service controllers to indicate terminal states  of the CR
-                  and its backend AWS service API resource
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the Condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-          required:
-          - ackResourceMetadata
-          - conditions
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: DomainName is the Schema for the DomainNames API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DomainNameSpec defines the desired state of DomainName
+            properties:
+              domainName:
+                type: string
+              domainNameConfigurations:
+                items:
+                  properties:
+                    apiGatewayDomainName:
+                      type: string
+                    certificateARN:
+                      type: string
+                    certificateName:
+                      type: string
+                    certificateUploadDate:
+                      format: date-time
+                      type: string
+                    domainNameStatus:
+                      type: string
+                    domainNameStatusMessage:
+                      type: string
+                    endpointType:
+                      type: string
+                    hostedZoneID:
+                      type: string
+                    securityPolicy:
+                      type: string
+                  type: object
+                type: array
+              mutualTLSAuthentication:
+                properties:
+                  truststoreURI:
+                    type: string
+                  truststoreVersion:
+                    type: string
+                type: object
+              tags:
+                additionalProperties:
+                  type: string
+                type: object
+            type: object
+          status:
+            description: DomainNameStatus defines the observed state of DomainName
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              apiMappingSelectionExpression:
+                type: string
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []

--- a/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_integrationresponses.yaml
+++ b/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_integrationresponses.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200716001835-4a903ddb7005
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: integrationresponses.apigatewayv2.services.k8s.aws
 spec:
@@ -15,120 +15,120 @@ spec:
     plural: integrationresponses
     singular: integrationresponse
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: IntegrationResponse is the Schema for the IntegrationResponses
-        API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: IntegrationResponseSpec defines the desired state of IntegrationResponse
-          properties:
-            apiID:
-              type: string
-            contentHandlingStrategy:
-              type: string
-            integrationID:
-              type: string
-            integrationResponseKey:
-              type: string
-            responseParameters:
-              additionalProperties:
-                type: string
-              type: object
-            responseTemplates:
-              additionalProperties:
-                type: string
-              type: object
-            templateSelectionExpression:
-              type: string
-          type: object
-        status:
-          description: IntegrationResponseStatus defines the observed state of IntegrationResponse
-          properties:
-            ackResourceMetadata:
-              description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
-                member that is used to contain resource sync state, account ownership,
-                constructed ARN for the resource
-              properties:
-                arn:
-                  description: 'ARN is the Amazon Resource Name for the resource.
-                    This is a globally-unique identifier and is set only by the ACK
-                    service controller once the controller has orchestrated the creation
-                    of the resource OR when it has verified that an "adopted" resource
-                    (a resource where the ARN annotation was set by the Kubernetes
-                    user on the CR) exists and matches the supplied CR''s Spec field
-                    values. TODO(vijat@): Find a better strategy for resources that
-                    do not have ARN in CreateOutputResponse https://github.com/aws/aws-controllers-k8s/issues/270'
-                  type: string
-                ownerAccountID:
-                  description: OwnerAccountID is the AWS Account ID of the account
-                    that owns the backend AWS service API resource.
-                  type: string
-              required:
-              - ownerAccountID
-              type: object
-            conditions:
-              description: All CRS managed by ACK have a common `Status.Conditions`
-                member that contains a collection of `ackv1alpha1.Condition` objects
-                that describe the various terminal states of the CR and its backend
-                AWS service API resource
-              items:
-                description: Condition is the common struct used by all CRDs managed
-                  by ACK service controllers to indicate terminal states  of the CR
-                  and its backend AWS service API resource
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the Condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            integrationResponseID:
-              type: string
-          required:
-          - ackResourceMetadata
-          - conditions
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: IntegrationResponse is the Schema for the IntegrationResponses
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IntegrationResponseSpec defines the desired state of IntegrationResponse
+            properties:
+              apiID:
+                type: string
+              contentHandlingStrategy:
+                type: string
+              integrationID:
+                type: string
+              integrationResponseKey:
+                type: string
+              responseParameters:
+                additionalProperties:
+                  type: string
+                type: object
+              responseTemplates:
+                additionalProperties:
+                  type: string
+                type: object
+              templateSelectionExpression:
+                type: string
+            type: object
+          status:
+            description: IntegrationResponseStatus defines the observed state of IntegrationResponse
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              integrationResponseID:
+                type: string
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []

--- a/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_integrations.yaml
+++ b/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_integrations.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200716001835-4a903ddb7005
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: integrations.apigatewayv2.services.k8s.aws
 spec:
@@ -15,147 +15,147 @@ spec:
     plural: integrations
     singular: integration
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Integration is the Schema for the Integrations API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: IntegrationSpec defines the desired state of Integration
-          properties:
-            apiID:
-              type: string
-            connectionID:
-              type: string
-            connectionType:
-              type: string
-            contentHandlingStrategy:
-              type: string
-            credentialsARN:
-              type: string
-            description:
-              type: string
-            integrationMethod:
-              type: string
-            integrationSubtype:
-              type: string
-            integrationType:
-              type: string
-            integrationURI:
-              type: string
-            passthroughBehavior:
-              type: string
-            payloadFormatVersion:
-              type: string
-            requestParameters:
-              additionalProperties:
-                type: string
-              type: object
-            requestTemplates:
-              additionalProperties:
-                type: string
-              type: object
-            templateSelectionExpression:
-              type: string
-            timeoutInMillis:
-              format: int64
-              type: integer
-            tlsConfig:
-              properties:
-                serverNameToVerify:
-                  type: string
-              type: object
-          type: object
-        status:
-          description: IntegrationStatus defines the observed state of Integration
-          properties:
-            ackResourceMetadata:
-              description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
-                member that is used to contain resource sync state, account ownership,
-                constructed ARN for the resource
-              properties:
-                arn:
-                  description: 'ARN is the Amazon Resource Name for the resource.
-                    This is a globally-unique identifier and is set only by the ACK
-                    service controller once the controller has orchestrated the creation
-                    of the resource OR when it has verified that an "adopted" resource
-                    (a resource where the ARN annotation was set by the Kubernetes
-                    user on the CR) exists and matches the supplied CR''s Spec field
-                    values. TODO(vijat@): Find a better strategy for resources that
-                    do not have ARN in CreateOutputResponse https://github.com/aws/aws-controllers-k8s/issues/270'
-                  type: string
-                ownerAccountID:
-                  description: OwnerAccountID is the AWS Account ID of the account
-                    that owns the backend AWS service API resource.
-                  type: string
-              required:
-              - ownerAccountID
-              type: object
-            apiGatewayManaged:
-              type: boolean
-            conditions:
-              description: All CRS managed by ACK have a common `Status.Conditions`
-                member that contains a collection of `ackv1alpha1.Condition` objects
-                that describe the various terminal states of the CR and its backend
-                AWS service API resource
-              items:
-                description: Condition is the common struct used by all CRDs managed
-                  by ACK service controllers to indicate terminal states  of the CR
-                  and its backend AWS service API resource
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the Condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            integrationID:
-              type: string
-            integrationResponseSelectionExpression:
-              type: string
-          required:
-          - ackResourceMetadata
-          - conditions
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Integration is the Schema for the Integrations API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: IntegrationSpec defines the desired state of Integration
+            properties:
+              apiID:
+                type: string
+              connectionID:
+                type: string
+              connectionType:
+                type: string
+              contentHandlingStrategy:
+                type: string
+              credentialsARN:
+                type: string
+              description:
+                type: string
+              integrationMethod:
+                type: string
+              integrationSubtype:
+                type: string
+              integrationType:
+                type: string
+              integrationURI:
+                type: string
+              passthroughBehavior:
+                type: string
+              payloadFormatVersion:
+                type: string
+              requestParameters:
+                additionalProperties:
+                  type: string
+                type: object
+              requestTemplates:
+                additionalProperties:
+                  type: string
+                type: object
+              templateSelectionExpression:
+                type: string
+              timeoutInMillis:
+                format: int64
+                type: integer
+              tlsConfig:
+                properties:
+                  serverNameToVerify:
+                    type: string
+                type: object
+            type: object
+          status:
+            description: IntegrationStatus defines the observed state of Integration
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              apiGatewayManaged:
+                type: boolean
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              integrationID:
+                type: string
+              integrationResponseSelectionExpression:
+                type: string
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []

--- a/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_models.yaml
+++ b/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_models.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200716001835-4a903ddb7005
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: models.apigatewayv2.services.k8s.aws
 spec:
@@ -15,111 +15,111 @@ spec:
     plural: models
     singular: model
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Model is the Schema for the Models API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ModelSpec defines the desired state of Model
-          properties:
-            apiID:
-              type: string
-            contentType:
-              type: string
-            description:
-              type: string
-            name:
-              type: string
-            schema:
-              type: string
-          type: object
-        status:
-          description: ModelStatus defines the observed state of Model
-          properties:
-            ackResourceMetadata:
-              description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
-                member that is used to contain resource sync state, account ownership,
-                constructed ARN for the resource
-              properties:
-                arn:
-                  description: 'ARN is the Amazon Resource Name for the resource.
-                    This is a globally-unique identifier and is set only by the ACK
-                    service controller once the controller has orchestrated the creation
-                    of the resource OR when it has verified that an "adopted" resource
-                    (a resource where the ARN annotation was set by the Kubernetes
-                    user on the CR) exists and matches the supplied CR''s Spec field
-                    values. TODO(vijat@): Find a better strategy for resources that
-                    do not have ARN in CreateOutputResponse https://github.com/aws/aws-controllers-k8s/issues/270'
-                  type: string
-                ownerAccountID:
-                  description: OwnerAccountID is the AWS Account ID of the account
-                    that owns the backend AWS service API resource.
-                  type: string
-              required:
-              - ownerAccountID
-              type: object
-            conditions:
-              description: All CRS managed by ACK have a common `Status.Conditions`
-                member that contains a collection of `ackv1alpha1.Condition` objects
-                that describe the various terminal states of the CR and its backend
-                AWS service API resource
-              items:
-                description: Condition is the common struct used by all CRDs managed
-                  by ACK service controllers to indicate terminal states  of the CR
-                  and its backend AWS service API resource
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the Condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            modelID:
-              type: string
-          required:
-          - ackResourceMetadata
-          - conditions
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Model is the Schema for the Models API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ModelSpec defines the desired state of Model
+            properties:
+              apiID:
+                type: string
+              contentType:
+                type: string
+              description:
+                type: string
+              name:
+                type: string
+              schema:
+                type: string
+            type: object
+          status:
+            description: ModelStatus defines the observed state of Model
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              modelID:
+                type: string
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []

--- a/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_routeresponses.yaml
+++ b/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_routeresponses.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200716001835-4a903ddb7005
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: routeresponses.apigatewayv2.services.k8s.aws
 spec:
@@ -15,120 +15,120 @@ spec:
     plural: routeresponses
     singular: routeresponse
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: RouteResponse is the Schema for the RouteResponses API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: RouteResponseSpec defines the desired state of RouteResponse
-          properties:
-            apiID:
-              type: string
-            modelSelectionExpression:
-              type: string
-            responseModels:
-              additionalProperties:
-                type: string
-              type: object
-            responseParameters:
-              additionalProperties:
-                properties:
-                  required:
-                    type: boolean
-                type: object
-              type: object
-            routeID:
-              type: string
-            routeResponseKey:
-              type: string
-          type: object
-        status:
-          description: RouteResponseStatus defines the observed state of RouteResponse
-          properties:
-            ackResourceMetadata:
-              description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
-                member that is used to contain resource sync state, account ownership,
-                constructed ARN for the resource
-              properties:
-                arn:
-                  description: 'ARN is the Amazon Resource Name for the resource.
-                    This is a globally-unique identifier and is set only by the ACK
-                    service controller once the controller has orchestrated the creation
-                    of the resource OR when it has verified that an "adopted" resource
-                    (a resource where the ARN annotation was set by the Kubernetes
-                    user on the CR) exists and matches the supplied CR''s Spec field
-                    values. TODO(vijat@): Find a better strategy for resources that
-                    do not have ARN in CreateOutputResponse https://github.com/aws/aws-controllers-k8s/issues/270'
-                  type: string
-                ownerAccountID:
-                  description: OwnerAccountID is the AWS Account ID of the account
-                    that owns the backend AWS service API resource.
-                  type: string
-              required:
-              - ownerAccountID
-              type: object
-            conditions:
-              description: All CRS managed by ACK have a common `Status.Conditions`
-                member that contains a collection of `ackv1alpha1.Condition` objects
-                that describe the various terminal states of the CR and its backend
-                AWS service API resource
-              items:
-                description: Condition is the common struct used by all CRDs managed
-                  by ACK service controllers to indicate terminal states  of the CR
-                  and its backend AWS service API resource
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the Condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            routeResponseID:
-              type: string
-          required:
-          - ackResourceMetadata
-          - conditions
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: RouteResponse is the Schema for the RouteResponses API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RouteResponseSpec defines the desired state of RouteResponse
+            properties:
+              apiID:
+                type: string
+              modelSelectionExpression:
+                type: string
+              responseModels:
+                additionalProperties:
+                  type: string
+                type: object
+              responseParameters:
+                additionalProperties:
+                  properties:
+                    required:
+                      type: boolean
+                  type: object
+                type: object
+              routeID:
+                type: string
+              routeResponseKey:
+                type: string
+            type: object
+          status:
+            description: RouteResponseStatus defines the observed state of RouteResponse
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              routeResponseID:
+                type: string
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []

--- a/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_routes.yaml
+++ b/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_routes.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200716001835-4a903ddb7005
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: routes.apigatewayv2.services.k8s.aws
 spec:
@@ -15,136 +15,136 @@ spec:
     plural: routes
     singular: route
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Route is the Schema for the Routes API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: RouteSpec defines the desired state of Route
-          properties:
-            apiID:
-              type: string
-            apiKeyRequired:
-              type: boolean
-            authorizationScopes:
-              items:
-                type: string
-              type: array
-            authorizationType:
-              type: string
-            authorizerID:
-              type: string
-            modelSelectionExpression:
-              type: string
-            operationName:
-              type: string
-            requestModels:
-              additionalProperties:
-                type: string
-              type: object
-            requestParameters:
-              additionalProperties:
-                properties:
-                  required:
-                    type: boolean
-                type: object
-              type: object
-            routeKey:
-              type: string
-            routeResponseSelectionExpression:
-              type: string
-            target:
-              type: string
-          type: object
-        status:
-          description: RouteStatus defines the observed state of Route
-          properties:
-            ackResourceMetadata:
-              description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
-                member that is used to contain resource sync state, account ownership,
-                constructed ARN for the resource
-              properties:
-                arn:
-                  description: 'ARN is the Amazon Resource Name for the resource.
-                    This is a globally-unique identifier and is set only by the ACK
-                    service controller once the controller has orchestrated the creation
-                    of the resource OR when it has verified that an "adopted" resource
-                    (a resource where the ARN annotation was set by the Kubernetes
-                    user on the CR) exists and matches the supplied CR''s Spec field
-                    values. TODO(vijat@): Find a better strategy for resources that
-                    do not have ARN in CreateOutputResponse https://github.com/aws/aws-controllers-k8s/issues/270'
-                  type: string
-                ownerAccountID:
-                  description: OwnerAccountID is the AWS Account ID of the account
-                    that owns the backend AWS service API resource.
-                  type: string
-              required:
-              - ownerAccountID
-              type: object
-            apiGatewayManaged:
-              type: boolean
-            conditions:
-              description: All CRS managed by ACK have a common `Status.Conditions`
-                member that contains a collection of `ackv1alpha1.Condition` objects
-                that describe the various terminal states of the CR and its backend
-                AWS service API resource
-              items:
-                description: Condition is the common struct used by all CRDs managed
-                  by ACK service controllers to indicate terminal states  of the CR
-                  and its backend AWS service API resource
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the Condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            routeID:
-              type: string
-          required:
-          - ackResourceMetadata
-          - conditions
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Route is the Schema for the Routes API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RouteSpec defines the desired state of Route
+            properties:
+              apiID:
+                type: string
+              apiKeyRequired:
+                type: boolean
+              authorizationScopes:
+                items:
+                  type: string
+                type: array
+              authorizationType:
+                type: string
+              authorizerID:
+                type: string
+              modelSelectionExpression:
+                type: string
+              operationName:
+                type: string
+              requestModels:
+                additionalProperties:
+                  type: string
+                type: object
+              requestParameters:
+                additionalProperties:
+                  properties:
+                    required:
+                      type: boolean
+                  type: object
+                type: object
+              routeKey:
+                type: string
+              routeResponseSelectionExpression:
+                type: string
+              target:
+                type: string
+            type: object
+          status:
+            description: RouteStatus defines the observed state of Route
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              apiGatewayManaged:
+                type: boolean
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              routeID:
+                type: string
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []

--- a/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_stages.yaml
+++ b/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_stages.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200716001835-4a903ddb7005
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: stages.apigatewayv2.services.k8s.aws
 spec:
@@ -15,60 +15,41 @@ spec:
     plural: stages
     singular: stage
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Stage is the Schema for the Stages API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: StageSpec defines the desired state of Stage
-          properties:
-            accessLogSettings:
-              properties:
-                destinationARN:
-                  type: string
-                format:
-                  type: string
-              type: object
-            apiID:
-              type: string
-            autoDeploy:
-              type: boolean
-            clientCertificateID:
-              type: string
-            defaultRouteSettings:
-              properties:
-                dataTraceEnabled:
-                  type: boolean
-                detailedMetricsEnabled:
-                  type: boolean
-                loggingLevel:
-                  type: string
-                throttlingBurstLimit:
-                  format: int64
-                  type: integer
-                throttlingRateLimit:
-                  type: number
-              type: object
-            deploymentID:
-              type: string
-            description:
-              type: string
-            routeSettings:
-              additionalProperties:
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Stage is the Schema for the Stages API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: StageSpec defines the desired state of Stage
+            properties:
+              accessLogSettings:
+                properties:
+                  destinationARN:
+                    type: string
+                  format:
+                    type: string
+                type: object
+              apiID:
+                type: string
+              autoDeploy:
+                type: boolean
+              clientCertificateID:
+                type: string
+              defaultRouteSettings:
                 properties:
                   dataTraceEnabled:
                     type: boolean
@@ -82,99 +63,118 @@ spec:
                   throttlingRateLimit:
                     type: number
                 type: object
-              type: object
-            stageName:
-              type: string
-            stageVariables:
-              additionalProperties:
+              deploymentID:
                 type: string
-              type: object
-            tags:
-              additionalProperties:
+              description:
                 type: string
-              type: object
-          type: object
-        status:
-          description: StageStatus defines the observed state of Stage
-          properties:
-            ackResourceMetadata:
-              description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
-                member that is used to contain resource sync state, account ownership,
-                constructed ARN for the resource
-              properties:
-                arn:
-                  description: 'ARN is the Amazon Resource Name for the resource.
-                    This is a globally-unique identifier and is set only by the ACK
-                    service controller once the controller has orchestrated the creation
-                    of the resource OR when it has verified that an "adopted" resource
-                    (a resource where the ARN annotation was set by the Kubernetes
-                    user on the CR) exists and matches the supplied CR''s Spec field
-                    values. TODO(vijat@): Find a better strategy for resources that
-                    do not have ARN in CreateOutputResponse https://github.com/aws/aws-controllers-k8s/issues/270'
+              routeSettings:
+                additionalProperties:
+                  properties:
+                    dataTraceEnabled:
+                      type: boolean
+                    detailedMetricsEnabled:
+                      type: boolean
+                    loggingLevel:
+                      type: string
+                    throttlingBurstLimit:
+                      format: int64
+                      type: integer
+                    throttlingRateLimit:
+                      type: number
+                  type: object
+                type: object
+              stageName:
+                type: string
+              stageVariables:
+                additionalProperties:
                   type: string
-                ownerAccountID:
-                  description: OwnerAccountID is the AWS Account ID of the account
-                    that owns the backend AWS service API resource.
+                type: object
+              tags:
+                additionalProperties:
                   type: string
-              required:
-              - ownerAccountID
-              type: object
-            apiGatewayManaged:
-              type: boolean
-            conditions:
-              description: All CRS managed by ACK have a common `Status.Conditions`
-                member that contains a collection of `ackv1alpha1.Condition` objects
-                that describe the various terminal states of the CR and its backend
-                AWS service API resource
-              items:
-                description: Condition is the common struct used by all CRDs managed
-                  by ACK service controllers to indicate terminal states  of the CR
-                  and its backend AWS service API resource
+                type: object
+            type: object
+          status:
+            description: StageStatus defines the observed state of Stage
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
                 properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
                     type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the Condition
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
                     type: string
                 required:
-                - status
-                - type
+                - ownerAccountID
                 type: object
-              type: array
-            createdDate:
-              format: date-time
-              type: string
-            lastDeploymentStatusMessage:
-              type: string
-            lastUpdatedDate:
-              format: date-time
-              type: string
-          required:
-          - ackResourceMetadata
-          - conditions
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+              apiGatewayManaged:
+                type: boolean
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              createdDate:
+                format: date-time
+                type: string
+              lastDeploymentStatusMessage:
+                type: string
+              lastUpdatedDate:
+                format: date-time
+                type: string
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []

--- a/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_vpclinks.yaml
+++ b/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_vpclinks.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200716001835-4a903ddb7005
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: vpclinks.apigatewayv2.services.k8s.aws
 spec:
@@ -15,124 +15,124 @@ spec:
     plural: vpclinks
     singular: vpclink
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: VPCLink is the Schema for the VPCLinks API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: VPCLinkSpec defines the desired state of VPCLink
-          properties:
-            name:
-              type: string
-            securityGroupIDs:
-              items:
-                type: string
-              type: array
-            subnetIDs:
-              items:
-                type: string
-              type: array
-            tags:
-              additionalProperties:
-                type: string
-              type: object
-          type: object
-        status:
-          description: VPCLinkStatus defines the observed state of VPCLink
-          properties:
-            ackResourceMetadata:
-              description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
-                member that is used to contain resource sync state, account ownership,
-                constructed ARN for the resource
-              properties:
-                arn:
-                  description: 'ARN is the Amazon Resource Name for the resource.
-                    This is a globally-unique identifier and is set only by the ACK
-                    service controller once the controller has orchestrated the creation
-                    of the resource OR when it has verified that an "adopted" resource
-                    (a resource where the ARN annotation was set by the Kubernetes
-                    user on the CR) exists and matches the supplied CR''s Spec field
-                    values. TODO(vijat@): Find a better strategy for resources that
-                    do not have ARN in CreateOutputResponse https://github.com/aws/aws-controllers-k8s/issues/270'
-                  type: string
-                ownerAccountID:
-                  description: OwnerAccountID is the AWS Account ID of the account
-                    that owns the backend AWS service API resource.
-                  type: string
-              required:
-              - ownerAccountID
-              type: object
-            conditions:
-              description: All CRS managed by ACK have a common `Status.Conditions`
-                member that contains a collection of `ackv1alpha1.Condition` objects
-                that describe the various terminal states of the CR and its backend
-                AWS service API resource
-              items:
-                description: Condition is the common struct used by all CRDs managed
-                  by ACK service controllers to indicate terminal states  of the CR
-                  and its backend AWS service API resource
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the Condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            createdDate:
-              format: date-time
-              type: string
-            vpcLinkID:
-              type: string
-            vpcLinkStatus:
-              type: string
-            vpcLinkStatusMessage:
-              type: string
-            vpcLinkVersion:
-              type: string
-          required:
-          - ackResourceMetadata
-          - conditions
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: VPCLink is the Schema for the VPCLinks API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VPCLinkSpec defines the desired state of VPCLink
+            properties:
+              name:
+                type: string
+              securityGroupIDs:
+                items:
+                  type: string
+                type: array
+              subnetIDs:
+                items:
+                  type: string
+                type: array
+              tags:
+                additionalProperties:
+                  type: string
+                type: object
+            type: object
+          status:
+            description: VPCLinkStatus defines the observed state of VPCLink
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              createdDate:
+                format: date-time
+                type: string
+              vpcLinkID:
+                type: string
+              vpcLinkStatus:
+                type: string
+              vpcLinkStatusMessage:
+                type: string
+              vpcLinkVersion:
+                type: string
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []

--- a/services/dynamodb/config/crd/bases/dynamodb.services.k8s.aws_backups.yaml
+++ b/services/dynamodb/config/crd/bases/dynamodb.services.k8s.aws_backups.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200716001835-4a903ddb7005
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: backups.dynamodb.services.k8s.aws
 spec:
@@ -15,116 +15,116 @@ spec:
     plural: backups
     singular: backup
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Backup is the Schema for the Backups API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: BackupSpec defines the desired state of Backup
-          properties:
-            backupName:
-              type: string
-            tableName:
-              type: string
-          type: object
-        status:
-          description: BackupStatus defines the observed state of Backup
-          properties:
-            ackResourceMetadata:
-              description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
-                member that is used to contain resource sync state, account ownership,
-                constructed ARN for the resource
-              properties:
-                arn:
-                  description: 'ARN is the Amazon Resource Name for the resource.
-                    This is a globally-unique identifier and is set only by the ACK
-                    service controller once the controller has orchestrated the creation
-                    of the resource OR when it has verified that an "adopted" resource
-                    (a resource where the ARN annotation was set by the Kubernetes
-                    user on the CR) exists and matches the supplied CR''s Spec field
-                    values. TODO(vijat@): Find a better strategy for resources that
-                    do not have ARN in CreateOutputResponse https://github.com/aws/aws-controllers-k8s/issues/270'
-                  type: string
-                ownerAccountID:
-                  description: OwnerAccountID is the AWS Account ID of the account
-                    that owns the backend AWS service API resource.
-                  type: string
-              required:
-              - ownerAccountID
-              type: object
-            backupCreationDateTime:
-              format: date-time
-              type: string
-            backupExpiryDateTime:
-              format: date-time
-              type: string
-            backupSizeBytes:
-              format: int64
-              type: integer
-            backupStatus:
-              type: string
-            backupType:
-              type: string
-            conditions:
-              description: All CRS managed by ACK have a common `Status.Conditions`
-                member that contains a collection of `ackv1alpha1.Condition` objects
-                that describe the various terminal states of the CR and its backend
-                AWS service API resource
-              items:
-                description: Condition is the common struct used by all CRDs managed
-                  by ACK service controllers to indicate terminal states  of the CR
-                  and its backend AWS service API resource
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the Condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-          required:
-          - ackResourceMetadata
-          - conditions
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Backup is the Schema for the Backups API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BackupSpec defines the desired state of Backup
+            properties:
+              backupName:
+                type: string
+              tableName:
+                type: string
+            type: object
+          status:
+            description: BackupStatus defines the observed state of Backup
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              backupCreationDateTime:
+                format: date-time
+                type: string
+              backupExpiryDateTime:
+                format: date-time
+                type: string
+              backupSizeBytes:
+                format: int64
+                type: integer
+              backupStatus:
+                type: string
+              backupType:
+                type: string
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []

--- a/services/dynamodb/config/crd/bases/dynamodb.services.k8s.aws_globaltables.yaml
+++ b/services/dynamodb/config/crd/bases/dynamodb.services.k8s.aws_globaltables.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200716001835-4a903ddb7005
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: globaltables.dynamodb.services.k8s.aws
 spec:
@@ -15,113 +15,113 @@ spec:
     plural: globaltables
     singular: globaltable
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: GlobalTable is the Schema for the GlobalTables API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: GlobalTableSpec defines the desired state of GlobalTable
-          properties:
-            globalTableName:
-              type: string
-            replicationGroup:
-              items:
-                properties:
-                  regionName:
-                    type: string
-                type: object
-              type: array
-          type: object
-        status:
-          description: GlobalTableStatus defines the observed state of GlobalTable
-          properties:
-            ackResourceMetadata:
-              description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
-                member that is used to contain resource sync state, account ownership,
-                constructed ARN for the resource
-              properties:
-                arn:
-                  description: 'ARN is the Amazon Resource Name for the resource.
-                    This is a globally-unique identifier and is set only by the ACK
-                    service controller once the controller has orchestrated the creation
-                    of the resource OR when it has verified that an "adopted" resource
-                    (a resource where the ARN annotation was set by the Kubernetes
-                    user on the CR) exists and matches the supplied CR''s Spec field
-                    values. TODO(vijat@): Find a better strategy for resources that
-                    do not have ARN in CreateOutputResponse https://github.com/aws/aws-controllers-k8s/issues/270'
-                  type: string
-                ownerAccountID:
-                  description: OwnerAccountID is the AWS Account ID of the account
-                    that owns the backend AWS service API resource.
-                  type: string
-              required:
-              - ownerAccountID
-              type: object
-            conditions:
-              description: All CRS managed by ACK have a common `Status.Conditions`
-                member that contains a collection of `ackv1alpha1.Condition` objects
-                that describe the various terminal states of the CR and its backend
-                AWS service API resource
-              items:
-                description: Condition is the common struct used by all CRDs managed
-                  by ACK service controllers to indicate terminal states  of the CR
-                  and its backend AWS service API resource
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the Condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            creationDateTime:
-              format: date-time
-              type: string
-            globalTableStatus:
-              type: string
-          required:
-          - ackResourceMetadata
-          - conditions
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: GlobalTable is the Schema for the GlobalTables API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: GlobalTableSpec defines the desired state of GlobalTable
+            properties:
+              globalTableName:
+                type: string
+              replicationGroup:
+                items:
+                  properties:
+                    regionName:
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: GlobalTableStatus defines the observed state of GlobalTable
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              creationDateTime:
+                format: date-time
+                type: string
+              globalTableStatus:
+                type: string
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []

--- a/services/dynamodb/config/crd/bases/dynamodb.services.k8s.aws_tables.yaml
+++ b/services/dynamodb/config/crd/bases/dynamodb.services.k8s.aws_tables.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200716001835-4a903ddb7005
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: tables.dynamodb.services.k8s.aws
 spec:
@@ -15,309 +15,309 @@ spec:
     plural: tables
     singular: table
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Table is the Schema for the Tables API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: TableSpec defines the desired state of Table
-          properties:
-            attributeDefinitions:
-              items:
-                properties:
-                  attributeName:
-                    type: string
-                  attributeType:
-                    type: string
-                type: object
-              type: array
-            billingMode:
-              type: string
-            globalSecondaryIndexes:
-              items:
-                properties:
-                  indexName:
-                    type: string
-                  keySchema:
-                    items:
-                      properties:
-                        attributeName:
-                          type: string
-                        keyType:
-                          type: string
-                      type: object
-                    type: array
-                  projection:
-                    properties:
-                      nonKeyAttributes:
-                        items:
-                          type: string
-                        type: array
-                      projectionType:
-                        type: string
-                    type: object
-                  provisionedThroughput:
-                    properties:
-                      readCapacityUnits:
-                        format: int64
-                        type: integer
-                      writeCapacityUnits:
-                        format: int64
-                        type: integer
-                    type: object
-                type: object
-              type: array
-            keySchema:
-              items:
-                properties:
-                  attributeName:
-                    type: string
-                  keyType:
-                    type: string
-                type: object
-              type: array
-            localSecondaryIndexes:
-              items:
-                properties:
-                  indexName:
-                    type: string
-                  keySchema:
-                    items:
-                      properties:
-                        attributeName:
-                          type: string
-                        keyType:
-                          type: string
-                      type: object
-                    type: array
-                  projection:
-                    properties:
-                      nonKeyAttributes:
-                        items:
-                          type: string
-                        type: array
-                      projectionType:
-                        type: string
-                    type: object
-                type: object
-              type: array
-            provisionedThroughput:
-              properties:
-                readCapacityUnits:
-                  format: int64
-                  type: integer
-                writeCapacityUnits:
-                  format: int64
-                  type: integer
-              type: object
-            sseSpecification:
-              properties:
-                enabled:
-                  type: boolean
-                kmsMasterKeyID:
-                  type: string
-                sseType:
-                  type: string
-              type: object
-            streamSpecification:
-              properties:
-                streamEnabled:
-                  type: boolean
-                streamViewType:
-                  type: string
-              type: object
-            tableName:
-              type: string
-            tags:
-              items:
-                properties:
-                  key:
-                    type: string
-                  value:
-                    type: string
-                type: object
-              type: array
-          type: object
-        status:
-          description: TableStatus defines the observed state of Table
-          properties:
-            ackResourceMetadata:
-              description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
-                member that is used to contain resource sync state, account ownership,
-                constructed ARN for the resource
-              properties:
-                arn:
-                  description: 'ARN is the Amazon Resource Name for the resource.
-                    This is a globally-unique identifier and is set only by the ACK
-                    service controller once the controller has orchestrated the creation
-                    of the resource OR when it has verified that an "adopted" resource
-                    (a resource where the ARN annotation was set by the Kubernetes
-                    user on the CR) exists and matches the supplied CR''s Spec field
-                    values. TODO(vijat@): Find a better strategy for resources that
-                    do not have ARN in CreateOutputResponse https://github.com/aws/aws-controllers-k8s/issues/270'
-                  type: string
-                ownerAccountID:
-                  description: OwnerAccountID is the AWS Account ID of the account
-                    that owns the backend AWS service API resource.
-                  type: string
-              required:
-              - ownerAccountID
-              type: object
-            archivalSummary:
-              properties:
-                archivalBackupARN:
-                  type: string
-                archivalDateTime:
-                  format: date-time
-                  type: string
-                archivalReason:
-                  type: string
-              type: object
-            billingModeSummary:
-              properties:
-                billingMode:
-                  type: string
-                lastUpdateToPayPerRequestDateTime:
-                  format: date-time
-                  type: string
-              type: object
-            conditions:
-              description: All CRS managed by ACK have a common `Status.Conditions`
-                member that contains a collection of `ackv1alpha1.Condition` objects
-                that describe the various terminal states of the CR and its backend
-                AWS service API resource
-              items:
-                description: Condition is the common struct used by all CRDs managed
-                  by ACK service controllers to indicate terminal states  of the CR
-                  and its backend AWS service API resource
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the Condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            creationDateTime:
-              format: date-time
-              type: string
-            globalTableVersion:
-              type: string
-            itemCount:
-              format: int64
-              type: integer
-            latestStreamARN:
-              type: string
-            latestStreamLabel:
-              type: string
-            replicas:
-              items:
-                properties:
-                  globalSecondaryIndexes:
-                    items:
-                      properties:
-                        indexName:
-                          type: string
-                        provisionedThroughputOverride:
-                          properties:
-                            readCapacityUnits:
-                              format: int64
-                              type: integer
-                          type: object
-                      type: object
-                    type: array
-                  kmsMasterKeyID:
-                    type: string
-                  provisionedThroughputOverride:
-                    properties:
-                      readCapacityUnits:
-                        format: int64
-                        type: integer
-                    type: object
-                  regionName:
-                    type: string
-                  replicaStatus:
-                    type: string
-                  replicaStatusDescription:
-                    type: string
-                  replicaStatusPercentProgress:
-                    type: string
-                type: object
-              type: array
-            restoreSummary:
-              properties:
-                restoreDateTime:
-                  format: date-time
-                  type: string
-                restoreInProgress:
-                  type: boolean
-                sourceBackupARN:
-                  type: string
-                sourceTableARN:
-                  type: string
-              type: object
-            sseDescription:
-              properties:
-                inaccessibleEncryptionDateTime:
-                  format: date-time
-                  type: string
-                kmsMasterKeyARN:
-                  type: string
-                sseType:
-                  type: string
-                status:
-                  type: string
-              type: object
-            tableID:
-              type: string
-            tableSizeBytes:
-              format: int64
-              type: integer
-            tableStatus:
-              type: string
-          required:
-          - ackResourceMetadata
-          - conditions
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Table is the Schema for the Tables API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TableSpec defines the desired state of Table
+            properties:
+              attributeDefinitions:
+                items:
+                  properties:
+                    attributeName:
+                      type: string
+                    attributeType:
+                      type: string
+                  type: object
+                type: array
+              billingMode:
+                type: string
+              globalSecondaryIndexes:
+                items:
+                  properties:
+                    indexName:
+                      type: string
+                    keySchema:
+                      items:
+                        properties:
+                          attributeName:
+                            type: string
+                          keyType:
+                            type: string
+                        type: object
+                      type: array
+                    projection:
+                      properties:
+                        nonKeyAttributes:
+                          items:
+                            type: string
+                          type: array
+                        projectionType:
+                          type: string
+                      type: object
+                    provisionedThroughput:
+                      properties:
+                        readCapacityUnits:
+                          format: int64
+                          type: integer
+                        writeCapacityUnits:
+                          format: int64
+                          type: integer
+                      type: object
+                  type: object
+                type: array
+              keySchema:
+                items:
+                  properties:
+                    attributeName:
+                      type: string
+                    keyType:
+                      type: string
+                  type: object
+                type: array
+              localSecondaryIndexes:
+                items:
+                  properties:
+                    indexName:
+                      type: string
+                    keySchema:
+                      items:
+                        properties:
+                          attributeName:
+                            type: string
+                          keyType:
+                            type: string
+                        type: object
+                      type: array
+                    projection:
+                      properties:
+                        nonKeyAttributes:
+                          items:
+                            type: string
+                          type: array
+                        projectionType:
+                          type: string
+                      type: object
+                  type: object
+                type: array
+              provisionedThroughput:
+                properties:
+                  readCapacityUnits:
+                    format: int64
+                    type: integer
+                  writeCapacityUnits:
+                    format: int64
+                    type: integer
+                type: object
+              sseSpecification:
+                properties:
+                  enabled:
+                    type: boolean
+                  kmsMasterKeyID:
+                    type: string
+                  sseType:
+                    type: string
+                type: object
+              streamSpecification:
+                properties:
+                  streamEnabled:
+                    type: boolean
+                  streamViewType:
+                    type: string
+                type: object
+              tableName:
+                type: string
+              tags:
+                items:
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: TableStatus defines the observed state of Table
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              archivalSummary:
+                properties:
+                  archivalBackupARN:
+                    type: string
+                  archivalDateTime:
+                    format: date-time
+                    type: string
+                  archivalReason:
+                    type: string
+                type: object
+              billingModeSummary:
+                properties:
+                  billingMode:
+                    type: string
+                  lastUpdateToPayPerRequestDateTime:
+                    format: date-time
+                    type: string
+                type: object
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              creationDateTime:
+                format: date-time
+                type: string
+              globalTableVersion:
+                type: string
+              itemCount:
+                format: int64
+                type: integer
+              latestStreamARN:
+                type: string
+              latestStreamLabel:
+                type: string
+              replicas:
+                items:
+                  properties:
+                    globalSecondaryIndexes:
+                      items:
+                        properties:
+                          indexName:
+                            type: string
+                          provisionedThroughputOverride:
+                            properties:
+                              readCapacityUnits:
+                                format: int64
+                                type: integer
+                            type: object
+                        type: object
+                      type: array
+                    kmsMasterKeyID:
+                      type: string
+                    provisionedThroughputOverride:
+                      properties:
+                        readCapacityUnits:
+                          format: int64
+                          type: integer
+                      type: object
+                    regionName:
+                      type: string
+                    replicaStatus:
+                      type: string
+                    replicaStatusDescription:
+                      type: string
+                    replicaStatusPercentProgress:
+                      type: string
+                  type: object
+                type: array
+              restoreSummary:
+                properties:
+                  restoreDateTime:
+                    format: date-time
+                    type: string
+                  restoreInProgress:
+                    type: boolean
+                  sourceBackupARN:
+                    type: string
+                  sourceTableARN:
+                    type: string
+                type: object
+              sseDescription:
+                properties:
+                  inaccessibleEncryptionDateTime:
+                    format: date-time
+                    type: string
+                  kmsMasterKeyARN:
+                    type: string
+                  sseType:
+                    type: string
+                  status:
+                    type: string
+                type: object
+              tableID:
+                type: string
+              tableSizeBytes:
+                format: int64
+                type: integer
+              tableStatus:
+                type: string
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []

--- a/services/dynamodb/config/rbac/role.yaml
+++ b/services/dynamodb/config/rbac/role.yaml
@@ -7,6 +7,22 @@ metadata:
   name: ack-controller
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - dynamodb.services.k8s.aws
   resources:
   - backups

--- a/services/dynamodb/pkg/resource/backup/manager.go
+++ b/services/dynamodb/pkg/resource/backup/manager.go
@@ -30,6 +30,8 @@ import (
 
 // +kubebuilder:rbac:groups=dynamodb.services.k8s.aws,resources=backups,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=dynamodb.services.k8s.aws,resources=backups/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.

--- a/services/dynamodb/pkg/resource/global_table/manager.go
+++ b/services/dynamodb/pkg/resource/global_table/manager.go
@@ -30,6 +30,8 @@ import (
 
 // +kubebuilder:rbac:groups=dynamodb.services.k8s.aws,resources=globaltables,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=dynamodb.services.k8s.aws,resources=globaltables/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.

--- a/services/dynamodb/pkg/resource/table/manager.go
+++ b/services/dynamodb/pkg/resource/table/manager.go
@@ -30,6 +30,8 @@ import (
 
 // +kubebuilder:rbac:groups=dynamodb.services.k8s.aws,resources=tables,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=dynamodb.services.k8s.aws,resources=tables/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.

--- a/services/ecr/config/crd/bases/ecr.services.k8s.aws_repositories.yaml
+++ b/services/ecr/config/crd/bases/ecr.services.k8s.aws_repositories.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200716001835-4a903ddb7005
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: repositories.ecr.services.k8s.aws
 spec:
@@ -15,131 +15,131 @@ spec:
     plural: repositories
     singular: repository
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Repository is the Schema for the Repositories API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: RepositorySpec defines the desired state of Repository
-          properties:
-            encryptionConfiguration:
-              properties:
-                encryptionType:
-                  type: string
-                kmsKey:
-                  type: string
-              type: object
-            imageScanningConfiguration:
-              properties:
-                scanOnPush:
-                  type: boolean
-              type: object
-            imageTagMutability:
-              type: string
-            repositoryName:
-              type: string
-            tags:
-              items:
-                properties:
-                  key:
-                    type: string
-                  value:
-                    type: string
-                type: object
-              type: array
-          type: object
-        status:
-          description: RepositoryStatus defines the observed state of Repository
-          properties:
-            ackResourceMetadata:
-              description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
-                member that is used to contain resource sync state, account ownership,
-                constructed ARN for the resource
-              properties:
-                arn:
-                  description: 'ARN is the Amazon Resource Name for the resource.
-                    This is a globally-unique identifier and is set only by the ACK
-                    service controller once the controller has orchestrated the creation
-                    of the resource OR when it has verified that an "adopted" resource
-                    (a resource where the ARN annotation was set by the Kubernetes
-                    user on the CR) exists and matches the supplied CR''s Spec field
-                    values. TODO(vijat@): Find a better strategy for resources that
-                    do not have ARN in CreateOutputResponse https://github.com/aws/aws-controllers-k8s/issues/270'
-                  type: string
-                ownerAccountID:
-                  description: OwnerAccountID is the AWS Account ID of the account
-                    that owns the backend AWS service API resource.
-                  type: string
-              required:
-              - ownerAccountID
-              type: object
-            conditions:
-              description: All CRS managed by ACK have a common `Status.Conditions`
-                member that contains a collection of `ackv1alpha1.Condition` objects
-                that describe the various terminal states of the CR and its backend
-                AWS service API resource
-              items:
-                description: Condition is the common struct used by all CRDs managed
-                  by ACK service controllers to indicate terminal states  of the CR
-                  and its backend AWS service API resource
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the Condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            createdAt:
-              format: date-time
-              type: string
-            registryID:
-              type: string
-            repositoryURI:
-              type: string
-          required:
-          - ackResourceMetadata
-          - conditions
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Repository is the Schema for the Repositories API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RepositorySpec defines the desired state of Repository
+            properties:
+              encryptionConfiguration:
+                properties:
+                  encryptionType:
+                    type: string
+                  kmsKey:
+                    type: string
+                type: object
+              imageScanningConfiguration:
+                properties:
+                  scanOnPush:
+                    type: boolean
+                type: object
+              imageTagMutability:
+                type: string
+              repositoryName:
+                type: string
+              tags:
+                items:
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: RepositoryStatus defines the observed state of Repository
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              createdAt:
+                format: date-time
+                type: string
+              registryID:
+                type: string
+              repositoryURI:
+                type: string
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []

--- a/services/elasticache/config/crd/bases/elasticache.services.k8s.aws_cachesubnetgroups.yaml
+++ b/services/elasticache/config/crd/bases/elasticache.services.k8s.aws_cachesubnetgroups.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200716001835-4a903ddb7005
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: cachesubnetgroups.elasticache.services.k8s.aws
 spec:
@@ -15,121 +15,121 @@ spec:
     plural: cachesubnetgroups
     singular: cachesubnetgroup
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: CacheSubnetGroup is the Schema for the CacheSubnetGroups API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CacheSubnetGroupSpec defines the desired state of CacheSubnetGroup
-          properties:
-            cacheSubnetGroupDescription:
-              type: string
-            cacheSubnetGroupName:
-              type: string
-            subnetIDs:
-              items:
-                type: string
-              type: array
-          type: object
-        status:
-          description: CacheSubnetGroupStatus defines the observed state of CacheSubnetGroup
-          properties:
-            ackResourceMetadata:
-              description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
-                member that is used to contain resource sync state, account ownership,
-                constructed ARN for the resource
-              properties:
-                arn:
-                  description: 'ARN is the Amazon Resource Name for the resource.
-                    This is a globally-unique identifier and is set only by the ACK
-                    service controller once the controller has orchestrated the creation
-                    of the resource OR when it has verified that an "adopted" resource
-                    (a resource where the ARN annotation was set by the Kubernetes
-                    user on the CR) exists and matches the supplied CR''s Spec field
-                    values. TODO(vijat@): Find a better strategy for resources that
-                    do not have ARN in CreateOutputResponse https://github.com/aws/aws-controllers-k8s/issues/270'
-                  type: string
-                ownerAccountID:
-                  description: OwnerAccountID is the AWS Account ID of the account
-                    that owns the backend AWS service API resource.
-                  type: string
-              required:
-              - ownerAccountID
-              type: object
-            conditions:
-              description: All CRS managed by ACK have a common `Status.Conditions`
-                member that contains a collection of `ackv1alpha1.Condition` objects
-                that describe the various terminal states of the CR and its backend
-                AWS service API resource
-              items:
-                description: Condition is the common struct used by all CRDs managed
-                  by ACK service controllers to indicate terminal states  of the CR
-                  and its backend AWS service API resource
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the Condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            subnets:
-              items:
-                properties:
-                  subnetAvailabilityZone:
-                    properties:
-                      name:
-                        type: string
-                    type: object
-                  subnetIdentifier:
-                    type: string
-                type: object
-              type: array
-            vpcID:
-              type: string
-          required:
-          - ackResourceMetadata
-          - conditions
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: CacheSubnetGroup is the Schema for the CacheSubnetGroups API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CacheSubnetGroupSpec defines the desired state of CacheSubnetGroup
+            properties:
+              cacheSubnetGroupDescription:
+                type: string
+              cacheSubnetGroupName:
+                type: string
+              subnetIDs:
+                items:
+                  type: string
+                type: array
+            type: object
+          status:
+            description: CacheSubnetGroupStatus defines the observed state of CacheSubnetGroup
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              subnets:
+                items:
+                  properties:
+                    subnetAvailabilityZone:
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                    subnetIdentifier:
+                      type: string
+                  type: object
+                type: array
+              vpcID:
+                type: string
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []

--- a/services/elasticache/config/crd/bases/elasticache.services.k8s.aws_replicationgroups.yaml
+++ b/services/elasticache/config/crd/bases/elasticache.services.k8s.aws_replicationgroups.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200716001835-4a903ddb7005
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: replicationgroups.elasticache.services.k8s.aws
 spec:
@@ -15,298 +15,298 @@ spec:
     plural: replicationgroups
     singular: replicationgroup
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ReplicationGroup is the Schema for the ReplicationGroups API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ReplicationGroupSpec defines the desired state of ReplicationGroup
-          properties:
-            atRestEncryptionEnabled:
-              type: boolean
-            authToken:
-              type: string
-            autoMinorVersionUpgrade:
-              type: boolean
-            automaticFailoverEnabled:
-              type: boolean
-            cacheNodeType:
-              type: string
-            cacheParameterGroupName:
-              type: string
-            cacheSecurityGroupNames:
-              items:
-                type: string
-              type: array
-            cacheSubnetGroupName:
-              type: string
-            engine:
-              type: string
-            engineVersion:
-              type: string
-            globalReplicationGroupID:
-              type: string
-            kmsKeyID:
-              type: string
-            multiAZEnabled:
-              type: boolean
-            nodeGroupConfiguration:
-              items:
-                properties:
-                  nodeGroupID:
-                    type: string
-                  primaryAvailabilityZone:
-                    type: string
-                  replicaAvailabilityZones:
-                    items:
-                      type: string
-                    type: array
-                  replicaCount:
-                    format: int64
-                    type: integer
-                  slots:
-                    type: string
-                type: object
-              type: array
-            notificationTopicARN:
-              type: string
-            numCacheClusters:
-              format: int64
-              type: integer
-            numNodeGroups:
-              format: int64
-              type: integer
-            port:
-              format: int64
-              type: integer
-            preferredCacheClusterAZs:
-              items:
-                type: string
-              type: array
-            preferredMaintenanceWindow:
-              type: string
-            primaryClusterID:
-              type: string
-            replicasPerNodeGroup:
-              format: int64
-              type: integer
-            replicationGroupDescription:
-              type: string
-            replicationGroupID:
-              type: string
-            securityGroupIDs:
-              items:
-                type: string
-              type: array
-            snapshotARNs:
-              items:
-                type: string
-              type: array
-            snapshotName:
-              type: string
-            snapshotRetentionLimit:
-              format: int64
-              type: integer
-            snapshotWindow:
-              type: string
-            tags:
-              items:
-                properties:
-                  key:
-                    type: string
-                  value:
-                    type: string
-                type: object
-              type: array
-            transitEncryptionEnabled:
-              type: boolean
-          type: object
-        status:
-          description: ReplicationGroupStatus defines the observed state of ReplicationGroup
-          properties:
-            ackResourceMetadata:
-              description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
-                member that is used to contain resource sync state, account ownership,
-                constructed ARN for the resource
-              properties:
-                arn:
-                  description: 'ARN is the Amazon Resource Name for the resource.
-                    This is a globally-unique identifier and is set only by the ACK
-                    service controller once the controller has orchestrated the creation
-                    of the resource OR when it has verified that an "adopted" resource
-                    (a resource where the ARN annotation was set by the Kubernetes
-                    user on the CR) exists and matches the supplied CR''s Spec field
-                    values. TODO(vijat@): Find a better strategy for resources that
-                    do not have ARN in CreateOutputResponse https://github.com/aws/aws-controllers-k8s/issues/270'
-                  type: string
-                ownerAccountID:
-                  description: OwnerAccountID is the AWS Account ID of the account
-                    that owns the backend AWS service API resource.
-                  type: string
-              required:
-              - ownerAccountID
-              type: object
-            authTokenEnabled:
-              type: boolean
-            authTokenLastModifiedDate:
-              format: date-time
-              type: string
-            automaticFailover:
-              type: string
-            clusterEnabled:
-              type: boolean
-            conditions:
-              description: All CRS managed by ACK have a common `Status.Conditions`
-                member that contains a collection of `ackv1alpha1.Condition` objects
-                that describe the various terminal states of the CR and its backend
-                AWS service API resource
-              items:
-                description: Condition is the common struct used by all CRDs managed
-                  by ACK service controllers to indicate terminal states  of the CR
-                  and its backend AWS service API resource
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the Condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            configurationEndpoint:
-              properties:
-                address:
-                  type: string
-                port:
-                  format: int64
-                  type: integer
-              type: object
-            description:
-              type: string
-            globalReplicationGroupInfo:
-              properties:
-                globalReplicationGroupID:
-                  type: string
-                globalReplicationGroupMemberRole:
-                  type: string
-              type: object
-            memberClusters:
-              items:
-                type: string
-              type: array
-            multiAZ:
-              type: string
-            nodeGroups:
-              items:
-                properties:
-                  nodeGroupID:
-                    type: string
-                  nodeGroupMembers:
-                    items:
-                      properties:
-                        cacheClusterID:
-                          type: string
-                        cacheNodeID:
-                          type: string
-                        currentRole:
-                          type: string
-                        preferredAvailabilityZone:
-                          type: string
-                        readEndpoint:
-                          properties:
-                            address:
-                              type: string
-                            port:
-                              format: int64
-                              type: integer
-                          type: object
-                      type: object
-                    type: array
-                  primaryEndpoint:
-                    properties:
-                      address:
-                        type: string
-                      port:
-                        format: int64
-                        type: integer
-                    type: object
-                  readerEndpoint:
-                    properties:
-                      address:
-                        type: string
-                      port:
-                        format: int64
-                        type: integer
-                    type: object
-                  slots:
-                    type: string
-                  status:
-                    type: string
-                type: object
-              type: array
-            pendingModifiedValues:
-              properties:
-                authTokenStatus:
-                  type: string
-                automaticFailoverStatus:
-                  type: string
-                primaryClusterID:
-                  type: string
-                resharding:
-                  properties:
-                    slotMigration:
-                      properties:
-                        progressPercentage:
-                          type: number
-                      type: object
-                  type: object
-              type: object
-            snapshottingClusterID:
-              type: string
-            status:
-              type: string
-          required:
-          - ackResourceMetadata
-          - conditions
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ReplicationGroup is the Schema for the ReplicationGroups API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ReplicationGroupSpec defines the desired state of ReplicationGroup
+            properties:
+              atRestEncryptionEnabled:
+                type: boolean
+              authToken:
+                type: string
+              autoMinorVersionUpgrade:
+                type: boolean
+              automaticFailoverEnabled:
+                type: boolean
+              cacheNodeType:
+                type: string
+              cacheParameterGroupName:
+                type: string
+              cacheSecurityGroupNames:
+                items:
+                  type: string
+                type: array
+              cacheSubnetGroupName:
+                type: string
+              engine:
+                type: string
+              engineVersion:
+                type: string
+              globalReplicationGroupID:
+                type: string
+              kmsKeyID:
+                type: string
+              multiAZEnabled:
+                type: boolean
+              nodeGroupConfiguration:
+                items:
+                  properties:
+                    nodeGroupID:
+                      type: string
+                    primaryAvailabilityZone:
+                      type: string
+                    replicaAvailabilityZones:
+                      items:
+                        type: string
+                      type: array
+                    replicaCount:
+                      format: int64
+                      type: integer
+                    slots:
+                      type: string
+                  type: object
+                type: array
+              notificationTopicARN:
+                type: string
+              numCacheClusters:
+                format: int64
+                type: integer
+              numNodeGroups:
+                format: int64
+                type: integer
+              port:
+                format: int64
+                type: integer
+              preferredCacheClusterAZs:
+                items:
+                  type: string
+                type: array
+              preferredMaintenanceWindow:
+                type: string
+              primaryClusterID:
+                type: string
+              replicasPerNodeGroup:
+                format: int64
+                type: integer
+              replicationGroupDescription:
+                type: string
+              replicationGroupID:
+                type: string
+              securityGroupIDs:
+                items:
+                  type: string
+                type: array
+              snapshotARNs:
+                items:
+                  type: string
+                type: array
+              snapshotName:
+                type: string
+              snapshotRetentionLimit:
+                format: int64
+                type: integer
+              snapshotWindow:
+                type: string
+              tags:
+                items:
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+              transitEncryptionEnabled:
+                type: boolean
+            type: object
+          status:
+            description: ReplicationGroupStatus defines the observed state of ReplicationGroup
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              authTokenEnabled:
+                type: boolean
+              authTokenLastModifiedDate:
+                format: date-time
+                type: string
+              automaticFailover:
+                type: string
+              clusterEnabled:
+                type: boolean
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              configurationEndpoint:
+                properties:
+                  address:
+                    type: string
+                  port:
+                    format: int64
+                    type: integer
+                type: object
+              description:
+                type: string
+              globalReplicationGroupInfo:
+                properties:
+                  globalReplicationGroupID:
+                    type: string
+                  globalReplicationGroupMemberRole:
+                    type: string
+                type: object
+              memberClusters:
+                items:
+                  type: string
+                type: array
+              multiAZ:
+                type: string
+              nodeGroups:
+                items:
+                  properties:
+                    nodeGroupID:
+                      type: string
+                    nodeGroupMembers:
+                      items:
+                        properties:
+                          cacheClusterID:
+                            type: string
+                          cacheNodeID:
+                            type: string
+                          currentRole:
+                            type: string
+                          preferredAvailabilityZone:
+                            type: string
+                          readEndpoint:
+                            properties:
+                              address:
+                                type: string
+                              port:
+                                format: int64
+                                type: integer
+                            type: object
+                        type: object
+                      type: array
+                    primaryEndpoint:
+                      properties:
+                        address:
+                          type: string
+                        port:
+                          format: int64
+                          type: integer
+                      type: object
+                    readerEndpoint:
+                      properties:
+                        address:
+                          type: string
+                        port:
+                          format: int64
+                          type: integer
+                      type: object
+                    slots:
+                      type: string
+                    status:
+                      type: string
+                  type: object
+                type: array
+              pendingModifiedValues:
+                properties:
+                  authTokenStatus:
+                    type: string
+                  automaticFailoverStatus:
+                    type: string
+                  primaryClusterID:
+                    type: string
+                  resharding:
+                    properties:
+                      slotMigration:
+                        properties:
+                          progressPercentage:
+                            type: number
+                        type: object
+                    type: object
+                type: object
+              snapshottingClusterID:
+                type: string
+              status:
+                type: string
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []

--- a/services/readme.md
+++ b/services/readme.md
@@ -1,5 +1,0 @@
-## Supported services
-See the [documentation](https://aws.github.io/aws-controllers-k8s/services) for a list of supported services.
-
-### Adding a service controller
-See our [contributors guide](/CONTRIBUTING.md) for information on adding a new service controller.

--- a/services/s3/config/crd/bases/s3.services.k8s.aws_buckets.yaml
+++ b/services/s3/config/crd/bases/s3.services.k8s.aws_buckets.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200716001835-4a903ddb7005
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: buckets.s3.services.k8s.aws
 spec:
@@ -15,122 +15,122 @@ spec:
     plural: buckets
     singular: bucket
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Bucket is the Schema for the Buckets API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: BucketSpec defines the desired state of Bucket
-          properties:
-            acl:
-              type: string
-            createBucketConfiguration:
-              properties:
-                locationConstraint:
-                  type: string
-              type: object
-            grantFullControl:
-              type: string
-            grantRead:
-              type: string
-            grantReadACP:
-              type: string
-            grantWrite:
-              type: string
-            grantWriteACP:
-              type: string
-            name:
-              type: string
-            objectLockEnabledForBucket:
-              type: boolean
-          type: object
-        status:
-          description: BucketStatus defines the observed state of Bucket
-          properties:
-            ackResourceMetadata:
-              description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
-                member that is used to contain resource sync state, account ownership,
-                constructed ARN for the resource
-              properties:
-                arn:
-                  description: 'ARN is the Amazon Resource Name for the resource.
-                    This is a globally-unique identifier and is set only by the ACK
-                    service controller once the controller has orchestrated the creation
-                    of the resource OR when it has verified that an "adopted" resource
-                    (a resource where the ARN annotation was set by the Kubernetes
-                    user on the CR) exists and matches the supplied CR''s Spec field
-                    values. TODO(vijat@): Find a better strategy for resources that
-                    do not have ARN in CreateOutputResponse https://github.com/aws/aws-controllers-k8s/issues/270'
-                  type: string
-                ownerAccountID:
-                  description: OwnerAccountID is the AWS Account ID of the account
-                    that owns the backend AWS service API resource.
-                  type: string
-              required:
-              - ownerAccountID
-              type: object
-            conditions:
-              description: All CRS managed by ACK have a common `Status.Conditions`
-                member that contains a collection of `ackv1alpha1.Condition` objects
-                that describe the various terminal states of the CR and its backend
-                AWS service API resource
-              items:
-                description: Condition is the common struct used by all CRDs managed
-                  by ACK service controllers to indicate terminal states  of the CR
-                  and its backend AWS service API resource
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the Condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            location:
-              type: string
-          required:
-          - ackResourceMetadata
-          - conditions
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Bucket is the Schema for the Buckets API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BucketSpec defines the desired state of Bucket
+            properties:
+              acl:
+                type: string
+              createBucketConfiguration:
+                properties:
+                  locationConstraint:
+                    type: string
+                type: object
+              grantFullControl:
+                type: string
+              grantRead:
+                type: string
+              grantReadACP:
+                type: string
+              grantWrite:
+                type: string
+              grantWriteACP:
+                type: string
+              name:
+                type: string
+              objectLockEnabledForBucket:
+                type: boolean
+            type: object
+          status:
+            description: BucketStatus defines the observed state of Bucket
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              location:
+                type: string
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []

--- a/services/sns/config/crd/bases/sns.services.k8s.aws_platformapplications.yaml
+++ b/services/sns/config/crd/bases/sns.services.k8s.aws_platformapplications.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200716001835-4a903ddb7005
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: platformapplications.sns.services.k8s.aws
 spec:
@@ -15,122 +15,122 @@ spec:
     plural: platformapplications
     singular: platformapplication
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: PlatformApplication is the Schema for the PlatformApplications
-        API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: PlatformApplicationSpec defines the desired state of PlatformApplication
-          properties:
-            eventDeliveryFailure:
-              type: string
-            eventEndpointCreated:
-              type: string
-            eventEndpointDeleted:
-              type: string
-            eventEndpointUpdated:
-              type: string
-            failureFeedbackRoleARN:
-              type: string
-            name:
-              type: string
-            platform:
-              type: string
-            platformCredential:
-              type: string
-            platformPrincipal:
-              type: string
-            successFeedbackRoleARN:
-              type: string
-            successFeedbackSampleRate:
-              type: string
-          type: object
-        status:
-          description: PlatformApplicationStatus defines the observed state of PlatformApplication
-          properties:
-            ackResourceMetadata:
-              description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
-                member that is used to contain resource sync state, account ownership,
-                constructed ARN for the resource
-              properties:
-                arn:
-                  description: 'ARN is the Amazon Resource Name for the resource.
-                    This is a globally-unique identifier and is set only by the ACK
-                    service controller once the controller has orchestrated the creation
-                    of the resource OR when it has verified that an "adopted" resource
-                    (a resource where the ARN annotation was set by the Kubernetes
-                    user on the CR) exists and matches the supplied CR''s Spec field
-                    values. TODO(vijat@): Find a better strategy for resources that
-                    do not have ARN in CreateOutputResponse https://github.com/aws/aws-controllers-k8s/issues/270'
-                  type: string
-                ownerAccountID:
-                  description: OwnerAccountID is the AWS Account ID of the account
-                    that owns the backend AWS service API resource.
-                  type: string
-              required:
-              - ownerAccountID
-              type: object
-            conditions:
-              description: All CRS managed by ACK have a common `Status.Conditions`
-                member that contains a collection of `ackv1alpha1.Condition` objects
-                that describe the various terminal states of the CR and its backend
-                AWS service API resource
-              items:
-                description: Condition is the common struct used by all CRDs managed
-                  by ACK service controllers to indicate terminal states  of the CR
-                  and its backend AWS service API resource
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the Condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-          required:
-          - ackResourceMetadata
-          - conditions
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PlatformApplication is the Schema for the PlatformApplications
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PlatformApplicationSpec defines the desired state of PlatformApplication
+            properties:
+              eventDeliveryFailure:
+                type: string
+              eventEndpointCreated:
+                type: string
+              eventEndpointDeleted:
+                type: string
+              eventEndpointUpdated:
+                type: string
+              failureFeedbackRoleARN:
+                type: string
+              name:
+                type: string
+              platform:
+                type: string
+              platformCredential:
+                type: string
+              platformPrincipal:
+                type: string
+              successFeedbackRoleARN:
+                type: string
+              successFeedbackSampleRate:
+                type: string
+            type: object
+          status:
+            description: PlatformApplicationStatus defines the observed state of PlatformApplication
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []

--- a/services/sns/config/crd/bases/sns.services.k8s.aws_platformendpoints.yaml
+++ b/services/sns/config/crd/bases/sns.services.k8s.aws_platformendpoints.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200716001835-4a903ddb7005
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: platformendpoints.sns.services.k8s.aws
 spec:
@@ -15,111 +15,111 @@ spec:
     plural: platformendpoints
     singular: platformendpoint
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: PlatformEndpoint is the Schema for the PlatformEndpoints API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: PlatformEndpointSpec defines the desired state of PlatformEndpoint
-          properties:
-            attributes:
-              additionalProperties:
-                type: string
-              type: object
-            customUserData:
-              type: string
-            platformApplicationARN:
-              type: string
-            token:
-              type: string
-          type: object
-        status:
-          description: PlatformEndpointStatus defines the observed state of PlatformEndpoint
-          properties:
-            ackResourceMetadata:
-              description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
-                member that is used to contain resource sync state, account ownership,
-                constructed ARN for the resource
-              properties:
-                arn:
-                  description: 'ARN is the Amazon Resource Name for the resource.
-                    This is a globally-unique identifier and is set only by the ACK
-                    service controller once the controller has orchestrated the creation
-                    of the resource OR when it has verified that an "adopted" resource
-                    (a resource where the ARN annotation was set by the Kubernetes
-                    user on the CR) exists and matches the supplied CR''s Spec field
-                    values. TODO(vijat@): Find a better strategy for resources that
-                    do not have ARN in CreateOutputResponse https://github.com/aws/aws-controllers-k8s/issues/270'
-                  type: string
-                ownerAccountID:
-                  description: OwnerAccountID is the AWS Account ID of the account
-                    that owns the backend AWS service API resource.
-                  type: string
-              required:
-              - ownerAccountID
-              type: object
-            conditions:
-              description: All CRS managed by ACK have a common `Status.Conditions`
-                member that contains a collection of `ackv1alpha1.Condition` objects
-                that describe the various terminal states of the CR and its backend
-                AWS service API resource
-              items:
-                description: Condition is the common struct used by all CRDs managed
-                  by ACK service controllers to indicate terminal states  of the CR
-                  and its backend AWS service API resource
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the Condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            endpointARN:
-              type: string
-          required:
-          - ackResourceMetadata
-          - conditions
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PlatformEndpoint is the Schema for the PlatformEndpoints API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PlatformEndpointSpec defines the desired state of PlatformEndpoint
+            properties:
+              attributes:
+                additionalProperties:
+                  type: string
+                type: object
+              customUserData:
+                type: string
+              platformApplicationARN:
+                type: string
+              token:
+                type: string
+            type: object
+          status:
+            description: PlatformEndpointStatus defines the observed state of PlatformEndpoint
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              endpointARN:
+                type: string
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []

--- a/services/sns/config/crd/bases/sns.services.k8s.aws_topics.yaml
+++ b/services/sns/config/crd/bases/sns.services.k8s.aws_topics.yaml
@@ -1,10 +1,10 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200716001835-4a903ddb7005
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: topics.sns.services.k8s.aws
 spec:
@@ -15,122 +15,122 @@ spec:
     plural: topics
     singular: topic
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: Topic is the Schema for the Topics API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: TopicSpec defines the desired state of Topic
-          properties:
-            deliveryPolicy:
-              type: string
-            displayName:
-              type: string
-            kmsMasterKeyID:
-              type: string
-            name:
-              type: string
-            policy:
-              type: string
-            tags:
-              items:
-                properties:
-                  key:
-                    type: string
-                  value:
-                    type: string
-                type: object
-              type: array
-          type: object
-        status:
-          description: TopicStatus defines the observed state of Topic
-          properties:
-            ackResourceMetadata:
-              description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
-                member that is used to contain resource sync state, account ownership,
-                constructed ARN for the resource
-              properties:
-                arn:
-                  description: 'ARN is the Amazon Resource Name for the resource.
-                    This is a globally-unique identifier and is set only by the ACK
-                    service controller once the controller has orchestrated the creation
-                    of the resource OR when it has verified that an "adopted" resource
-                    (a resource where the ARN annotation was set by the Kubernetes
-                    user on the CR) exists and matches the supplied CR''s Spec field
-                    values. TODO(vijat@): Find a better strategy for resources that
-                    do not have ARN in CreateOutputResponse https://github.com/aws/aws-controllers-k8s/issues/270'
-                  type: string
-                ownerAccountID:
-                  description: OwnerAccountID is the AWS Account ID of the account
-                    that owns the backend AWS service API resource.
-                  type: string
-              required:
-              - ownerAccountID
-              type: object
-            conditions:
-              description: All CRS managed by ACK have a common `Status.Conditions`
-                member that contains a collection of `ackv1alpha1.Condition` objects
-                that describe the various terminal states of the CR and its backend
-                AWS service API resource
-              items:
-                description: Condition is the common struct used by all CRDs managed
-                  by ACK service controllers to indicate terminal states  of the CR
-                  and its backend AWS service API resource
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another.
-                    format: date-time
-                    type: string
-                  message:
-                    description: A human readable message indicating details about
-                      the transition.
-                    type: string
-                  reason:
-                    description: The reason for the condition's last transition.
-                    type: string
-                  status:
-                    description: Status of the condition, one of True, False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the Condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            effectiveDeliveryPolicy:
-              type: string
-            owner:
-              type: string
-          required:
-          - ackResourceMetadata
-          - conditions
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Topic is the Schema for the Topics API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TopicSpec defines the desired state of Topic
+            properties:
+              deliveryPolicy:
+                type: string
+              displayName:
+                type: string
+              kmsMasterKeyID:
+                type: string
+              name:
+                type: string
+              policy:
+                type: string
+              tags:
+                items:
+                  properties:
+                    key:
+                      type: string
+                    value:
+                      type: string
+                  type: object
+                type: array
+            type: object
+          status:
+            description: TopicStatus defines the observed state of Topic
+            properties:
+              ackResourceMetadata:
+                description: All CRs managed by ACK have a common `Status.ACKResourceMetadata`
+                  member that is used to contain resource sync state, account ownership,
+                  constructed ARN for the resource
+                properties:
+                  arn:
+                    description: 'ARN is the Amazon Resource Name for the resource.
+                      This is a globally-unique identifier and is set only by the
+                      ACK service controller once the controller has orchestrated
+                      the creation of the resource OR when it has verified that an
+                      "adopted" resource (a resource where the ARN annotation was
+                      set by the Kubernetes user on the CR) exists and matches the
+                      supplied CR''s Spec field values. TODO(vijat@): Find a better
+                      strategy for resources that do not have ARN in CreateOutputResponse
+                      https://github.com/aws/aws-controllers-k8s/issues/270'
+                    type: string
+                  ownerAccountID:
+                    description: OwnerAccountID is the AWS Account ID of the account
+                      that owns the backend AWS service API resource.
+                    type: string
+                required:
+                - ownerAccountID
+                type: object
+              conditions:
+                description: All CRS managed by ACK have a common `Status.Conditions`
+                  member that contains a collection of `ackv1alpha1.Condition` objects
+                  that describe the various terminal states of the CR and its backend
+                  AWS service API resource
+                items:
+                  description: Condition is the common struct used by all CRDs managed
+                    by ACK service controllers to indicate terminal states  of the
+                    CR and its backend AWS service API resource
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the Condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              effectiveDeliveryPolicy:
+                type: string
+              owner:
+                type: string
+            required:
+            - ackResourceMetadata
+            - conditions
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: null
-  storedVersions: null
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
controller-gen 0.4.0 is now our standard build tooling and produces CRD
and Role files that are annotated with a specific version of the tool
that built them.

This patch simply updates all the service controllers to align with that
controller-gen 0.4.0 standard.

Fixes Issue #349

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
