### PR TITLE
Replica count logic fix for Redis Cluster mode enabled

### DIFF
--- a/services/elasticache/pkg/resource/replication_group/custom_update_api.go
+++ b/services/elasticache/pkg/resource/replication_group/custom_update_api.go
@@ -90,9 +90,9 @@ func (rm *resourceManager) diffReplicasPerNodeGroup(
 
 	for _, latestShard := range latestStatus.NodeGroups {
 		latestReplicaCount := 0
-		for _, latestShardMember := range latestShard.NodeGroupMembers {
-			if latestShardMember.CurrentRole != nil && *latestShardMember.CurrentRole == "replica" {
-				latestReplicaCount++
+		if latestShard.NodeGroupMembers != nil {
+			if len(latestShard.NodeGroupMembers) > 0 {
+				latestReplicaCount = len(latestShard.NodeGroupMembers) - 1
 			}
 		}
 		if desiredReplicaCount := int(*desiredSpec.ReplicasPerNodeGroup); desiredReplicaCount != latestReplicaCount {
@@ -125,9 +125,9 @@ func (rm *resourceManager) diffReplicasNodeGroupConfiguration(
 			continue
 		}
 		latestReplicaCount := 0
-		for _, latestShardMember := range latestShard.NodeGroupMembers {
-			if latestShardMember.CurrentRole != nil && *latestShardMember.CurrentRole == "replica" {
-				latestReplicaCount++
+		if latestShard.NodeGroupMembers != nil {
+			if len(latestShard.NodeGroupMembers) > 0 {
+				latestReplicaCount = len(latestShard.NodeGroupMembers) - 1
 			}
 		}
 		latestReplicaCounts[*latestShard.NodeGroupID] = latestReplicaCount


### PR DESCRIPTION
Issue #377 

Description of changes:
Updated the logic to compute the replica count as `NodeGroupMembers - 1` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
