### PR TITLE
install mockery into bin/mockery always

### DIFF
--- a/.github/workflows/build-unit-test.yaml
+++ b/.github/workflows/build-unit-test.yaml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v2
-      - name: install mockery
-        run: ./scripts/install_mockery.sh
       - name: make test
         run: make test
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ DOCKER_PASSWORD ?= ""
 PKGS=$(sort $(dir $(wildcard pkg/*/*/)))
 MOCKS=$(foreach x, $(PKGS), mocks/$(x))
 
-MOCKERY_BIN=$(shell which mockery || "./bin/mockery")
 AWS_SERVICE=$(shell echo $(SERVICE) | tr '[:upper:]' '[:lower:]')
 
 # Build ldflags
@@ -58,10 +57,15 @@ delete-all-kind-clusters:	## Delete all local kind clusters
 	done
 	@rm -rf build/tmp-test*
 
-mocks: $(MOCKS)	## Run mock tests
+install-mockery:
+	@scripts/install-mockery.sh
+
+mocks: install-mockery $(MOCKS)	## Run mock tests
 
 $(MOCKS): mocks/% : %
-	${MOCKERY_BIN} --tags=codegen --case=underscore --output=$@ --dir=$^ --all
+	@echo -n "building mocks for $^... "
+	@bin/mockery --quiet --all --tags=codegen --case=underscore --output=$@ --dir=$^
+	@echo "ok."
 
 help:           ## Show this help.
 	@grep -F -h "##" $(MAKEFILE_LIST) | grep -F -v grep | sed -e 's/\\$$//' \

--- a/scripts/install-mockery.sh
+++ b/scripts/install-mockery.sh
@@ -14,12 +14,12 @@ OS=$(uname -s)
 ARCH=$(uname -m)
 VERSION=2.2.2
 MOCKERY_RELEASE_URL="https://github.com/vektra/mockery/releases/download/v${VERSION}/mockery_${VERSION}_${OS}_${ARCH}.tar.gz"
-source "$SCRIPTS_DIR/lib/common.sh"
 
-if ! is_installed mockery; then
+if [[ ! -f $BIN_DIR/mockery ]]; then
+    echo -n "Installing mockery into bin/mockery ... "
     mkdir -p $BIN_DIR
     cd $BIN_DIR
     wget -q --no-check-certificate --content-disposition $MOCKERY_RELEASE_URL -O mockery.tar.gz
-    tar -xvf mockery.tar.gz
-    export PATH="$PATH:$BIN_DIR"
+    tar -xf mockery.tar.gz
+    echo "ok."
 fi


### PR DESCRIPTION
Modifies the `make` targets that create mocks to rely on installing
`mockery` v2.2.0 always into `bin/mockery`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
