### PR TITLE
Fixed the ENV variable error

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -43,7 +43,8 @@ jobs:
           SERVICE: ${{ matrix.service }}
       - name: execute e2e tests
         run: |
-          export AWS_ROLE_ARN=${{ secrets.AWS_ROLE_ARN }}
+          export AWS_ROLE_ARN=$(aws ssm get-parameter --name ACK_ROLE_ARN | jq -r '.Parameter.Value')
+          export AWS_ROLE_ARN_ALT=$(aws ssm get-parameter --name ACK_ROLE_ARN_ALT | jq -r '.Parameter.Value')
           ./scripts/kind-build-test.sh -s $SERVICE -r $AWS_ROLE_ARN
         env:
           SERVICE: ${{ matrix.service }}


### PR DESCRIPTION
Issue #, if available:

```
 export AWS_ROLE_ARN=
  ./scripts/kind-build-test.sh -s $SERVICE -r $AWS_ROLE_ARN
  shell: /usr/bin/bash -e {0}
  env:
    GOROOT: /home/ssm-user/actions-runner/_work/_tool/go/1.15.2/x64
    SERVICE: s3
./scripts/kind-build-test.sh: option requires an argument -- r
```

Description of changes: 
- The GitHub secrets were not being passed as a `env` variable for forked repos
- Added `AWS_ROLE_ARN` and `AWS_ROLE_ARN_ALT` exports by reading the SSM parameters

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
