### PR TITLE
`replacePkgName` handle cases of nested slices and nested maps

### DIFF
--- a/pkg/generate/generator.go
+++ b/pkg/generate/generator.go
@@ -239,10 +239,11 @@ func (g *Generator) GetTypeDefs() ([]*ackmodel.TypeDef, map[string]string, error
 			if strings.Contains(goPkgType, ".") {
 				if strings.HasPrefix(goPkgType, "[]") {
 					// For slice types, we just want the element type...
-					goPkgType = goPkgType[2:]
+					goPkgType = strings.TrimLeft(goPkgType, "[]")
 				}
 				if strings.HasPrefix(goPkgType, "map[") {
-					goPkgType = strings.Split(goPkgType, "]")[1]
+					// Assuming the map keys are always of type string.
+					goPkgType = strings.TrimLeft(goPkgType, "map[string]")
 				}
 				if strings.HasPrefix(goPkgType, "*") {
 					// For slice and map types, the element type might be a

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -1329,7 +1329,7 @@ func (r *CRD) goCodeVarEmptyConstructorSDKType(
 	indent := strings.Repeat("\t", indentLevel)
 	goType := shape.GoTypeWithPkgName()
 	keepPointer := (shape.Type == "list" || shape.Type == "map")
-	goType = r.replacePkgName(goType, "svcsdk", keepPointer)
+	goType = replacePkgName(goType, r.sdkAPI.API.PackageName(), "svcsdk", keepPointer)
 	switch shape.Type {
 	case "structure":
 		// f0 := &svcsdk.BookData{}
@@ -1355,7 +1355,7 @@ func (r *CRD) goCodeVarEmptyConstructorK8sType(
 	indent := strings.Repeat("\t", indentLevel)
 	goType := shape.GoTypeWithPkgName()
 	keepPointer := (shape.Type == "list" || shape.Type == "map")
-	goType = r.replacePkgName(goType, "svcapitypes", keepPointer)
+	goType = replacePkgName(goType, r.sdkAPI.API.PackageName(), "svcapitypes", keepPointer)
 	goTypeNoPkg := goType
 	goPkg := ""
 	hadPkg := false
@@ -2294,19 +2294,25 @@ func (r *CRD) goCodeSetOutputForScalar(
 // Shape.GoTypeWithPkgName() and replaces the package name of the aws-sdk-go
 // SDK API (e.g. "ecr" for the ECR API) with the string "svcsdkapi" which is
 // the only alias we always use in our templated output.
-func (r *CRD) replacePkgName(
+func replacePkgName(
 	subject string,
+	apiPkgName string,
 	replacePkgAlias string,
 	keepPointer bool,
 ) string {
 	memberType := subject
+	sliceDepth := 0 // Depth of the slice type
 	isSliceType := strings.HasPrefix(memberType, "[]")
 	if isSliceType {
-		memberType = memberType[2:]
+		sliceDepth = strings.LastIndex(subject, "[]")/2 + 1
+		memberType = memberType[sliceDepth*2:]
 	}
+	mapDepth := 0 // Depth of the map type
+	// Assuming the map keys are always of type string.
 	isMapType := strings.HasPrefix(memberType, "map[string]")
 	if isMapType {
-		memberType = memberType[11:]
+		mapDepth = strings.LastIndex(subject, "map[string]")/11 + 1
+		memberType = memberType[mapDepth*11:]
 	}
 	isPointerType := strings.HasPrefix(memberType, "*")
 	if isPointerType {
@@ -2318,11 +2324,9 @@ func (r *CRD) replacePkgName(
 	if strings.Contains(memberType, ".") {
 		pkgName := strings.Split(memberType, ".")[0]
 		typeName := strings.Split(memberType, ".")[1]
-		apiPkgName := r.sdkAPI.API.PackageName()
 		if pkgName == apiPkgName {
 			memberType = replacePkgAlias + "." + typeName
 		} else {
-			// Leave package prefixes like "time." alone...
 			memberType = pkgName + "." + typeName
 		}
 	}
@@ -2330,10 +2334,10 @@ func (r *CRD) replacePkgName(
 		memberType = "*" + memberType
 	}
 	if isMapType {
-		memberType = "map[string]" + memberType
+		memberType = strings.Repeat("map[string]", mapDepth) + memberType
 	}
 	if isSliceType {
-		memberType = "[]" + memberType
+		memberType = strings.Repeat("[]", sliceDepth) + memberType
 	}
 	return memberType
 }

--- a/pkg/model/crd_test.go
+++ b/pkg/model/crd_test.go
@@ -1,0 +1,78 @@
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReplacePkgName(t *testing.T) {
+	assert := assert.New(t)
+	testCases := []struct {
+		subject         string
+		pkgName         string
+		replacePkgAlias string
+		keepPointer     bool
+		want            string
+	}{
+		{ // most frequent case
+			"*ecr.Repository",
+			"ecr",
+			"svcsdk",
+			true,
+			"*svcsdk.Repository",
+		},
+		{ // don't keep pointer
+			"*ecr.Repository",
+			"ecr",
+			"svcsdk",
+			false,
+			"svcsdk.Repository",
+		},
+		{ // non sdk type
+			"*time.Time",
+			"ecr",
+			"svcsdk",
+			true,
+			"*time.Time",
+		},
+		{ // map type
+			"map[string]*ecr.Repository",
+			"ecr",
+			"svcsdk",
+			true,
+			"map[string]*svcsdk.Repository",
+		},
+		{ // nested map type
+			"map[string]map[string]uint8",
+			"ec2",
+			"svcsdk",
+			true,
+			"map[string]map[string]uint8",
+		},
+		{ // slice type
+			"[]ecr.Repository",
+			"ecr",
+			"svcsdk",
+			true,
+			"[]svcsdk.Repository",
+		},
+		{ // nested slices type
+			"[][]*codedeploy.EC2TagFilter",
+			"codedeploy",
+			"svcsdk",
+			true,
+			"[][]*svcsdk.EC2TagFilter",
+		},
+	}
+
+	for _, tc := range testCases {
+		result := replacePkgName(
+			tc.subject,
+			tc.pkgName,
+			tc.replacePkgAlias,
+			tc.keepPointer,
+		)
+		assert.Equal(tc.want, result)
+	}
+}


### PR DESCRIPTION
Issue N/A

Description of changes:
- `replacePkgName` handle cases where `goType` is a nested slice or a nested map
- detach `replacePkgName` from `model.CRD` and change it signature
- Add unit tests for `replacePkgName`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
