### PR TITLE
remove reference to CLA

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,5 +49,3 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## Licensing
 See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
-
-We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.


### PR DESCRIPTION
Our open source program office has consulted with our legal folks and
determined that this mention of a CLA in our CONTRIBUTING docs was
neither necessary nor desired.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
