### PR TITLE
Update status after Read operation and Requeue sync based on Conditions

### DIFF
--- a/pkg/compare/reporter.go
+++ b/pkg/compare/reporter.go
@@ -8,12 +8,10 @@ import (
 
 type DiffItem struct {
 	Path string
-	ValueA string
-	ValueB string
 }
 
 func (diff *DiffItem) String() string {
-	return fmt.Sprintf("%#v:\n\t-: %+v\n\t+: %+v\n", diff.Path, diff.ValueA, diff.ValueB)
+	return fmt.Sprintf("%#v\n", diff.Path)
 }
 
 type Reporter struct {
@@ -31,8 +29,7 @@ func (reporter *Reporter) PopStep() {
 
 func (reporter *Reporter) Report(result cmp.Result) {
 	if !result.Equal() {
-		a, b := reporter.path.Last().Values()
-		reporter.Differences = append(reporter.Differences, DiffItem{reporter.path.String(), fmt.Sprintf("%v",a), fmt.Sprintf("%v",b)});
+		reporter.Differences = append(reporter.Differences, DiffItem{reporter.path.String()})
 	}
 }
 

--- a/pkg/requeue/requeue.go
+++ b/pkg/requeue/requeue.go
@@ -17,6 +17,11 @@ import (
 	"time"
 )
 
+
+const (
+	DefaultRequeueAfterDuration time.Duration = 30 * time.Second
+)
+
 // Needed returns a new RequeueNeeded to instruct the ACK runtime to requeue
 // the processing item without been logged as error.
 func Needed(err error) *RequeueNeeded {

--- a/scripts/lib/aws_elasticache_testutil.sh
+++ b/scripts/lib/aws_elasticache_testutil.sh
@@ -122,7 +122,6 @@ spec:
     engine: redis
     replicationGroupID: $rg_id
     replicationGroupDescription: $rg_description
-    automaticFailover: true
     cacheNodeType: cache.t3.micro
     numNodeGroups: $num_node_groups
     replicasPerNodeGroup: $replicas_per_node_group

--- a/services/apigatewayv2/pkg/resource/api/sdk.go
+++ b/services/apigatewayv2/pkg/resource/api/sdk.go
@@ -177,6 +177,13 @@ func (rm *resourceManager) sdkFind(
 		ko.Status.Warnings = f15
 	}
 
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	return &resource{ko}, nil
 }
 
@@ -271,6 +278,7 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 

--- a/services/apigatewayv2/pkg/resource/api_mapping/sdk.go
+++ b/services/apigatewayv2/pkg/resource/api_mapping/sdk.go
@@ -80,6 +80,13 @@ func (rm *resourceManager) sdkFind(
 		ko.Spec.Stage = resp.Stage
 	}
 
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	return &resource{ko}, nil
 }
 
@@ -154,6 +161,7 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 

--- a/services/apigatewayv2/pkg/resource/authorizer/sdk.go
+++ b/services/apigatewayv2/pkg/resource/authorizer/sdk.go
@@ -120,6 +120,13 @@ func (rm *resourceManager) sdkFind(
 		ko.Spec.Name = resp.Name
 	}
 
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	return &resource{ko}, nil
 }
 
@@ -194,6 +201,7 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 

--- a/services/apigatewayv2/pkg/resource/deployment/sdk.go
+++ b/services/apigatewayv2/pkg/resource/deployment/sdk.go
@@ -86,6 +86,13 @@ func (rm *resourceManager) sdkFind(
 		ko.Spec.Description = resp.Description
 	}
 
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	return &resource{ko}, nil
 }
 
@@ -172,6 +179,7 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 

--- a/services/apigatewayv2/pkg/resource/domain_name/sdk.go
+++ b/services/apigatewayv2/pkg/resource/domain_name/sdk.go
@@ -128,6 +128,13 @@ func (rm *resourceManager) sdkFind(
 		ko.Spec.Tags = f4
 	}
 
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	return &resource{ko}, nil
 }
 
@@ -195,6 +202,7 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 

--- a/services/apigatewayv2/pkg/resource/integration/sdk.go
+++ b/services/apigatewayv2/pkg/resource/integration/sdk.go
@@ -141,6 +141,13 @@ func (rm *resourceManager) sdkFind(
 		ko.Spec.TLSConfig = f18
 	}
 
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	return &resource{ko}, nil
 }
 
@@ -221,6 +228,7 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 

--- a/services/apigatewayv2/pkg/resource/integration_response/sdk.go
+++ b/services/apigatewayv2/pkg/resource/integration_response/sdk.go
@@ -98,6 +98,13 @@ func (rm *resourceManager) sdkFind(
 		ko.Spec.TemplateSelectionExpression = resp.TemplateSelectionExpression
 	}
 
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	return &resource{ko}, nil
 }
 
@@ -178,6 +185,7 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 

--- a/services/apigatewayv2/pkg/resource/model/sdk.go
+++ b/services/apigatewayv2/pkg/resource/model/sdk.go
@@ -83,6 +83,13 @@ func (rm *resourceManager) sdkFind(
 		ko.Spec.Schema = resp.Schema
 	}
 
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	return &resource{ko}, nil
 }
 
@@ -157,6 +164,7 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 

--- a/services/apigatewayv2/pkg/resource/route/sdk.go
+++ b/services/apigatewayv2/pkg/resource/route/sdk.go
@@ -127,6 +127,13 @@ func (rm *resourceManager) sdkFind(
 		ko.Spec.Target = resp.Target
 	}
 
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	return &resource{ko}, nil
 }
 
@@ -204,6 +211,7 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 

--- a/services/apigatewayv2/pkg/resource/route_response/sdk.go
+++ b/services/apigatewayv2/pkg/resource/route_response/sdk.go
@@ -97,6 +97,13 @@ func (rm *resourceManager) sdkFind(
 		ko.Spec.RouteResponseKey = resp.RouteResponseKey
 	}
 
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	return &resource{ko}, nil
 }
 
@@ -177,6 +184,7 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 

--- a/services/apigatewayv2/pkg/resource/stage/sdk.go
+++ b/services/apigatewayv2/pkg/resource/stage/sdk.go
@@ -165,6 +165,13 @@ func (rm *resourceManager) sdkFind(
 		ko.Spec.Tags = f13
 	}
 
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	return &resource{ko}, nil
 }
 
@@ -248,6 +255,7 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 

--- a/services/apigatewayv2/pkg/resource/vpc_link/sdk.go
+++ b/services/apigatewayv2/pkg/resource/vpc_link/sdk.go
@@ -113,6 +113,13 @@ func (rm *resourceManager) sdkFind(
 		ko.Status.VPCLinkVersion = resp.VpcLinkVersion
 	}
 
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	return &resource{ko}, nil
 }
 
@@ -192,6 +199,7 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 

--- a/services/dynamodb/pkg/resource/backup/sdk.go
+++ b/services/dynamodb/pkg/resource/backup/sdk.go
@@ -67,6 +67,13 @@ func (rm *resourceManager) sdkFind(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	return &resource{ko}, nil
 }
 
@@ -162,6 +169,7 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 

--- a/services/dynamodb/pkg/resource/global_table/sdk.go
+++ b/services/dynamodb/pkg/resource/global_table/sdk.go
@@ -95,6 +95,13 @@ func (rm *resourceManager) sdkFind(
 		ko.Spec.ReplicationGroup = f4
 	}
 
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	return &resource{ko}, nil
 }
 
@@ -172,6 +179,7 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 

--- a/services/dynamodb/pkg/resource/table/sdk.go
+++ b/services/dynamodb/pkg/resource/table/sdk.go
@@ -345,6 +345,13 @@ func (rm *resourceManager) sdkFind(
 		ko.Status.TableStatus = resp.Table.TableStatus
 	}
 
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	return &resource{ko}, nil
 }
 
@@ -543,6 +550,7 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 

--- a/services/ecr/pkg/resource/repository/sdk.go
+++ b/services/ecr/pkg/resource/repository/sdk.go
@@ -116,6 +116,14 @@ func (rm *resourceManager) sdkFind(
 		return nil, ackerr.NotFound
 	}
 
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 
@@ -176,6 +184,7 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 

--- a/services/elasticache/pkg/resource/cache_subnet_group/sdk.go
+++ b/services/elasticache/pkg/resource/cache_subnet_group/sdk.go
@@ -106,6 +106,14 @@ func (rm *resourceManager) sdkFind(
 		return nil, ackerr.NotFound
 	}
 
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 
@@ -178,6 +186,7 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 

--- a/services/elasticache/pkg/resource/replication_group/sdk.go
+++ b/services/elasticache/pkg/resource/replication_group/sdk.go
@@ -244,6 +244,14 @@ func (rm *resourceManager) sdkFind(
 		return nil, ackerr.NotFound
 	}
 
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	// custom set output from response
 	rm.CustomDescribeReplicationGroupsSetOutput(r, resp, ko)
 
@@ -435,9 +443,6 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.Status = resp.ReplicationGroup.Status
 	}
 
-	// custom set output from response
-	rm.CustomCreateReplicationGroupSetOutput(r, resp, ko)
-
 	if ko.Status.ACKResourceMetadata == nil {
 		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
 	}
@@ -445,6 +450,10 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
+	// custom set output from response
+	rm.CustomCreateReplicationGroupSetOutput(r, resp, ko)
+
 	return &resource{ko}, nil
 }
 

--- a/services/s3/pkg/resource/bucket/sdk.go
+++ b/services/s3/pkg/resource/bucket/sdk.go
@@ -80,6 +80,14 @@ func (rm *resourceManager) sdkFind(
 		return nil, ackerr.NotFound
 	}
 
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 
@@ -123,6 +131,7 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 

--- a/services/sns/pkg/resource/platform_application/sdk.go
+++ b/services/sns/pkg/resource/platform_application/sdk.go
@@ -67,6 +67,13 @@ func (rm *resourceManager) sdkFind(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	return &resource{ko}, nil
 }
 
@@ -140,6 +147,7 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 

--- a/services/sns/pkg/resource/platform_endpoint/sdk.go
+++ b/services/sns/pkg/resource/platform_endpoint/sdk.go
@@ -79,6 +79,7 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 

--- a/services/sns/pkg/resource/topic/sdk.go
+++ b/services/sns/pkg/resource/topic/sdk.go
@@ -76,6 +76,13 @@ func (rm *resourceManager) sdkFind(
 	tmpARN := ackv1alpha1.AWSResourceName(*resp.Attributes["TopicArn"])
 	ko.Status.ACKResourceMetadata.ARN = &tmpARN
 
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	return &resource{ko}, nil
 }
 
@@ -149,6 +156,7 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+
 	return &resource{ko}, nil
 }
 

--- a/templates/pkg/crd_sdk.go.tpl
+++ b/templates/pkg/crd_sdk.go.tpl
@@ -61,6 +61,13 @@ func (rm *resourceManager) sdkFind(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 {{ $setCode }}
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	return &resource{ko}, nil
 {{- else if .CRD.Ops.GetAttributes }}
 	// If any required fields in the input shape are missing, AWS resource is
@@ -87,6 +94,13 @@ func (rm *resourceManager) sdkFind(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 {{ $setCode }}
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	return &resource{ko}, nil
 {{- else if .CRD.Ops.ReadMany }}
 	input, err := rm.newListRequestPayload(r)
@@ -106,6 +120,13 @@ func (rm *resourceManager) sdkFind(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 {{ $setCode }}
+	if ko.Status.ACKResourceMetadata == nil {
+		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
+	}
+	if ko.Status.ACKResourceMetadata.OwnerAccountID == nil {
+		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
+	}
+	ko.Status.Conditions = []*ackv1alpha1.Condition{}
 {{ if $setOutputCustomMethodName := .CRD.SetOutputCustomMethodName .CRD.Ops.ReadMany }}
 	// custom set output from response
 	rm.{{ $setOutputCustomMethodName }}(r, resp, ko)
@@ -192,10 +213,6 @@ func (rm *resourceManager) sdkCreate(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 {{ $createCode }}
-{{ if $setOutputCustomMethodName := .CRD.SetOutputCustomMethodName .CRD.Ops.Create }}
-	// custom set output from response
-	rm.{{ $setOutputCustomMethodName }}(r, resp, ko)
-{{ end }}
 	if ko.Status.ACKResourceMetadata == nil {
 		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
 	}
@@ -203,6 +220,10 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.ACKResourceMetadata.OwnerAccountID = &rm.awsAccountID
 	}
 	ko.Status.Conditions = []*ackv1alpha1.Condition{}
+	{{ if $setOutputCustomMethodName := .CRD.SetOutputCustomMethodName .CRD.Ops.Create }}
+		// custom set output from response
+		rm.{{ $setOutputCustomMethodName }}(r, resp, ko)
+	{{ end }}
 	return &resource{ko}, nil
 }
 


### PR DESCRIPTION
Issue #378 

Description of changes:
* Added reconcile logic to Requeue after default interval (based on Conditions).
* Updated reconcile logic to updateCRStatus using already 'read' status (using ReadOne). This helps provide updated status to user when an ongoing operation takes long on remote service side and rm.update() fails due ongoing operation.
  * Added logic to populate `OwnerAccountID` and `Conditions` inside sdkFind, as these is required in ko.Status
* Updated ElastiCache replicationgroup custom update method to check of available state in order to proceed.
* Updated ElastiCache replicationgroup custom output set method to populate `Conditions` with `ConditionTypeResourceSynced`
* Updated diff reporter to not include properties values. It lead to runtime errors when accessing properties using reflection


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
