### PR TITLE
install controller-gen@v0.4.0 in unit test runner

### DIFF
--- a/.github/workflows/build-unit-test.yaml
+++ b/.github/workflows/build-unit-test.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v2
+      - name: install controller-gen@v0.4.0
+        run: go get -u sigs.k8s.io/controller-tools@v0.4.0
       - name: make test
         run: make test
 
@@ -37,6 +39,8 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v2
+      - name: install controller-gen@v0.4.0
+        run: go get -u sigs.k8s.io/controller-tools@v0.4.0
       - name: build service controller
         run: |
           export PATH=$PATH:$(go env GOPATH)/bin


### PR DESCRIPTION
Need to manually ensure controller-gen@v0.4.0 is installed for the unit test runners.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
