### PR TITLE
GH actions workflow changes

### DIFF
--- a/.github/workflows/build-unit-test.yaml
+++ b/.github/workflows/build-unit-test.yaml
@@ -1,5 +1,7 @@
 name: build-unit-test
 on:
+  # Allow manual trigger of e2e tests
+  workflow_dispatch:
   pull_request:
     branches:
       - main

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -2,15 +2,6 @@ name: e2e-test
 on:
   # Allow manual trigger of e2e tests
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - '**.go'
-      - Makefile
-      - '**.tpl'
-      - go.mod
-      - go.sum
 
 jobs:
   test-controllers:


### PR DESCRIPTION
* allow build-unit-test to be manually triggered
* ONLY allow e2e-test to be manually triggered (for now... soon we will
  set up an integration branch to run against on a periodic)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
