### PR TITLE
instrument top-level AWS API call metrics

### DIFF
--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -47,3 +47,22 @@ func AWSError(err error) (awserr.Error, bool) {
 	awsErr, ok := err.(awserr.Error)
 	return awsErr, ok
 }
+
+// AWSRequestFailure returns the type conversion for the supplied error to an
+// aws-sdk-go RequestFailure interface
+func AWSRequestFailure(err error) (awserr.RequestFailure, bool) {
+	awsRF, ok := err.(awserr.RequestFailure)
+	return awsRF, ok
+}
+
+// HTTPStatusCode returns the HTTP status code from the supplied error by
+// introspecting the error to see if it's an awserr.RequestFailure interface
+// and if so, calling StatusCode() on that type-converted RequestFailure. If
+// the type conversion fails, returns -1
+func HTTPStatusCode(err error) int {
+	awsRF, ok := AWSRequestFailure(err)
+	if !ok {
+		return -1
+	}
+	return awsRF.StatusCode()
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -16,6 +16,8 @@ package metrics
 import (
 	"strconv"
 
+	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -70,19 +72,18 @@ func (m *Metrics) RecordAPICall(
 	opType string,
 	// The name of the AWS API call, e.g. "CreateTopic"
 	opID string,
-	// The HTTP status code returned from the AWS API call
-	statusCode int,
 	// Any error that was returned from the aws-sdk-go client call
 	err error,
 ) {
 	m.obAPIRequestTotal.With(
 		prometheus.Labels{
 			"service": m.serviceID,
-			"op_type": string(opType),
+			"op_type": opType,
 			"op_id":   opID,
 		},
 	).Inc()
-	if statusCode >= 400 && statusCode < 600 {
+	if err != nil {
+		statusCode := ackerr.HTTPStatusCode(err)
 		m.obAPIRequestErrorTotal.With(
 			prometheus.Labels{
 				"service":     m.serviceID,

--- a/services/apigatewayv2/pkg/resource/api/sdk.go
+++ b/services/apigatewayv2/pkg/resource/api/sdk.go
@@ -56,6 +56,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	resp, respErr := rm.sdkapi.GetApiWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_ONE", "GetApi", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
@@ -227,6 +228,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	resp, respErr := rm.sdkapi.CreateApiWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateApi", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -384,6 +386,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	resp, respErr := rm.sdkapi.UpdateApiWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "UpdateApi", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -527,6 +530,7 @@ func (rm *resourceManager) sdkDelete(
 		return err
 	}
 	_, respErr := rm.sdkapi.DeleteApiWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "DeleteApi", respErr)
 	return respErr
 }
 

--- a/services/apigatewayv2/pkg/resource/api_mapping/sdk.go
+++ b/services/apigatewayv2/pkg/resource/api_mapping/sdk.go
@@ -56,6 +56,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	resp, respErr := rm.sdkapi.GetApiMappingWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_ONE", "GetApiMapping", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
@@ -137,6 +138,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	resp, respErr := rm.sdkapi.CreateApiMappingWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateApiMapping", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -191,6 +193,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	resp, respErr := rm.sdkapi.UpdateApiMappingWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "UpdateApiMapping", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -243,6 +246,7 @@ func (rm *resourceManager) sdkDelete(
 		return err
 	}
 	_, respErr := rm.sdkapi.DeleteApiMappingWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "DeleteApiMapping", respErr)
 	return respErr
 }
 

--- a/services/apigatewayv2/pkg/resource/authorizer/sdk.go
+++ b/services/apigatewayv2/pkg/resource/authorizer/sdk.go
@@ -56,6 +56,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	resp, respErr := rm.sdkapi.GetAuthorizerWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_ONE", "GetAuthorizer", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
@@ -177,6 +178,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	resp, respErr := rm.sdkapi.CreateAuthorizerWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateAuthorizer", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -271,6 +273,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	resp, respErr := rm.sdkapi.UpdateAuthorizerWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "UpdateAuthorizer", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -363,6 +366,7 @@ func (rm *resourceManager) sdkDelete(
 		return err
 	}
 	_, respErr := rm.sdkapi.DeleteAuthorizerWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "DeleteAuthorizer", respErr)
 	return respErr
 }
 

--- a/services/apigatewayv2/pkg/resource/deployment/sdk.go
+++ b/services/apigatewayv2/pkg/resource/deployment/sdk.go
@@ -56,6 +56,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	resp, respErr := rm.sdkapi.GetDeploymentWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_ONE", "GetDeployment", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
@@ -143,6 +144,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	resp, respErr := rm.sdkapi.CreateDeploymentWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateDeployment", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -206,6 +208,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	resp, respErr := rm.sdkapi.UpdateDeploymentWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "UpdateDeployment", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -264,6 +267,7 @@ func (rm *resourceManager) sdkDelete(
 		return err
 	}
 	_, respErr := rm.sdkapi.DeleteDeploymentWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "DeleteDeployment", respErr)
 	return respErr
 }
 

--- a/services/apigatewayv2/pkg/resource/domain_name/sdk.go
+++ b/services/apigatewayv2/pkg/resource/domain_name/sdk.go
@@ -56,6 +56,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	resp, respErr := rm.sdkapi.GetDomainNameWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_ONE", "GetDomainName", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
@@ -178,6 +179,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	resp, respErr := rm.sdkapi.CreateDomainNameWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateDomainName", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -277,6 +279,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	resp, respErr := rm.sdkapi.UpdateDomainNameWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "UpdateDomainName", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -362,6 +365,7 @@ func (rm *resourceManager) sdkDelete(
 		return err
 	}
 	_, respErr := rm.sdkapi.DeleteDomainNameWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "DeleteDomainName", respErr)
 	return respErr
 }
 

--- a/services/apigatewayv2/pkg/resource/integration/sdk.go
+++ b/services/apigatewayv2/pkg/resource/integration/sdk.go
@@ -56,6 +56,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	resp, respErr := rm.sdkapi.GetIntegrationWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_ONE", "GetIntegration", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
@@ -198,6 +199,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	resp, respErr := rm.sdkapi.CreateIntegrationWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateIntegration", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -313,6 +315,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	resp, respErr := rm.sdkapi.UpdateIntegrationWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "UpdateIntegration", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -426,6 +429,7 @@ func (rm *resourceManager) sdkDelete(
 		return err
 	}
 	_, respErr := rm.sdkapi.DeleteIntegrationWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "DeleteIntegration", respErr)
 	return respErr
 }
 

--- a/services/apigatewayv2/pkg/resource/integration_response/sdk.go
+++ b/services/apigatewayv2/pkg/resource/integration_response/sdk.go
@@ -56,6 +56,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	resp, respErr := rm.sdkapi.GetIntegrationResponseWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_ONE", "GetIntegrationResponse", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
@@ -161,6 +162,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	resp, respErr := rm.sdkapi.CreateIntegrationResponseWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateIntegrationResponse", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -236,6 +238,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	resp, respErr := rm.sdkapi.UpdateIntegrationResponseWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "UpdateIntegrationResponse", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -309,6 +312,7 @@ func (rm *resourceManager) sdkDelete(
 		return err
 	}
 	_, respErr := rm.sdkapi.DeleteIntegrationResponseWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "DeleteIntegrationResponse", respErr)
 	return respErr
 }
 

--- a/services/apigatewayv2/pkg/resource/model/sdk.go
+++ b/services/apigatewayv2/pkg/resource/model/sdk.go
@@ -56,6 +56,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	resp, respErr := rm.sdkapi.GetModelWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_ONE", "GetModel", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
@@ -140,6 +141,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	resp, respErr := rm.sdkapi.CreateModelWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateModel", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -197,6 +199,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	resp, respErr := rm.sdkapi.UpdateModelWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "UpdateModel", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -252,6 +255,7 @@ func (rm *resourceManager) sdkDelete(
 		return err
 	}
 	_, respErr := rm.sdkapi.DeleteModelWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "DeleteModel", respErr)
 	return respErr
 }
 

--- a/services/apigatewayv2/pkg/resource/route/sdk.go
+++ b/services/apigatewayv2/pkg/resource/route/sdk.go
@@ -56,6 +56,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	resp, respErr := rm.sdkapi.GetRouteWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_ONE", "GetRoute", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
@@ -184,6 +185,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	resp, respErr := rm.sdkapi.CreateRouteWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateRoute", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -285,6 +287,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	resp, respErr := rm.sdkapi.UpdateRouteWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "UpdateRoute", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -384,6 +387,7 @@ func (rm *resourceManager) sdkDelete(
 		return err
 	}
 	_, respErr := rm.sdkapi.DeleteRouteWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "DeleteRoute", respErr)
 	return respErr
 }
 

--- a/services/apigatewayv2/pkg/resource/route_response/sdk.go
+++ b/services/apigatewayv2/pkg/resource/route_response/sdk.go
@@ -56,6 +56,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	resp, respErr := rm.sdkapi.GetRouteResponseWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_ONE", "GetRouteResponse", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
@@ -160,6 +161,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	resp, respErr := rm.sdkapi.CreateRouteResponseWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateRouteResponse", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -234,6 +236,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	resp, respErr := rm.sdkapi.UpdateRouteResponseWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "UpdateRouteResponse", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -306,6 +309,7 @@ func (rm *resourceManager) sdkDelete(
 		return err
 	}
 	_, respErr := rm.sdkapi.DeleteRouteResponseWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "DeleteRouteResponse", respErr)
 	return respErr
 }
 

--- a/services/apigatewayv2/pkg/resource/stage/sdk.go
+++ b/services/apigatewayv2/pkg/resource/stage/sdk.go
@@ -56,6 +56,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	resp, respErr := rm.sdkapi.GetStageWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_ONE", "GetStage", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
@@ -222,6 +223,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	resp, respErr := rm.sdkapi.CreateStageWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateStage", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -361,6 +363,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	resp, respErr := rm.sdkapi.UpdateStageWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "UpdateStage", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -486,6 +489,7 @@ func (rm *resourceManager) sdkDelete(
 		return err
 	}
 	_, respErr := rm.sdkapi.DeleteStageWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "DeleteStage", respErr)
 	return respErr
 }
 

--- a/services/apigatewayv2/pkg/resource/vpc_link/sdk.go
+++ b/services/apigatewayv2/pkg/resource/vpc_link/sdk.go
@@ -56,6 +56,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	resp, respErr := rm.sdkapi.GetVpcLinkWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_ONE", "GetVpcLink", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
@@ -163,6 +164,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	resp, respErr := rm.sdkapi.CreateVpcLinkWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateVpcLink", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -247,6 +249,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	resp, respErr := rm.sdkapi.UpdateVpcLinkWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "UpdateVpcLink", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -302,6 +305,7 @@ func (rm *resourceManager) sdkDelete(
 		return err
 	}
 	_, respErr := rm.sdkapi.DeleteVpcLinkWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "DeleteVpcLink", respErr)
 	return respErr
 }
 

--- a/services/dynamodb/pkg/resource/backup/sdk.go
+++ b/services/dynamodb/pkg/resource/backup/sdk.go
@@ -56,6 +56,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	_, respErr := rm.sdkapi.DescribeBackupWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_ONE", "DescribeBackup", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "UNKNOWN" {
 			return nil, ackerr.NotFound
@@ -126,6 +127,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	resp, respErr := rm.sdkapi.CreateBackupWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateBackup", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -200,6 +202,7 @@ func (rm *resourceManager) sdkDelete(
 		return err
 	}
 	_, respErr := rm.sdkapi.DeleteBackupWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "DeleteBackup", respErr)
 	return respErr
 }
 

--- a/services/dynamodb/pkg/resource/global_table/sdk.go
+++ b/services/dynamodb/pkg/resource/global_table/sdk.go
@@ -56,6 +56,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	resp, respErr := rm.sdkapi.DescribeGlobalTableWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_ONE", "DescribeGlobalTable", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "UNKNOWN" {
 			return nil, ackerr.NotFound
@@ -145,6 +146,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	resp, respErr := rm.sdkapi.CreateGlobalTableWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateGlobalTable", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -211,6 +213,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	resp, respErr := rm.sdkapi.UpdateGlobalTableWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "UpdateGlobalTable", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}

--- a/services/dynamodb/pkg/resource/table/sdk.go
+++ b/services/dynamodb/pkg/resource/table/sdk.go
@@ -56,6 +56,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	resp, respErr := rm.sdkapi.DescribeTableWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_ONE", "DescribeTable", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "ResourceNotFoundException" {
 			return nil, ackerr.NotFound
@@ -395,6 +396,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	resp, respErr := rm.sdkapi.CreateTableWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateTable", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -741,6 +743,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	resp, respErr := rm.sdkapi.UpdateTableWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "UpdateTable", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -962,6 +965,7 @@ func (rm *resourceManager) sdkDelete(
 		return err
 	}
 	_, respErr := rm.sdkapi.DeleteTableWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "DeleteTable", respErr)
 	return respErr
 }
 

--- a/services/ecr/pkg/resource/repository/sdk.go
+++ b/services/ecr/pkg/resource/repository/sdk.go
@@ -49,6 +49,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	resp, respErr := rm.sdkapi.DescribeRepositoriesWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_MANY", "DescribeRepositories", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "RepositoryNotFoundException" {
 			return nil, ackerr.NotFound
@@ -147,6 +148,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	resp, respErr := rm.sdkapi.CreateRepositoryWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateRepository", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -245,6 +247,7 @@ func (rm *resourceManager) sdkDelete(
 		return err
 	}
 	_, respErr := rm.sdkapi.DeleteRepositoryWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "DeleteRepository", respErr)
 	return respErr
 }
 

--- a/services/elasticache/pkg/resource/cache_subnet_group/sdk.go
+++ b/services/elasticache/pkg/resource/cache_subnet_group/sdk.go
@@ -49,6 +49,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	resp, respErr := rm.sdkapi.DescribeCacheSubnetGroupsWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_MANY", "DescribeCacheSubnetGroups", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "CacheSubnetGroupNotFoundFault" {
 			return nil, ackerr.NotFound
@@ -137,6 +138,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	resp, respErr := rm.sdkapi.CreateCacheSubnetGroupWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateCacheSubnetGroup", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -219,6 +221,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	resp, respErr := rm.sdkapi.ModifyCacheSubnetGroupWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "ModifyCacheSubnetGroup", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -296,6 +299,7 @@ func (rm *resourceManager) sdkDelete(
 		return err
 	}
 	_, respErr := rm.sdkapi.DeleteCacheSubnetGroupWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "DeleteCacheSubnetGroup", respErr)
 	return respErr
 }
 

--- a/services/elasticache/pkg/resource/replication_group/sdk.go
+++ b/services/elasticache/pkg/resource/replication_group/sdk.go
@@ -49,6 +49,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	resp, respErr := rm.sdkapi.DescribeReplicationGroupsWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_MANY", "DescribeReplicationGroups", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "ReplicationGroupNotFoundFault" {
 			return nil, ackerr.NotFound
@@ -278,6 +279,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	resp, respErr := rm.sdkapi.CreateReplicationGroupWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateReplicationGroup", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -630,6 +632,7 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	resp, respErr := rm.sdkapi.ModifyReplicationGroupWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "ModifyReplicationGroup", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -882,6 +885,7 @@ func (rm *resourceManager) sdkDelete(
 		return err
 	}
 	_, respErr := rm.sdkapi.DeleteReplicationGroupWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "DeleteReplicationGroup", respErr)
 	return respErr
 }
 

--- a/services/s3/pkg/resource/bucket/sdk.go
+++ b/services/s3/pkg/resource/bucket/sdk.go
@@ -49,6 +49,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	resp, respErr := rm.sdkapi.ListBucketsWithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_MANY", "ListBuckets", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "UNKNOWN" {
 			return nil, ackerr.NotFound
@@ -107,6 +108,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	resp, respErr := rm.sdkapi.CreateBucketWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateBucket", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -187,6 +189,7 @@ func (rm *resourceManager) sdkDelete(
 		return err
 	}
 	_, respErr := rm.sdkapi.DeleteBucketWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "DeleteBucket", respErr)
 	return respErr
 }
 

--- a/services/sns/pkg/resource/platform_application/sdk.go
+++ b/services/sns/pkg/resource/platform_application/sdk.go
@@ -56,6 +56,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	_, respErr := rm.sdkapi.GetPlatformApplicationAttributesWithContext(ctx, input)
+	rm.metrics.RecordAPICall("GET_ATTRIBUTES", "GetPlatformApplicationAttributes", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFound" {
 			return nil, ackerr.NotFound
@@ -119,6 +120,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	resp, respErr := rm.sdkapi.CreatePlatformApplicationWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreatePlatformApplication", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -210,6 +212,7 @@ func (rm *resourceManager) sdkUpdate(
 	// DeepCopy of the supplied desired state, which should be fine because
 	// that desired state has been constructed from a call to GetAttributes...
 	_, respErr := rm.sdkapi.SetPlatformApplicationAttributesWithContext(ctx, input)
+	rm.metrics.RecordAPICall("SET_ATTRIBUTES", "SetPlatformApplicationAttributes", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFound" {
 			// Technically, this means someone deleted the backend resource in
@@ -291,6 +294,7 @@ func (rm *resourceManager) sdkDelete(
 		return err
 	}
 	_, respErr := rm.sdkapi.DeletePlatformApplicationWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "DeletePlatformApplication", respErr)
 	return respErr
 }
 

--- a/services/sns/pkg/resource/platform_endpoint/sdk.go
+++ b/services/sns/pkg/resource/platform_endpoint/sdk.go
@@ -61,6 +61,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	resp, respErr := rm.sdkapi.CreatePlatformEndpointWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreatePlatformEndpoint", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}

--- a/services/sns/pkg/resource/topic/sdk.go
+++ b/services/sns/pkg/resource/topic/sdk.go
@@ -56,6 +56,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	resp, respErr := rm.sdkapi.GetTopicAttributesWithContext(ctx, input)
+	rm.metrics.RecordAPICall("GET_ATTRIBUTES", "GetTopicAttributes", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFound" {
 			return nil, ackerr.NotFound
@@ -128,6 +129,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	resp, respErr := rm.sdkapi.CreateTopicWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "CreateTopic", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -215,6 +217,7 @@ func (rm *resourceManager) sdkUpdate(
 	// DeepCopy of the supplied desired state, which should be fine because
 	// that desired state has been constructed from a call to GetAttributes...
 	_, respErr := rm.sdkapi.SetTopicAttributesWithContext(ctx, input)
+	rm.metrics.RecordAPICall("SET_ATTRIBUTES", "SetTopicAttributes", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFound" {
 			// Technically, this means someone deleted the backend resource in
@@ -261,6 +264,7 @@ func (rm *resourceManager) sdkDelete(
 		return err
 	}
 	_, respErr := rm.sdkapi.DeleteTopicWithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "DeleteTopic", respErr)
 	return respErr
 }
 

--- a/templates/pkg/crd_sdk.go.tpl
+++ b/templates/pkg/crd_sdk.go.tpl
@@ -50,6 +50,7 @@ func (rm *resourceManager) sdkFind(
 	}
 {{ $setCode := GoCodeSetReadOneOutput .CRD "resp" "ko" 1 true }}
 	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.ReadOne.Name }}WithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_ONE", "{{ .CRD.Ops.ReadOne.Name }}", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceExceptionCode .CRD 404 }}" {
 			return nil, ackerr.NotFound
@@ -77,6 +78,7 @@ func (rm *resourceManager) sdkFind(
 	}
 {{ $setCode := GoCodeGetAttributesSetOutput .CRD "resp" "ko.Status" 1 }}
 	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.GetAttributes.Name }}WithContext(ctx, input)
+	rm.metrics.RecordAPICall("GET_ATTRIBUTES", "{{ .CRD.Ops.GetAttributes.Name }}", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceExceptionCode .CRD 404 }}" {
 			return nil, ackerr.NotFound
@@ -97,6 +99,7 @@ func (rm *resourceManager) sdkFind(
 	}
 {{ $setCode := GoCodeSetReadManyOutput .CRD "resp" "ko" 1 true }}
 	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.ReadMany.Name }}WithContext(ctx, input)
+	rm.metrics.RecordAPICall("READ_MANY", "{{ .CRD.Ops.ReadMany.Name }}", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceExceptionCode .CRD 404 }}" {
 			return nil, ackerr.NotFound
@@ -188,6 +191,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 {{ $createCode := GoCodeSetCreateOutput .CRD "resp" "ko" 1 false }}
 	{{ if not ( Empty $createCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.Create.Name }}WithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "{{ .CRD.Ops.Create.Name }}", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -222,7 +226,7 @@ func (rm *resourceManager) sdkUpdate(
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 {{- if .CRD.CustomUpdateMethodName }}
-    return rm.{{ .CRD.CustomUpdateMethodName }}(ctx, desired, latest, diffReporter)
+	return rm.{{ .CRD.CustomUpdateMethodName }}(ctx, desired, latest, diffReporter)
 {{- else if .CRD.Ops.Update }}
 
 {{ $customMethod := .CRD.GetCustomImplementation .CRD.Ops.Update }}
@@ -240,6 +244,7 @@ func (rm *resourceManager) sdkUpdate(
 
 {{ $setCode := GoCodeSetUpdateOutput .CRD "resp" "ko" 1 false }}
 	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.Update.Name }}WithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "{{ .CRD.Ops.Update.Name }}", respErr)
 	if respErr != nil {
 		return nil, respErr
 	}
@@ -247,7 +252,7 @@ func (rm *resourceManager) sdkUpdate(
 	// the original Kubernetes object we passed to the function
 	ko := desired.ko.DeepCopy()
 {{ $setCode }}
-    rm.setStatusDefaults(ko)
+	rm.setStatusDefaults(ko)
 {{ if $setOutputCustomMethodName := .CRD.SetOutputCustomMethodName .CRD.Ops.Update }}
 	// custom set output from response
 	rm.{{ $setOutputCustomMethodName }}(desired, resp, ko)
@@ -271,6 +276,7 @@ func (rm *resourceManager) sdkUpdate(
 	// DeepCopy of the supplied desired state, which should be fine because
 	// that desired state has been constructed from a call to GetAttributes...
 	_, respErr := rm.sdkapi.{{ .CRD.Ops.SetAttributes.Name }}WithContext(ctx, input)
+	rm.metrics.RecordAPICall("SET_ATTRIBUTES", "{{ .CRD.Ops.SetAttributes.Name }}", respErr)
 	if respErr != nil {
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceExceptionCode .CRD 404 }}" {
 			// Technically, this means someone deleted the backend resource in
@@ -335,6 +341,7 @@ func (rm *resourceManager) sdkDelete(
 		return err
 	}
 	_, respErr := rm.sdkapi.{{ .CRD.Ops.Delete.Name }}WithContext(ctx, input)
+	rm.metrics.RecordAPICall("DELETE", "{{ .CRD.Ops.Delete.Name }}", respErr)
 	return respErr
 {{- else }}
 	// TODO(jaypipes): Figure this out...


### PR DESCRIPTION
Adds instrumentation into the sdk.go template to record API calls
made by the `resourceManager` against a backend AWS API. I left custom
update operations as an exercise for the reader...

Issue #355

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
