### PR TITLE
Append an underscore to CRD names matching Go keywords

### DIFF
--- a/pkg/names/names.go
+++ b/pkg/names/names.go
@@ -18,6 +18,8 @@ import (
 
 	regexp "github.com/dlclark/regexp2" // for negative lookahead support
 	"github.com/iancoleman/strcase"
+
+	"github.com/aws/aws-controllers-k8s/pkg/util"
 )
 
 type initialismTranslator struct {
@@ -115,6 +117,34 @@ var (
 	}
 )
 
+var goKeywords = []string{
+	"break",
+	"case",
+	"chan",
+	"const",
+	"continue",
+	"default",
+	"defer",
+	"else",
+	"fallthrough",
+	"for",
+	"func",
+	"go",
+	"goto",
+	"if",
+	"import",
+	"interface",
+	"map",
+	"package",
+	"range",
+	"return",
+	"select",
+	"struct",
+	"switch",
+	"type",
+	"var",
+}
+
 type Names struct {
 	ModelOrginal string
 	Original     string
@@ -149,6 +179,9 @@ func goName(original string, lowerFirst bool, snake bool) (result string) {
 	}
 	if snake {
 		result = strcase.ToSnake(result)
+	}
+	if util.InStrings(result, goKeywords) {
+		result = result + "_"
 	}
 	return
 }

--- a/pkg/names/names_test.go
+++ b/pkg/names/names_test.go
@@ -48,6 +48,7 @@ func TestNames(t *testing.T) {
 		{"RepositoryUriTest", "RepositoryURITest", "repositoryURITest", "repository_uri_test"},
 		{"Ip", "IP", "ip", "ip"},
 		{"MultipartUpload", "MultipartUpload", "multipartUpload", "multipart_upload"},
+		{"Package", "Package", "package_", "package_"},
 	}
 	for _, tc := range testCases {
 		n := names.New(tc.original)


### PR DESCRIPTION
Issue N/A

Description of changes:
- Append an underscore to CRD names matching Go keywords

This was originally detected during the process of generating `es` (elastic search) service controller. "elastic search'' uses a data type named "package" which causes `ack-generate controller` to generate a Go package called "package". 
This PR will help preventing `ack-generate` from using Go keywords as CRD names.

For more details see [Elastic Search API](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-configuration-api.html#es-configuration-api-actions-createpackage) or try to run `make build-controller SERVICE=es`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
