### PR TITLE
session handler info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV GO111MODULE=on
 ENV GOARCH=amd64
 ENV GOOS=linux
 ENV CGO_ENABLED=0
+ENV VERSION_PKG=github.com/aws/aws-controllers-k8s/pkg/version
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -19,10 +20,16 @@ RUN  go mod download
 # Copy the go source
 COPY . $work_dir/
 # Build
-RUN  go build -a -o $work_dir/bin/controller $work_dir/services/$service_alias/cmd/controller/main.go
+RUN GIT_VERSION=$(git describe --tags --dirty --always) && \
+    GIT_COMMIT=$(git rev-parse HEAD) && \
+    BUILD_DATE=$(date +%Y-%m-%dT%H:%M) && \
+    go build -ldflags="-X ${VERSION_PKG}.GitVersion=${GIT_VERSION} \
+    -X ${VERSION_PKG}.GitCommit=${GIT_COMMIT} \
+    -X ${VERSION_PKG}.BuildDate=${BUILD_DATE}" \
+    -a -o $work_dir/bin/controller $work_dir/services/$service_alias/cmd/controller/main.go
 
 FROM amazonlinux:2
 ARG work_dir=/github.com/aws/aws-controllers-k8s
 WORKDIR /
-COPY --from=builder $work_dir/bin/controller $work_dir/LICENSE $work_dir/ATTRIBUTION.md /bin/.
+COPY --from=builder $work_dir/bin/controller $work_dir/LICENSE $work_dir/ATTRIBUTION.md /bin/
 ENTRYPOINT ["/bin/controller"]

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -110,7 +110,7 @@ func (r *reconciler) reconcile(req ctrlrt.Request) error {
 	acctID := r.getOwnerAccountID(res)
 	region := r.getRegion(res)
 	roleARN := r.getRoleARN(acctID)
-	sess, err := NewSession(region, roleARN)
+	sess, err := NewSession(region, roleARN, res.RuntimeObject().GetObjectKind().GroupVersionKind())
 	if err != nil {
 		return err
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,20 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package version
+
+var (
+	GitVersion string
+	GitCommit  string
+	BuildDate  string
+)


### PR DESCRIPTION
Issue #, if available: #409 

Description of changes:
With this PR, we will inject session handler information/user-agent information while creating the session. 

Tested with debug logging:
```
Host: api.ecr.us-west-2.amazonaws.com
**User-Agent: aws-controller-k8s/0c76963-dirty (GitCommit/0c76963771053ea4310b5ffd0aaa399af0f88e87; BuildDate/2020-10-14T00:33:32+0000; Kind/Repository; CRDVersion/v1alpha1) aws-sdk-go/1.34.32 (go1.14.1; linux; amd64)
Content-Length: 72**
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
