### PR TITLE
renew credentials during e2e test

### DIFF
--- a/scripts/lib/aws/elasticache.sh
+++ b/scripts/lib/aws/elasticache.sh
@@ -8,6 +8,8 @@ SCRIPTS_DIR="$ROOT_DIR/scripts"
 . $SCRIPTS_DIR/lib/testutil.sh
 . $SCRIPTS_DIR/lib/aws.sh
 
+service_name="elasticache"
+
 #################################################
 # functions for tests
 #################################################
@@ -180,13 +182,14 @@ EOF
 aws_wait_replication_group_available() {
   if [[ $# -ne 2 ]]; then
     echo "FATAL: Wrong number of arguments passed to aws_wait_replication_group_available"
-    echo "Usage: aws_wait_replication_group_available replication_group_id $failure_message"
+    echo "Usage: aws_wait_replication_group_available replication_group_id failure_message"
     exit 1
   fi
   local replication_group_id="$1"
   local failure_message="$2"
   local wait_failed="true"
-  for i in $(seq 0 3); do
+  for i in $(seq 0 5); do
+    k8s_controller_reload_credentials "$service_name"
     debug_msg "starting to wait for replication group: $replication_group_id to be available."
     $(daws elasticache wait replication-group-available --replication-group-id "$replication_group_id")
     if [[ $? -eq 255 ]]; then
@@ -201,6 +204,7 @@ aws_wait_replication_group_available() {
     print_k8s_ack_controller_pod_logs
     exit 1
   fi
+  k8s_controller_reload_credentials "$service_name"
 }
 
 # aws_wait_replication_group_deleted waits for supplied replication_group_id to be deleted
@@ -210,13 +214,14 @@ aws_wait_replication_group_available() {
 aws_wait_replication_group_deleted() {
   if [[ $# -ne 2 ]]; then
     echo "FATAL: Wrong number of arguments passed to aws_wait_replication_group_deleted"
-    echo "Usage: aws_wait_replication_group_deleted replication_group_id $failure_message"
+    echo "Usage: aws_wait_replication_group_deleted replication_group_id failure_message"
     exit 1
   fi
   local replication_group_id="$1"
   local failure_message="$2"
   local wait_failed="true"
-  for i in $(seq 0 3); do
+  for i in $(seq 0 5); do
+    k8s_controller_reload_credentials "$service_name"
     debug_msg "starting to wait for replication group: $replication_group_id to be deleted."
     $(daws elasticache wait replication-group-deleted --replication-group-id "$replication_group_id")
     if [[ $? -eq 255 ]]; then
@@ -231,6 +236,7 @@ aws_wait_replication_group_deleted() {
     print_k8s_ack_controller_pod_logs
     exit 1
   fi
+  k8s_controller_reload_credentials "$service_name"
 }
 
 # aws_assert_replication_group_status compares status of supplied replication_group_id with supplied status
@@ -255,9 +261,9 @@ aws_assert_replication_group_status() {
   fi
 }
 
-# k8s_assert_replication_group_status compares status of supplied replication_group_id with supplied status
+# k8s_assert_replication_group_status_property compares status of supplied replication_group_id with supplied status
 # current status is retrieved from latest state of replication group in k8s cluster using kubectl
-# aws_assert_replication_group_status requires 3 arguments
+# k8s_assert_replication_group_status_property requires 3 arguments
 #     replication_group_id
 #     property_json_path - json path inside k8s crd status object. example: .description
 #     expected_value - expected value of the property
@@ -280,7 +286,7 @@ k8s_assert_replication_group_status_property() {
 
 # k8s_assert_replication_group_shard_count compares shard count of supplied replication_group_id with supplied count
 # current status is retrieved from latest state of replication group in k8s cluster using kubectl
-# aws_assert_replication_group_status requires 2 arguments
+# k8s_assert_replication_group_shard_count requires 2 arguments
 #     replication_group_id
 #     expected_count - expected shard count
 k8s_assert_replication_group_shard_count() {
@@ -301,7 +307,7 @@ k8s_assert_replication_group_shard_count() {
 
 # k8s_assert_replication_group_replica_count compares replica count of supplied replication_group_id with supplied count
 # current status is retrieved from latest state of replication group in k8s cluster using kubectl
-# aws_assert_replication_group_status requires 2 arguments
+# k8s_assert_replication_group_replica_count requires 2 arguments
 #     replication_group_id
 #     expected_count - expected replica count
 k8s_assert_replication_group_replica_count() {

--- a/test/e2e/elasticache/replication_group/e2e.sh
+++ b/test/e2e/elasticache/replication_group/e2e.sh
@@ -18,7 +18,6 @@ source "$SCRIPTS_DIR/lib/aws/elasticache.sh"
 check_is_installed jq "Please install jq before running this script."
 
 test_name="$( filenoext "${BASH_SOURCE[0]}" )"
-service_name="elasticache"
 ack_ctrl_pod_id=$( controller_pod_id )
 debug_msg "executing test: $service_name/$test_name"
 
@@ -49,6 +48,8 @@ ack_apply_replication_group_with_node_groups_yaml() {
   rg_yaml="$(provide_replication_group_detailed_yaml)"  # helps determine node groups to retain during decrease
   echo "$rg_yaml" | kubectl apply -f -
 }
+
+k8s_controller_reload_credentials "$service_name"
 
 #################################################
 # create replication group
@@ -130,4 +131,3 @@ assert_equal "0" "$?" "Expected success from kubectl delete but got $?" || exit 
 sleep 5
 aws_wait_replication_group_deleted  "$rg_id" "FAIL: expected replication group $rg_id to have been deleted in ${service_name}"
 
-assert_pod_not_restarted "$ack_ctrl_pod_id"


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Renew credentials during e2e test.

`SERVICE=elasticache && make kind-test` ran the tests:
```
...
DEBUG: executing test: elasticache/smoke
...
DEBUG: Creating subnet group ack-test-smoke-elasticache-subnet-gp in elasticache
cachesubnetgroup.elasticache.services.k8s.aws/ack-test-smoke-elasticache-subnet-gp created
DEBUG: checking subnet group ack-test-smoke-elasticache-subnet-gp created in elasticache
DEBUG: Modifying subnet group ack-test-smoke-elasticache-subnet-gp in elasticache
cachesubnetgroup.elasticache.services.k8s.aws/ack-test-smoke-elasticache-subnet-gp configured
DEBUG: subnet group ack-test-smoke-elasticache-subnet-gp modified in elasticache
DEBUG: Deleting subnet group ack-test-smoke-elasticache-subnet-gp in elasticache
cachesubnetgroup.elasticache.services.k8s.aws "ack-test-smoke-elasticache-subnet-gp" deleted
smoke took 69 second(s)
DEBUG: executing test: elasticache/e2e
generating AWS temporary credentials and adding to env vars map ... DEBUG: Testing create replication group: ack-test-rg-1.
replicationgroup.elasticache.services.k8s.aws/ack-test-rg-1 created
generating AWS temporary credentials and adding to env vars map ... DEBUG: starting to wait for replication group: ack-test-rg-1 to be available.
generating AWS temporary credentials and adding to env vars map ... DEBUG: Testing modify replication group: ack-test-rg-1.
replicationgroup.elasticache.services.k8s.aws/ack-test-rg-1 configured
generating AWS temporary credentials and adding to env vars map ... DEBUG: starting to wait for replication group: ack-test-rg-1 to be available.
generating AWS temporary credentials and adding to env vars map ... DEBUG: Testing modify replication group: ack-test-rg-1 shards count to new value: 3.
replicationgroup.elasticache.services.k8s.aws/ack-test-rg-1 configured
generating AWS temporary credentials and adding to env vars map ... DEBUG: starting to wait for replication group: ack-test-rg-1 to be available.

Waiter ReplicationGroupAvailable failed: Max attempts exceeded
generating AWS temporary credentials and adding to env vars map ... DEBUG: starting to wait for replication group: ack-test-rg-1 to be available.
generating AWS temporary credentials and adding to env vars map ... DEBUG: Testing modify replication group: ack-test-rg-1 shards count to new value: 2.
replicationgroup.elasticache.services.k8s.aws/ack-test-rg-1 configured
generating AWS temporary credentials and adding to env vars map ... DEBUG: starting to wait for replication group: ack-test-rg-1 to be available.

Waiter ReplicationGroupAvailable failed: Max attempts exceeded
generating AWS temporary credentials and adding to env vars map ... DEBUG: starting to wait for replication group: ack-test-rg-1 to be available.
generating AWS temporary credentials and adding to env vars map ... DEBUG: Testing modify replication group: ack-test-rg-1 replica count to new value: 2.
replicationgroup.elasticache.services.k8s.aws/ack-test-rg-1 configured
generating AWS temporary credentials and adding to env vars map ... DEBUG: starting to wait for replication group: ack-test-rg-1 to be available.
generating AWS temporary credentials and adding to env vars map ... DEBUG: Testing modify replication group: ack-test-rg-1 replica count to new value: 1.
replicationgroup.elasticache.services.k8s.aws/ack-test-rg-1 configured
generating AWS temporary credentials and adding to env vars map ... DEBUG: starting to wait for replication group: ack-test-rg-1 to be available.
generating AWS temporary credentials and adding to env vars map ... DEBUG: Testing delete replication group: ack-test-rg-1.
replicationgroup.elasticache.services.k8s.aws "ack-test-rg-1" deleted
generating AWS temporary credentials and adding to env vars map ... DEBUG: starting to wait for replication group: ack-test-rg-1 to be deleted.
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
