### PR TITLE
add terminal condition during sync

### DIFF
--- a/apis/core/v1alpha1/conditions.go
+++ b/apis/core/v1alpha1/conditions.go
@@ -26,6 +26,12 @@ const (
 	// ConditionTypeResourceSynced indicates the state of the resource in the
 	// backend service is in sync with the ACK service controller
 	ConditionTypeResourceSynced ConditionType = "ACK.ResourceSynced"
+	// ConditionTypeTerminal indicates that the custom resource Spec need to be
+	// updated before any further sync.
+	// Examples include:
+	//		- As a result of InvalidArgument in input yaml
+	//		- Resource server state is "create-failed"
+	ConditionTypeTerminal ConditionType = "ACK.Terminal"
 )
 
 // Condition is the common struct used by all CRDs managed by ACK service

--- a/pkg/errors/error.go
+++ b/pkg/errors/error.go
@@ -38,7 +38,10 @@ var (
 	// but more of a marker that the status check will be performed
 	// after some wait time
 	TemporaryOutOfSync = fmt.Errorf(
-		"Temporary out of sync, reconcile after some time")
+		"temporary out of sync, reconcile after some time")
+	// Terminal is returned with resource is in Terminal Condition
+	Terminal = fmt.Errorf(
+		"resource is in terminal condition")
 )
 
 // AWSError returns the type conversion for the supplied error to an aws-sdk-go

--- a/pkg/generate/config/config.go
+++ b/pkg/generate/config/config.go
@@ -101,6 +101,10 @@ type ResourceConfig struct {
 	// very little consistency to the APIs that we can use to instruct the code
 	// generator :(
 	UpdateOperation *UpdateOperationConfig `json:"update_operation,omitempty"`
+	// UpdateConditionsCustomMethodName provides the name of the custom method on the
+	// `resourceManager` struct that will set Conditions on a `resource` struct
+	// depending on the status of the resource.
+	UpdateConditionsCustomMethodName string `json:"update_conditions_custom_method_name,omitempty"`
 }
 
 // UnpackAttributesMapConfig informs the code generator that the API follows a
@@ -188,6 +192,8 @@ type ExceptionsConfig struct {
 	// Codes is a map of HTTP status code to the name of the Exception shape
 	// that corresponds to that HTTP status code for this resource
 	Codes map[int]string `json:"codes"`
+	// Set of aws exception codes that are terminal exceptions for this resource
+	TerminalCodes []string `json:"terminal_codes"`
 }
 
 // RenamesConfig contains instructions to the code generator how to rename

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -356,6 +356,32 @@ func (r *CRD) GetCustomImplementation(
 	return operationConfig.CustomImplementation
 }
 
+// UpdateConditionsCustomMethodName returns custom update conditions operation
+// as *string for custom resource, if specified in generator config
+func (r *CRD) UpdateConditionsCustomMethodName() string {
+	if r.genCfg == nil {
+		return ""
+	}
+	resGenConfig, found := r.genCfg.Resources[r.Names.Original]
+	if !found {
+		return ""
+	}
+	return resGenConfig.UpdateConditionsCustomMethodName
+}
+
+// TerminalExceptionCodes returns terminal exception codes as
+// []string for custom resource, if specified in generator config
+func (r *CRD) TerminalExceptionCodes() []string {
+	if r.genCfg == nil {
+		return nil
+	}
+	resGenConfig, found := r.genCfg.Resources[r.Names.Original]
+	if found && resGenConfig.Exceptions != nil {
+		return resGenConfig.Exceptions.TerminalCodes
+	}
+	return nil
+}
+
 // ExceptionCode returns the name of the resource's Exception code for the
 // Exception having the exception code. If the generator config has
 // instructions for overriding the name of an exception code for a resource for

--- a/services/apigatewayv2/pkg/resource/api/manager.go
+++ b/services/apigatewayv2/pkg/resource/api/manager.go
@@ -18,6 +18,8 @@ package api
 import (
 	"context"
 	"fmt"
+	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -85,7 +87,7 @@ func (rm *resourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return observed, nil
+	return rm.onSuccess(observed)
 }
 
 // Create attempts to create the supplied AWSResource in the backend AWS
@@ -102,9 +104,9 @@ func (rm *resourceManager) Create(
 	}
 	created, err := rm.sdkCreate(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
-	return created, nil
+	return rm.onSuccess(created)
 }
 
 // Update attempts to mutate the supplied desired AWSResource in the backend AWS
@@ -129,9 +131,9 @@ func (rm *resourceManager) Update(
 	}
 	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
-		return nil, err
+		return rm.onError(latest, err)
 	}
-	return updated, nil
+	return rm.onSuccess(updated)
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
@@ -180,4 +182,37 @@ func newResourceManager(
 		sess:         sess,
 		sdkapi:       svcsdk.New(sess),
 	}, nil
+}
+
+// onError updates resource conditions and returns updated resource
+// it returns nil if no condition is updated.
+func (rm *resourceManager) onError(
+	r *resource,
+	err error,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, err)
+	if !updated {
+		return nil, err
+	}
+	for _, condition := range r1.Conditions() {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&
+			condition.Status == corev1.ConditionTrue {
+			// resource is in Terminal condition
+			// return Terminal error
+			return r1, ackerr.Terminal
+		}
+	}
+	return r1, err
+}
+
+// onSuccess updates resource conditions and returns updated resource
+// it returns the supplied resource if no condition is updated.
+func (rm *resourceManager) onSuccess(
+	r *resource,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, nil)
+	if !updated {
+		return r, nil
+	}
+	return r1, nil
 }

--- a/services/apigatewayv2/pkg/resource/api/sdk.go
+++ b/services/apigatewayv2/pkg/resource/api/sdk.go
@@ -17,6 +17,7 @@ package api
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -557,4 +558,51 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.Conditions == nil {
 		ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	}
+}
+
+// updateConditions returns updated resource, true; if conditions were updated
+// else it returns nil, false
+func (rm *resourceManager) updateConditions(
+	r *resource,
+	err error,
+) (*resource, bool) {
+	ko := r.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+
+	// Terminal condition
+	var terminalCondition *ackv1alpha1.Condition = nil
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
+			terminalCondition = condition
+			break
+		}
+	}
+
+	if rm.terminalAWSError(err) {
+		if terminalCondition == nil {
+			terminalCondition = &ackv1alpha1.Condition{
+				Type: ackv1alpha1.ConditionTypeTerminal,
+			}
+			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
+		}
+		terminalCondition.Status = corev1.ConditionTrue
+		awsErr, _ := ackerr.AWSError(err)
+		errorMessage := awsErr.Message()
+		terminalCondition.Message = &errorMessage
+	} else if terminalCondition != nil {
+		terminalCondition.Status = corev1.ConditionFalse
+		terminalCondition.Message = nil
+	}
+	if terminalCondition != nil {
+		return &resource{ko}, true // updated
+	}
+	return nil, false // not updated
+}
+
+// terminalAWSError returns awserr, true; if the supplied error is an aws Error type
+// and if the exception indicates that it is a Terminal exception
+// 'Terminal' exception are specified in generator configuration
+func (rm *resourceManager) terminalAWSError(err error) bool {
+	// No terminal_errors specified for this resource in generator config
+	return false
 }

--- a/services/apigatewayv2/pkg/resource/api_mapping/manager.go
+++ b/services/apigatewayv2/pkg/resource/api_mapping/manager.go
@@ -18,6 +18,8 @@ package api_mapping
 import (
 	"context"
 	"fmt"
+	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -85,7 +87,7 @@ func (rm *resourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return observed, nil
+	return rm.onSuccess(observed)
 }
 
 // Create attempts to create the supplied AWSResource in the backend AWS
@@ -102,9 +104,9 @@ func (rm *resourceManager) Create(
 	}
 	created, err := rm.sdkCreate(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
-	return created, nil
+	return rm.onSuccess(created)
 }
 
 // Update attempts to mutate the supplied desired AWSResource in the backend AWS
@@ -129,9 +131,9 @@ func (rm *resourceManager) Update(
 	}
 	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
-		return nil, err
+		return rm.onError(latest, err)
 	}
-	return updated, nil
+	return rm.onSuccess(updated)
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
@@ -180,4 +182,37 @@ func newResourceManager(
 		sess:         sess,
 		sdkapi:       svcsdk.New(sess),
 	}, nil
+}
+
+// onError updates resource conditions and returns updated resource
+// it returns nil if no condition is updated.
+func (rm *resourceManager) onError(
+	r *resource,
+	err error,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, err)
+	if !updated {
+		return nil, err
+	}
+	for _, condition := range r1.Conditions() {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&
+			condition.Status == corev1.ConditionTrue {
+			// resource is in Terminal condition
+			// return Terminal error
+			return r1, ackerr.Terminal
+		}
+	}
+	return r1, err
+}
+
+// onSuccess updates resource conditions and returns updated resource
+// it returns the supplied resource if no condition is updated.
+func (rm *resourceManager) onSuccess(
+	r *resource,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, nil)
+	if !updated {
+		return r, nil
+	}
+	return r1, nil
 }

--- a/services/apigatewayv2/pkg/resource/api_mapping/sdk.go
+++ b/services/apigatewayv2/pkg/resource/api_mapping/sdk.go
@@ -17,6 +17,7 @@ package api_mapping
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -276,4 +277,51 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.Conditions == nil {
 		ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	}
+}
+
+// updateConditions returns updated resource, true; if conditions were updated
+// else it returns nil, false
+func (rm *resourceManager) updateConditions(
+	r *resource,
+	err error,
+) (*resource, bool) {
+	ko := r.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+
+	// Terminal condition
+	var terminalCondition *ackv1alpha1.Condition = nil
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
+			terminalCondition = condition
+			break
+		}
+	}
+
+	if rm.terminalAWSError(err) {
+		if terminalCondition == nil {
+			terminalCondition = &ackv1alpha1.Condition{
+				Type: ackv1alpha1.ConditionTypeTerminal,
+			}
+			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
+		}
+		terminalCondition.Status = corev1.ConditionTrue
+		awsErr, _ := ackerr.AWSError(err)
+		errorMessage := awsErr.Message()
+		terminalCondition.Message = &errorMessage
+	} else if terminalCondition != nil {
+		terminalCondition.Status = corev1.ConditionFalse
+		terminalCondition.Message = nil
+	}
+	if terminalCondition != nil {
+		return &resource{ko}, true // updated
+	}
+	return nil, false // not updated
+}
+
+// terminalAWSError returns awserr, true; if the supplied error is an aws Error type
+// and if the exception indicates that it is a Terminal exception
+// 'Terminal' exception are specified in generator configuration
+func (rm *resourceManager) terminalAWSError(err error) bool {
+	// No terminal_errors specified for this resource in generator config
+	return false
 }

--- a/services/apigatewayv2/pkg/resource/authorizer/manager.go
+++ b/services/apigatewayv2/pkg/resource/authorizer/manager.go
@@ -18,6 +18,8 @@ package authorizer
 import (
 	"context"
 	"fmt"
+	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -85,7 +87,7 @@ func (rm *resourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return observed, nil
+	return rm.onSuccess(observed)
 }
 
 // Create attempts to create the supplied AWSResource in the backend AWS
@@ -102,9 +104,9 @@ func (rm *resourceManager) Create(
 	}
 	created, err := rm.sdkCreate(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
-	return created, nil
+	return rm.onSuccess(created)
 }
 
 // Update attempts to mutate the supplied desired AWSResource in the backend AWS
@@ -129,9 +131,9 @@ func (rm *resourceManager) Update(
 	}
 	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
-		return nil, err
+		return rm.onError(latest, err)
 	}
-	return updated, nil
+	return rm.onSuccess(updated)
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
@@ -180,4 +182,37 @@ func newResourceManager(
 		sess:         sess,
 		sdkapi:       svcsdk.New(sess),
 	}, nil
+}
+
+// onError updates resource conditions and returns updated resource
+// it returns nil if no condition is updated.
+func (rm *resourceManager) onError(
+	r *resource,
+	err error,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, err)
+	if !updated {
+		return nil, err
+	}
+	for _, condition := range r1.Conditions() {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&
+			condition.Status == corev1.ConditionTrue {
+			// resource is in Terminal condition
+			// return Terminal error
+			return r1, ackerr.Terminal
+		}
+	}
+	return r1, err
+}
+
+// onSuccess updates resource conditions and returns updated resource
+// it returns the supplied resource if no condition is updated.
+func (rm *resourceManager) onSuccess(
+	r *resource,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, nil)
+	if !updated {
+		return r, nil
+	}
+	return r1, nil
 }

--- a/services/apigatewayv2/pkg/resource/authorizer/sdk.go
+++ b/services/apigatewayv2/pkg/resource/authorizer/sdk.go
@@ -17,6 +17,7 @@ package authorizer
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -396,4 +397,51 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.Conditions == nil {
 		ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	}
+}
+
+// updateConditions returns updated resource, true; if conditions were updated
+// else it returns nil, false
+func (rm *resourceManager) updateConditions(
+	r *resource,
+	err error,
+) (*resource, bool) {
+	ko := r.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+
+	// Terminal condition
+	var terminalCondition *ackv1alpha1.Condition = nil
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
+			terminalCondition = condition
+			break
+		}
+	}
+
+	if rm.terminalAWSError(err) {
+		if terminalCondition == nil {
+			terminalCondition = &ackv1alpha1.Condition{
+				Type: ackv1alpha1.ConditionTypeTerminal,
+			}
+			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
+		}
+		terminalCondition.Status = corev1.ConditionTrue
+		awsErr, _ := ackerr.AWSError(err)
+		errorMessage := awsErr.Message()
+		terminalCondition.Message = &errorMessage
+	} else if terminalCondition != nil {
+		terminalCondition.Status = corev1.ConditionFalse
+		terminalCondition.Message = nil
+	}
+	if terminalCondition != nil {
+		return &resource{ko}, true // updated
+	}
+	return nil, false // not updated
+}
+
+// terminalAWSError returns awserr, true; if the supplied error is an aws Error type
+// and if the exception indicates that it is a Terminal exception
+// 'Terminal' exception are specified in generator configuration
+func (rm *resourceManager) terminalAWSError(err error) bool {
+	// No terminal_errors specified for this resource in generator config
+	return false
 }

--- a/services/apigatewayv2/pkg/resource/deployment/manager.go
+++ b/services/apigatewayv2/pkg/resource/deployment/manager.go
@@ -18,6 +18,8 @@ package deployment
 import (
 	"context"
 	"fmt"
+	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -85,7 +87,7 @@ func (rm *resourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return observed, nil
+	return rm.onSuccess(observed)
 }
 
 // Create attempts to create the supplied AWSResource in the backend AWS
@@ -102,9 +104,9 @@ func (rm *resourceManager) Create(
 	}
 	created, err := rm.sdkCreate(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
-	return created, nil
+	return rm.onSuccess(created)
 }
 
 // Update attempts to mutate the supplied desired AWSResource in the backend AWS
@@ -129,9 +131,9 @@ func (rm *resourceManager) Update(
 	}
 	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
-		return nil, err
+		return rm.onError(latest, err)
 	}
-	return updated, nil
+	return rm.onSuccess(updated)
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
@@ -180,4 +182,37 @@ func newResourceManager(
 		sess:         sess,
 		sdkapi:       svcsdk.New(sess),
 	}, nil
+}
+
+// onError updates resource conditions and returns updated resource
+// it returns nil if no condition is updated.
+func (rm *resourceManager) onError(
+	r *resource,
+	err error,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, err)
+	if !updated {
+		return nil, err
+	}
+	for _, condition := range r1.Conditions() {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&
+			condition.Status == corev1.ConditionTrue {
+			// resource is in Terminal condition
+			// return Terminal error
+			return r1, ackerr.Terminal
+		}
+	}
+	return r1, err
+}
+
+// onSuccess updates resource conditions and returns updated resource
+// it returns the supplied resource if no condition is updated.
+func (rm *resourceManager) onSuccess(
+	r *resource,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, nil)
+	if !updated {
+		return r, nil
+	}
+	return r1, nil
 }

--- a/services/apigatewayv2/pkg/resource/deployment/sdk.go
+++ b/services/apigatewayv2/pkg/resource/deployment/sdk.go
@@ -17,6 +17,7 @@ package deployment
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -297,4 +298,51 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.Conditions == nil {
 		ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	}
+}
+
+// updateConditions returns updated resource, true; if conditions were updated
+// else it returns nil, false
+func (rm *resourceManager) updateConditions(
+	r *resource,
+	err error,
+) (*resource, bool) {
+	ko := r.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+
+	// Terminal condition
+	var terminalCondition *ackv1alpha1.Condition = nil
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
+			terminalCondition = condition
+			break
+		}
+	}
+
+	if rm.terminalAWSError(err) {
+		if terminalCondition == nil {
+			terminalCondition = &ackv1alpha1.Condition{
+				Type: ackv1alpha1.ConditionTypeTerminal,
+			}
+			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
+		}
+		terminalCondition.Status = corev1.ConditionTrue
+		awsErr, _ := ackerr.AWSError(err)
+		errorMessage := awsErr.Message()
+		terminalCondition.Message = &errorMessage
+	} else if terminalCondition != nil {
+		terminalCondition.Status = corev1.ConditionFalse
+		terminalCondition.Message = nil
+	}
+	if terminalCondition != nil {
+		return &resource{ko}, true // updated
+	}
+	return nil, false // not updated
+}
+
+// terminalAWSError returns awserr, true; if the supplied error is an aws Error type
+// and if the exception indicates that it is a Terminal exception
+// 'Terminal' exception are specified in generator configuration
+func (rm *resourceManager) terminalAWSError(err error) bool {
+	// No terminal_errors specified for this resource in generator config
+	return false
 }

--- a/services/apigatewayv2/pkg/resource/domain_name/manager.go
+++ b/services/apigatewayv2/pkg/resource/domain_name/manager.go
@@ -18,6 +18,8 @@ package domain_name
 import (
 	"context"
 	"fmt"
+	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -85,7 +87,7 @@ func (rm *resourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return observed, nil
+	return rm.onSuccess(observed)
 }
 
 // Create attempts to create the supplied AWSResource in the backend AWS
@@ -102,9 +104,9 @@ func (rm *resourceManager) Create(
 	}
 	created, err := rm.sdkCreate(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
-	return created, nil
+	return rm.onSuccess(created)
 }
 
 // Update attempts to mutate the supplied desired AWSResource in the backend AWS
@@ -129,9 +131,9 @@ func (rm *resourceManager) Update(
 	}
 	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
-		return nil, err
+		return rm.onError(latest, err)
 	}
-	return updated, nil
+	return rm.onSuccess(updated)
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
@@ -180,4 +182,37 @@ func newResourceManager(
 		sess:         sess,
 		sdkapi:       svcsdk.New(sess),
 	}, nil
+}
+
+// onError updates resource conditions and returns updated resource
+// it returns nil if no condition is updated.
+func (rm *resourceManager) onError(
+	r *resource,
+	err error,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, err)
+	if !updated {
+		return nil, err
+	}
+	for _, condition := range r1.Conditions() {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&
+			condition.Status == corev1.ConditionTrue {
+			// resource is in Terminal condition
+			// return Terminal error
+			return r1, ackerr.Terminal
+		}
+	}
+	return r1, err
+}
+
+// onSuccess updates resource conditions and returns updated resource
+// it returns the supplied resource if no condition is updated.
+func (rm *resourceManager) onSuccess(
+	r *resource,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, nil)
+	if !updated {
+		return r, nil
+	}
+	return r1, nil
 }

--- a/services/apigatewayv2/pkg/resource/domain_name/sdk.go
+++ b/services/apigatewayv2/pkg/resource/domain_name/sdk.go
@@ -17,6 +17,7 @@ package domain_name
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -392,4 +393,51 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.Conditions == nil {
 		ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	}
+}
+
+// updateConditions returns updated resource, true; if conditions were updated
+// else it returns nil, false
+func (rm *resourceManager) updateConditions(
+	r *resource,
+	err error,
+) (*resource, bool) {
+	ko := r.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+
+	// Terminal condition
+	var terminalCondition *ackv1alpha1.Condition = nil
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
+			terminalCondition = condition
+			break
+		}
+	}
+
+	if rm.terminalAWSError(err) {
+		if terminalCondition == nil {
+			terminalCondition = &ackv1alpha1.Condition{
+				Type: ackv1alpha1.ConditionTypeTerminal,
+			}
+			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
+		}
+		terminalCondition.Status = corev1.ConditionTrue
+		awsErr, _ := ackerr.AWSError(err)
+		errorMessage := awsErr.Message()
+		terminalCondition.Message = &errorMessage
+	} else if terminalCondition != nil {
+		terminalCondition.Status = corev1.ConditionFalse
+		terminalCondition.Message = nil
+	}
+	if terminalCondition != nil {
+		return &resource{ko}, true // updated
+	}
+	return nil, false // not updated
+}
+
+// terminalAWSError returns awserr, true; if the supplied error is an aws Error type
+// and if the exception indicates that it is a Terminal exception
+// 'Terminal' exception are specified in generator configuration
+func (rm *resourceManager) terminalAWSError(err error) bool {
+	// No terminal_errors specified for this resource in generator config
+	return false
 }

--- a/services/apigatewayv2/pkg/resource/integration/manager.go
+++ b/services/apigatewayv2/pkg/resource/integration/manager.go
@@ -18,6 +18,8 @@ package integration
 import (
 	"context"
 	"fmt"
+	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -85,7 +87,7 @@ func (rm *resourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return observed, nil
+	return rm.onSuccess(observed)
 }
 
 // Create attempts to create the supplied AWSResource in the backend AWS
@@ -102,9 +104,9 @@ func (rm *resourceManager) Create(
 	}
 	created, err := rm.sdkCreate(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
-	return created, nil
+	return rm.onSuccess(created)
 }
 
 // Update attempts to mutate the supplied desired AWSResource in the backend AWS
@@ -129,9 +131,9 @@ func (rm *resourceManager) Update(
 	}
 	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
-		return nil, err
+		return rm.onError(latest, err)
 	}
-	return updated, nil
+	return rm.onSuccess(updated)
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
@@ -180,4 +182,37 @@ func newResourceManager(
 		sess:         sess,
 		sdkapi:       svcsdk.New(sess),
 	}, nil
+}
+
+// onError updates resource conditions and returns updated resource
+// it returns nil if no condition is updated.
+func (rm *resourceManager) onError(
+	r *resource,
+	err error,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, err)
+	if !updated {
+		return nil, err
+	}
+	for _, condition := range r1.Conditions() {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&
+			condition.Status == corev1.ConditionTrue {
+			// resource is in Terminal condition
+			// return Terminal error
+			return r1, ackerr.Terminal
+		}
+	}
+	return r1, err
+}
+
+// onSuccess updates resource conditions and returns updated resource
+// it returns the supplied resource if no condition is updated.
+func (rm *resourceManager) onSuccess(
+	r *resource,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, nil)
+	if !updated {
+		return r, nil
+	}
+	return r1, nil
 }

--- a/services/apigatewayv2/pkg/resource/integration/sdk.go
+++ b/services/apigatewayv2/pkg/resource/integration/sdk.go
@@ -17,6 +17,7 @@ package integration
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -459,4 +460,51 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.Conditions == nil {
 		ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	}
+}
+
+// updateConditions returns updated resource, true; if conditions were updated
+// else it returns nil, false
+func (rm *resourceManager) updateConditions(
+	r *resource,
+	err error,
+) (*resource, bool) {
+	ko := r.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+
+	// Terminal condition
+	var terminalCondition *ackv1alpha1.Condition = nil
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
+			terminalCondition = condition
+			break
+		}
+	}
+
+	if rm.terminalAWSError(err) {
+		if terminalCondition == nil {
+			terminalCondition = &ackv1alpha1.Condition{
+				Type: ackv1alpha1.ConditionTypeTerminal,
+			}
+			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
+		}
+		terminalCondition.Status = corev1.ConditionTrue
+		awsErr, _ := ackerr.AWSError(err)
+		errorMessage := awsErr.Message()
+		terminalCondition.Message = &errorMessage
+	} else if terminalCondition != nil {
+		terminalCondition.Status = corev1.ConditionFalse
+		terminalCondition.Message = nil
+	}
+	if terminalCondition != nil {
+		return &resource{ko}, true // updated
+	}
+	return nil, false // not updated
+}
+
+// terminalAWSError returns awserr, true; if the supplied error is an aws Error type
+// and if the exception indicates that it is a Terminal exception
+// 'Terminal' exception are specified in generator configuration
+func (rm *resourceManager) terminalAWSError(err error) bool {
+	// No terminal_errors specified for this resource in generator config
+	return false
 }

--- a/services/apigatewayv2/pkg/resource/integration_response/manager.go
+++ b/services/apigatewayv2/pkg/resource/integration_response/manager.go
@@ -18,6 +18,8 @@ package integration_response
 import (
 	"context"
 	"fmt"
+	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -85,7 +87,7 @@ func (rm *resourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return observed, nil
+	return rm.onSuccess(observed)
 }
 
 // Create attempts to create the supplied AWSResource in the backend AWS
@@ -102,9 +104,9 @@ func (rm *resourceManager) Create(
 	}
 	created, err := rm.sdkCreate(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
-	return created, nil
+	return rm.onSuccess(created)
 }
 
 // Update attempts to mutate the supplied desired AWSResource in the backend AWS
@@ -129,9 +131,9 @@ func (rm *resourceManager) Update(
 	}
 	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
-		return nil, err
+		return rm.onError(latest, err)
 	}
-	return updated, nil
+	return rm.onSuccess(updated)
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
@@ -180,4 +182,37 @@ func newResourceManager(
 		sess:         sess,
 		sdkapi:       svcsdk.New(sess),
 	}, nil
+}
+
+// onError updates resource conditions and returns updated resource
+// it returns nil if no condition is updated.
+func (rm *resourceManager) onError(
+	r *resource,
+	err error,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, err)
+	if !updated {
+		return nil, err
+	}
+	for _, condition := range r1.Conditions() {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&
+			condition.Status == corev1.ConditionTrue {
+			// resource is in Terminal condition
+			// return Terminal error
+			return r1, ackerr.Terminal
+		}
+	}
+	return r1, err
+}
+
+// onSuccess updates resource conditions and returns updated resource
+// it returns the supplied resource if no condition is updated.
+func (rm *resourceManager) onSuccess(
+	r *resource,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, nil)
+	if !updated {
+		return r, nil
+	}
+	return r1, nil
 }

--- a/services/apigatewayv2/pkg/resource/integration_response/sdk.go
+++ b/services/apigatewayv2/pkg/resource/integration_response/sdk.go
@@ -17,6 +17,7 @@ package integration_response
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -345,4 +346,51 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.Conditions == nil {
 		ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	}
+}
+
+// updateConditions returns updated resource, true; if conditions were updated
+// else it returns nil, false
+func (rm *resourceManager) updateConditions(
+	r *resource,
+	err error,
+) (*resource, bool) {
+	ko := r.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+
+	// Terminal condition
+	var terminalCondition *ackv1alpha1.Condition = nil
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
+			terminalCondition = condition
+			break
+		}
+	}
+
+	if rm.terminalAWSError(err) {
+		if terminalCondition == nil {
+			terminalCondition = &ackv1alpha1.Condition{
+				Type: ackv1alpha1.ConditionTypeTerminal,
+			}
+			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
+		}
+		terminalCondition.Status = corev1.ConditionTrue
+		awsErr, _ := ackerr.AWSError(err)
+		errorMessage := awsErr.Message()
+		terminalCondition.Message = &errorMessage
+	} else if terminalCondition != nil {
+		terminalCondition.Status = corev1.ConditionFalse
+		terminalCondition.Message = nil
+	}
+	if terminalCondition != nil {
+		return &resource{ko}, true // updated
+	}
+	return nil, false // not updated
+}
+
+// terminalAWSError returns awserr, true; if the supplied error is an aws Error type
+// and if the exception indicates that it is a Terminal exception
+// 'Terminal' exception are specified in generator configuration
+func (rm *resourceManager) terminalAWSError(err error) bool {
+	// No terminal_errors specified for this resource in generator config
+	return false
 }

--- a/services/apigatewayv2/pkg/resource/model/manager.go
+++ b/services/apigatewayv2/pkg/resource/model/manager.go
@@ -18,6 +18,8 @@ package model
 import (
 	"context"
 	"fmt"
+	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -85,7 +87,7 @@ func (rm *resourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return observed, nil
+	return rm.onSuccess(observed)
 }
 
 // Create attempts to create the supplied AWSResource in the backend AWS
@@ -102,9 +104,9 @@ func (rm *resourceManager) Create(
 	}
 	created, err := rm.sdkCreate(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
-	return created, nil
+	return rm.onSuccess(created)
 }
 
 // Update attempts to mutate the supplied desired AWSResource in the backend AWS
@@ -129,9 +131,9 @@ func (rm *resourceManager) Update(
 	}
 	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
-		return nil, err
+		return rm.onError(latest, err)
 	}
-	return updated, nil
+	return rm.onSuccess(updated)
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
@@ -180,4 +182,37 @@ func newResourceManager(
 		sess:         sess,
 		sdkapi:       svcsdk.New(sess),
 	}, nil
+}
+
+// onError updates resource conditions and returns updated resource
+// it returns nil if no condition is updated.
+func (rm *resourceManager) onError(
+	r *resource,
+	err error,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, err)
+	if !updated {
+		return nil, err
+	}
+	for _, condition := range r1.Conditions() {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&
+			condition.Status == corev1.ConditionTrue {
+			// resource is in Terminal condition
+			// return Terminal error
+			return r1, ackerr.Terminal
+		}
+	}
+	return r1, err
+}
+
+// onSuccess updates resource conditions and returns updated resource
+// it returns the supplied resource if no condition is updated.
+func (rm *resourceManager) onSuccess(
+	r *resource,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, nil)
+	if !updated {
+		return r, nil
+	}
+	return r1, nil
 }

--- a/services/apigatewayv2/pkg/resource/model/sdk.go
+++ b/services/apigatewayv2/pkg/resource/model/sdk.go
@@ -17,6 +17,7 @@ package model
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -285,4 +286,51 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.Conditions == nil {
 		ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	}
+}
+
+// updateConditions returns updated resource, true; if conditions were updated
+// else it returns nil, false
+func (rm *resourceManager) updateConditions(
+	r *resource,
+	err error,
+) (*resource, bool) {
+	ko := r.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+
+	// Terminal condition
+	var terminalCondition *ackv1alpha1.Condition = nil
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
+			terminalCondition = condition
+			break
+		}
+	}
+
+	if rm.terminalAWSError(err) {
+		if terminalCondition == nil {
+			terminalCondition = &ackv1alpha1.Condition{
+				Type: ackv1alpha1.ConditionTypeTerminal,
+			}
+			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
+		}
+		terminalCondition.Status = corev1.ConditionTrue
+		awsErr, _ := ackerr.AWSError(err)
+		errorMessage := awsErr.Message()
+		terminalCondition.Message = &errorMessage
+	} else if terminalCondition != nil {
+		terminalCondition.Status = corev1.ConditionFalse
+		terminalCondition.Message = nil
+	}
+	if terminalCondition != nil {
+		return &resource{ko}, true // updated
+	}
+	return nil, false // not updated
+}
+
+// terminalAWSError returns awserr, true; if the supplied error is an aws Error type
+// and if the exception indicates that it is a Terminal exception
+// 'Terminal' exception are specified in generator configuration
+func (rm *resourceManager) terminalAWSError(err error) bool {
+	// No terminal_errors specified for this resource in generator config
+	return false
 }

--- a/services/apigatewayv2/pkg/resource/route/manager.go
+++ b/services/apigatewayv2/pkg/resource/route/manager.go
@@ -18,6 +18,8 @@ package route
 import (
 	"context"
 	"fmt"
+	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -85,7 +87,7 @@ func (rm *resourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return observed, nil
+	return rm.onSuccess(observed)
 }
 
 // Create attempts to create the supplied AWSResource in the backend AWS
@@ -102,9 +104,9 @@ func (rm *resourceManager) Create(
 	}
 	created, err := rm.sdkCreate(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
-	return created, nil
+	return rm.onSuccess(created)
 }
 
 // Update attempts to mutate the supplied desired AWSResource in the backend AWS
@@ -129,9 +131,9 @@ func (rm *resourceManager) Update(
 	}
 	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
-		return nil, err
+		return rm.onError(latest, err)
 	}
-	return updated, nil
+	return rm.onSuccess(updated)
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
@@ -180,4 +182,37 @@ func newResourceManager(
 		sess:         sess,
 		sdkapi:       svcsdk.New(sess),
 	}, nil
+}
+
+// onError updates resource conditions and returns updated resource
+// it returns nil if no condition is updated.
+func (rm *resourceManager) onError(
+	r *resource,
+	err error,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, err)
+	if !updated {
+		return nil, err
+	}
+	for _, condition := range r1.Conditions() {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&
+			condition.Status == corev1.ConditionTrue {
+			// resource is in Terminal condition
+			// return Terminal error
+			return r1, ackerr.Terminal
+		}
+	}
+	return r1, err
+}
+
+// onSuccess updates resource conditions and returns updated resource
+// it returns the supplied resource if no condition is updated.
+func (rm *resourceManager) onSuccess(
+	r *resource,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, nil)
+	if !updated {
+		return r, nil
+	}
+	return r1, nil
 }

--- a/services/apigatewayv2/pkg/resource/route/sdk.go
+++ b/services/apigatewayv2/pkg/resource/route/sdk.go
@@ -17,6 +17,7 @@ package route
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -417,4 +418,51 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.Conditions == nil {
 		ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	}
+}
+
+// updateConditions returns updated resource, true; if conditions were updated
+// else it returns nil, false
+func (rm *resourceManager) updateConditions(
+	r *resource,
+	err error,
+) (*resource, bool) {
+	ko := r.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+
+	// Terminal condition
+	var terminalCondition *ackv1alpha1.Condition = nil
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
+			terminalCondition = condition
+			break
+		}
+	}
+
+	if rm.terminalAWSError(err) {
+		if terminalCondition == nil {
+			terminalCondition = &ackv1alpha1.Condition{
+				Type: ackv1alpha1.ConditionTypeTerminal,
+			}
+			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
+		}
+		terminalCondition.Status = corev1.ConditionTrue
+		awsErr, _ := ackerr.AWSError(err)
+		errorMessage := awsErr.Message()
+		terminalCondition.Message = &errorMessage
+	} else if terminalCondition != nil {
+		terminalCondition.Status = corev1.ConditionFalse
+		terminalCondition.Message = nil
+	}
+	if terminalCondition != nil {
+		return &resource{ko}, true // updated
+	}
+	return nil, false // not updated
+}
+
+// terminalAWSError returns awserr, true; if the supplied error is an aws Error type
+// and if the exception indicates that it is a Terminal exception
+// 'Terminal' exception are specified in generator configuration
+func (rm *resourceManager) terminalAWSError(err error) bool {
+	// No terminal_errors specified for this resource in generator config
+	return false
 }

--- a/services/apigatewayv2/pkg/resource/route_response/manager.go
+++ b/services/apigatewayv2/pkg/resource/route_response/manager.go
@@ -18,6 +18,8 @@ package route_response
 import (
 	"context"
 	"fmt"
+	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -85,7 +87,7 @@ func (rm *resourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return observed, nil
+	return rm.onSuccess(observed)
 }
 
 // Create attempts to create the supplied AWSResource in the backend AWS
@@ -102,9 +104,9 @@ func (rm *resourceManager) Create(
 	}
 	created, err := rm.sdkCreate(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
-	return created, nil
+	return rm.onSuccess(created)
 }
 
 // Update attempts to mutate the supplied desired AWSResource in the backend AWS
@@ -129,9 +131,9 @@ func (rm *resourceManager) Update(
 	}
 	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
-		return nil, err
+		return rm.onError(latest, err)
 	}
-	return updated, nil
+	return rm.onSuccess(updated)
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
@@ -180,4 +182,37 @@ func newResourceManager(
 		sess:         sess,
 		sdkapi:       svcsdk.New(sess),
 	}, nil
+}
+
+// onError updates resource conditions and returns updated resource
+// it returns nil if no condition is updated.
+func (rm *resourceManager) onError(
+	r *resource,
+	err error,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, err)
+	if !updated {
+		return nil, err
+	}
+	for _, condition := range r1.Conditions() {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&
+			condition.Status == corev1.ConditionTrue {
+			// resource is in Terminal condition
+			// return Terminal error
+			return r1, ackerr.Terminal
+		}
+	}
+	return r1, err
+}
+
+// onSuccess updates resource conditions and returns updated resource
+// it returns the supplied resource if no condition is updated.
+func (rm *resourceManager) onSuccess(
+	r *resource,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, nil)
+	if !updated {
+		return r, nil
+	}
+	return r1, nil
 }

--- a/services/apigatewayv2/pkg/resource/route_response/sdk.go
+++ b/services/apigatewayv2/pkg/resource/route_response/sdk.go
@@ -17,6 +17,7 @@ package route_response
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -342,4 +343,51 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.Conditions == nil {
 		ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	}
+}
+
+// updateConditions returns updated resource, true; if conditions were updated
+// else it returns nil, false
+func (rm *resourceManager) updateConditions(
+	r *resource,
+	err error,
+) (*resource, bool) {
+	ko := r.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+
+	// Terminal condition
+	var terminalCondition *ackv1alpha1.Condition = nil
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
+			terminalCondition = condition
+			break
+		}
+	}
+
+	if rm.terminalAWSError(err) {
+		if terminalCondition == nil {
+			terminalCondition = &ackv1alpha1.Condition{
+				Type: ackv1alpha1.ConditionTypeTerminal,
+			}
+			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
+		}
+		terminalCondition.Status = corev1.ConditionTrue
+		awsErr, _ := ackerr.AWSError(err)
+		errorMessage := awsErr.Message()
+		terminalCondition.Message = &errorMessage
+	} else if terminalCondition != nil {
+		terminalCondition.Status = corev1.ConditionFalse
+		terminalCondition.Message = nil
+	}
+	if terminalCondition != nil {
+		return &resource{ko}, true // updated
+	}
+	return nil, false // not updated
+}
+
+// terminalAWSError returns awserr, true; if the supplied error is an aws Error type
+// and if the exception indicates that it is a Terminal exception
+// 'Terminal' exception are specified in generator configuration
+func (rm *resourceManager) terminalAWSError(err error) bool {
+	// No terminal_errors specified for this resource in generator config
+	return false
 }

--- a/services/apigatewayv2/pkg/resource/stage/manager.go
+++ b/services/apigatewayv2/pkg/resource/stage/manager.go
@@ -18,6 +18,8 @@ package stage
 import (
 	"context"
 	"fmt"
+	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -85,7 +87,7 @@ func (rm *resourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return observed, nil
+	return rm.onSuccess(observed)
 }
 
 // Create attempts to create the supplied AWSResource in the backend AWS
@@ -102,9 +104,9 @@ func (rm *resourceManager) Create(
 	}
 	created, err := rm.sdkCreate(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
-	return created, nil
+	return rm.onSuccess(created)
 }
 
 // Update attempts to mutate the supplied desired AWSResource in the backend AWS
@@ -129,9 +131,9 @@ func (rm *resourceManager) Update(
 	}
 	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
-		return nil, err
+		return rm.onError(latest, err)
 	}
-	return updated, nil
+	return rm.onSuccess(updated)
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
@@ -180,4 +182,37 @@ func newResourceManager(
 		sess:         sess,
 		sdkapi:       svcsdk.New(sess),
 	}, nil
+}
+
+// onError updates resource conditions and returns updated resource
+// it returns nil if no condition is updated.
+func (rm *resourceManager) onError(
+	r *resource,
+	err error,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, err)
+	if !updated {
+		return nil, err
+	}
+	for _, condition := range r1.Conditions() {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&
+			condition.Status == corev1.ConditionTrue {
+			// resource is in Terminal condition
+			// return Terminal error
+			return r1, ackerr.Terminal
+		}
+	}
+	return r1, err
+}
+
+// onSuccess updates resource conditions and returns updated resource
+// it returns the supplied resource if no condition is updated.
+func (rm *resourceManager) onSuccess(
+	r *resource,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, nil)
+	if !updated {
+		return r, nil
+	}
+	return r1, nil
 }

--- a/services/apigatewayv2/pkg/resource/stage/sdk.go
+++ b/services/apigatewayv2/pkg/resource/stage/sdk.go
@@ -17,6 +17,7 @@ package stage
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -519,4 +520,51 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.Conditions == nil {
 		ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	}
+}
+
+// updateConditions returns updated resource, true; if conditions were updated
+// else it returns nil, false
+func (rm *resourceManager) updateConditions(
+	r *resource,
+	err error,
+) (*resource, bool) {
+	ko := r.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+
+	// Terminal condition
+	var terminalCondition *ackv1alpha1.Condition = nil
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
+			terminalCondition = condition
+			break
+		}
+	}
+
+	if rm.terminalAWSError(err) {
+		if terminalCondition == nil {
+			terminalCondition = &ackv1alpha1.Condition{
+				Type: ackv1alpha1.ConditionTypeTerminal,
+			}
+			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
+		}
+		terminalCondition.Status = corev1.ConditionTrue
+		awsErr, _ := ackerr.AWSError(err)
+		errorMessage := awsErr.Message()
+		terminalCondition.Message = &errorMessage
+	} else if terminalCondition != nil {
+		terminalCondition.Status = corev1.ConditionFalse
+		terminalCondition.Message = nil
+	}
+	if terminalCondition != nil {
+		return &resource{ko}, true // updated
+	}
+	return nil, false // not updated
+}
+
+// terminalAWSError returns awserr, true; if the supplied error is an aws Error type
+// and if the exception indicates that it is a Terminal exception
+// 'Terminal' exception are specified in generator configuration
+func (rm *resourceManager) terminalAWSError(err error) bool {
+	// No terminal_errors specified for this resource in generator config
+	return false
 }

--- a/services/apigatewayv2/pkg/resource/vpc_link/manager.go
+++ b/services/apigatewayv2/pkg/resource/vpc_link/manager.go
@@ -18,6 +18,8 @@ package vpc_link
 import (
 	"context"
 	"fmt"
+	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -85,7 +87,7 @@ func (rm *resourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return observed, nil
+	return rm.onSuccess(observed)
 }
 
 // Create attempts to create the supplied AWSResource in the backend AWS
@@ -102,9 +104,9 @@ func (rm *resourceManager) Create(
 	}
 	created, err := rm.sdkCreate(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
-	return created, nil
+	return rm.onSuccess(created)
 }
 
 // Update attempts to mutate the supplied desired AWSResource in the backend AWS
@@ -129,9 +131,9 @@ func (rm *resourceManager) Update(
 	}
 	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
-		return nil, err
+		return rm.onError(latest, err)
 	}
-	return updated, nil
+	return rm.onSuccess(updated)
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
@@ -180,4 +182,37 @@ func newResourceManager(
 		sess:         sess,
 		sdkapi:       svcsdk.New(sess),
 	}, nil
+}
+
+// onError updates resource conditions and returns updated resource
+// it returns nil if no condition is updated.
+func (rm *resourceManager) onError(
+	r *resource,
+	err error,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, err)
+	if !updated {
+		return nil, err
+	}
+	for _, condition := range r1.Conditions() {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&
+			condition.Status == corev1.ConditionTrue {
+			// resource is in Terminal condition
+			// return Terminal error
+			return r1, ackerr.Terminal
+		}
+	}
+	return r1, err
+}
+
+// onSuccess updates resource conditions and returns updated resource
+// it returns the supplied resource if no condition is updated.
+func (rm *resourceManager) onSuccess(
+	r *resource,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, nil)
+	if !updated {
+		return r, nil
+	}
+	return r1, nil
 }

--- a/services/apigatewayv2/pkg/resource/vpc_link/sdk.go
+++ b/services/apigatewayv2/pkg/resource/vpc_link/sdk.go
@@ -17,6 +17,7 @@ package vpc_link
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -332,4 +333,51 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.Conditions == nil {
 		ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	}
+}
+
+// updateConditions returns updated resource, true; if conditions were updated
+// else it returns nil, false
+func (rm *resourceManager) updateConditions(
+	r *resource,
+	err error,
+) (*resource, bool) {
+	ko := r.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+
+	// Terminal condition
+	var terminalCondition *ackv1alpha1.Condition = nil
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
+			terminalCondition = condition
+			break
+		}
+	}
+
+	if rm.terminalAWSError(err) {
+		if terminalCondition == nil {
+			terminalCondition = &ackv1alpha1.Condition{
+				Type: ackv1alpha1.ConditionTypeTerminal,
+			}
+			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
+		}
+		terminalCondition.Status = corev1.ConditionTrue
+		awsErr, _ := ackerr.AWSError(err)
+		errorMessage := awsErr.Message()
+		terminalCondition.Message = &errorMessage
+	} else if terminalCondition != nil {
+		terminalCondition.Status = corev1.ConditionFalse
+		terminalCondition.Message = nil
+	}
+	if terminalCondition != nil {
+		return &resource{ko}, true // updated
+	}
+	return nil, false // not updated
+}
+
+// terminalAWSError returns awserr, true; if the supplied error is an aws Error type
+// and if the exception indicates that it is a Terminal exception
+// 'Terminal' exception are specified in generator configuration
+func (rm *resourceManager) terminalAWSError(err error) bool {
+	// No terminal_errors specified for this resource in generator config
+	return false
 }

--- a/services/dynamodb/pkg/resource/backup/manager.go
+++ b/services/dynamodb/pkg/resource/backup/manager.go
@@ -18,6 +18,8 @@ package backup
 import (
 	"context"
 	"fmt"
+	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -85,7 +87,7 @@ func (rm *resourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return observed, nil
+	return rm.onSuccess(observed)
 }
 
 // Create attempts to create the supplied AWSResource in the backend AWS
@@ -102,9 +104,9 @@ func (rm *resourceManager) Create(
 	}
 	created, err := rm.sdkCreate(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
-	return created, nil
+	return rm.onSuccess(created)
 }
 
 // Update attempts to mutate the supplied desired AWSResource in the backend AWS
@@ -129,9 +131,9 @@ func (rm *resourceManager) Update(
 	}
 	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
-		return nil, err
+		return rm.onError(latest, err)
 	}
-	return updated, nil
+	return rm.onSuccess(updated)
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
@@ -180,4 +182,37 @@ func newResourceManager(
 		sess:         sess,
 		sdkapi:       svcsdk.New(sess),
 	}, nil
+}
+
+// onError updates resource conditions and returns updated resource
+// it returns nil if no condition is updated.
+func (rm *resourceManager) onError(
+	r *resource,
+	err error,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, err)
+	if !updated {
+		return nil, err
+	}
+	for _, condition := range r1.Conditions() {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&
+			condition.Status == corev1.ConditionTrue {
+			// resource is in Terminal condition
+			// return Terminal error
+			return r1, ackerr.Terminal
+		}
+	}
+	return r1, err
+}
+
+// onSuccess updates resource conditions and returns updated resource
+// it returns the supplied resource if no condition is updated.
+func (rm *resourceManager) onSuccess(
+	r *resource,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, nil)
+	if !updated {
+		return r, nil
+	}
+	return r1, nil
 }

--- a/services/dynamodb/pkg/resource/backup/sdk.go
+++ b/services/dynamodb/pkg/resource/backup/sdk.go
@@ -17,6 +17,7 @@ package backup
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -232,4 +233,51 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.Conditions == nil {
 		ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	}
+}
+
+// updateConditions returns updated resource, true; if conditions were updated
+// else it returns nil, false
+func (rm *resourceManager) updateConditions(
+	r *resource,
+	err error,
+) (*resource, bool) {
+	ko := r.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+
+	// Terminal condition
+	var terminalCondition *ackv1alpha1.Condition = nil
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
+			terminalCondition = condition
+			break
+		}
+	}
+
+	if rm.terminalAWSError(err) {
+		if terminalCondition == nil {
+			terminalCondition = &ackv1alpha1.Condition{
+				Type: ackv1alpha1.ConditionTypeTerminal,
+			}
+			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
+		}
+		terminalCondition.Status = corev1.ConditionTrue
+		awsErr, _ := ackerr.AWSError(err)
+		errorMessage := awsErr.Message()
+		terminalCondition.Message = &errorMessage
+	} else if terminalCondition != nil {
+		terminalCondition.Status = corev1.ConditionFalse
+		terminalCondition.Message = nil
+	}
+	if terminalCondition != nil {
+		return &resource{ko}, true // updated
+	}
+	return nil, false // not updated
+}
+
+// terminalAWSError returns awserr, true; if the supplied error is an aws Error type
+// and if the exception indicates that it is a Terminal exception
+// 'Terminal' exception are specified in generator configuration
+func (rm *resourceManager) terminalAWSError(err error) bool {
+	// No terminal_errors specified for this resource in generator config
+	return false
 }

--- a/services/dynamodb/pkg/resource/global_table/manager.go
+++ b/services/dynamodb/pkg/resource/global_table/manager.go
@@ -18,6 +18,8 @@ package global_table
 import (
 	"context"
 	"fmt"
+	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -85,7 +87,7 @@ func (rm *resourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return observed, nil
+	return rm.onSuccess(observed)
 }
 
 // Create attempts to create the supplied AWSResource in the backend AWS
@@ -102,9 +104,9 @@ func (rm *resourceManager) Create(
 	}
 	created, err := rm.sdkCreate(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
-	return created, nil
+	return rm.onSuccess(created)
 }
 
 // Update attempts to mutate the supplied desired AWSResource in the backend AWS
@@ -129,9 +131,9 @@ func (rm *resourceManager) Update(
 	}
 	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
-		return nil, err
+		return rm.onError(latest, err)
 	}
-	return updated, nil
+	return rm.onSuccess(updated)
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
@@ -180,4 +182,37 @@ func newResourceManager(
 		sess:         sess,
 		sdkapi:       svcsdk.New(sess),
 	}, nil
+}
+
+// onError updates resource conditions and returns updated resource
+// it returns nil if no condition is updated.
+func (rm *resourceManager) onError(
+	r *resource,
+	err error,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, err)
+	if !updated {
+		return nil, err
+	}
+	for _, condition := range r1.Conditions() {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&
+			condition.Status == corev1.ConditionTrue {
+			// resource is in Terminal condition
+			// return Terminal error
+			return r1, ackerr.Terminal
+		}
+	}
+	return r1, err
+}
+
+// onSuccess updates resource conditions and returns updated resource
+// it returns the supplied resource if no condition is updated.
+func (rm *resourceManager) onSuccess(
+	r *resource,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, nil)
+	if !updated {
+		return r, nil
+	}
+	return r1, nil
 }

--- a/services/dynamodb/pkg/resource/global_table/sdk.go
+++ b/services/dynamodb/pkg/resource/global_table/sdk.go
@@ -17,6 +17,7 @@ package global_table
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -274,4 +275,51 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.Conditions == nil {
 		ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	}
+}
+
+// updateConditions returns updated resource, true; if conditions were updated
+// else it returns nil, false
+func (rm *resourceManager) updateConditions(
+	r *resource,
+	err error,
+) (*resource, bool) {
+	ko := r.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+
+	// Terminal condition
+	var terminalCondition *ackv1alpha1.Condition = nil
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
+			terminalCondition = condition
+			break
+		}
+	}
+
+	if rm.terminalAWSError(err) {
+		if terminalCondition == nil {
+			terminalCondition = &ackv1alpha1.Condition{
+				Type: ackv1alpha1.ConditionTypeTerminal,
+			}
+			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
+		}
+		terminalCondition.Status = corev1.ConditionTrue
+		awsErr, _ := ackerr.AWSError(err)
+		errorMessage := awsErr.Message()
+		terminalCondition.Message = &errorMessage
+	} else if terminalCondition != nil {
+		terminalCondition.Status = corev1.ConditionFalse
+		terminalCondition.Message = nil
+	}
+	if terminalCondition != nil {
+		return &resource{ko}, true // updated
+	}
+	return nil, false // not updated
+}
+
+// terminalAWSError returns awserr, true; if the supplied error is an aws Error type
+// and if the exception indicates that it is a Terminal exception
+// 'Terminal' exception are specified in generator configuration
+func (rm *resourceManager) terminalAWSError(err error) bool {
+	// No terminal_errors specified for this resource in generator config
+	return false
 }

--- a/services/dynamodb/pkg/resource/table/manager.go
+++ b/services/dynamodb/pkg/resource/table/manager.go
@@ -18,6 +18,8 @@ package table
 import (
 	"context"
 	"fmt"
+	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -85,7 +87,7 @@ func (rm *resourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return observed, nil
+	return rm.onSuccess(observed)
 }
 
 // Create attempts to create the supplied AWSResource in the backend AWS
@@ -102,9 +104,9 @@ func (rm *resourceManager) Create(
 	}
 	created, err := rm.sdkCreate(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
-	return created, nil
+	return rm.onSuccess(created)
 }
 
 // Update attempts to mutate the supplied desired AWSResource in the backend AWS
@@ -129,9 +131,9 @@ func (rm *resourceManager) Update(
 	}
 	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
-		return nil, err
+		return rm.onError(latest, err)
 	}
-	return updated, nil
+	return rm.onSuccess(updated)
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
@@ -180,4 +182,37 @@ func newResourceManager(
 		sess:         sess,
 		sdkapi:       svcsdk.New(sess),
 	}, nil
+}
+
+// onError updates resource conditions and returns updated resource
+// it returns nil if no condition is updated.
+func (rm *resourceManager) onError(
+	r *resource,
+	err error,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, err)
+	if !updated {
+		return nil, err
+	}
+	for _, condition := range r1.Conditions() {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&
+			condition.Status == corev1.ConditionTrue {
+			// resource is in Terminal condition
+			// return Terminal error
+			return r1, ackerr.Terminal
+		}
+	}
+	return r1, err
+}
+
+// onSuccess updates resource conditions and returns updated resource
+// it returns the supplied resource if no condition is updated.
+func (rm *resourceManager) onSuccess(
+	r *resource,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, nil)
+	if !updated {
+		return r, nil
+	}
+	return r1, nil
 }

--- a/services/dynamodb/pkg/resource/table/sdk.go
+++ b/services/dynamodb/pkg/resource/table/sdk.go
@@ -17,6 +17,7 @@ package table
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -992,4 +993,51 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.Conditions == nil {
 		ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	}
+}
+
+// updateConditions returns updated resource, true; if conditions were updated
+// else it returns nil, false
+func (rm *resourceManager) updateConditions(
+	r *resource,
+	err error,
+) (*resource, bool) {
+	ko := r.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+
+	// Terminal condition
+	var terminalCondition *ackv1alpha1.Condition = nil
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
+			terminalCondition = condition
+			break
+		}
+	}
+
+	if rm.terminalAWSError(err) {
+		if terminalCondition == nil {
+			terminalCondition = &ackv1alpha1.Condition{
+				Type: ackv1alpha1.ConditionTypeTerminal,
+			}
+			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
+		}
+		terminalCondition.Status = corev1.ConditionTrue
+		awsErr, _ := ackerr.AWSError(err)
+		errorMessage := awsErr.Message()
+		terminalCondition.Message = &errorMessage
+	} else if terminalCondition != nil {
+		terminalCondition.Status = corev1.ConditionFalse
+		terminalCondition.Message = nil
+	}
+	if terminalCondition != nil {
+		return &resource{ko}, true // updated
+	}
+	return nil, false // not updated
+}
+
+// terminalAWSError returns awserr, true; if the supplied error is an aws Error type
+// and if the exception indicates that it is a Terminal exception
+// 'Terminal' exception are specified in generator configuration
+func (rm *resourceManager) terminalAWSError(err error) bool {
+	// No terminal_errors specified for this resource in generator config
+	return false
 }

--- a/services/ecr/pkg/resource/repository/manager.go
+++ b/services/ecr/pkg/resource/repository/manager.go
@@ -18,6 +18,8 @@ package repository
 import (
 	"context"
 	"fmt"
+	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -85,7 +87,7 @@ func (rm *resourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return observed, nil
+	return rm.onSuccess(observed)
 }
 
 // Create attempts to create the supplied AWSResource in the backend AWS
@@ -102,9 +104,9 @@ func (rm *resourceManager) Create(
 	}
 	created, err := rm.sdkCreate(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
-	return created, nil
+	return rm.onSuccess(created)
 }
 
 // Update attempts to mutate the supplied desired AWSResource in the backend AWS
@@ -129,9 +131,9 @@ func (rm *resourceManager) Update(
 	}
 	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
-		return nil, err
+		return rm.onError(latest, err)
 	}
-	return updated, nil
+	return rm.onSuccess(updated)
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
@@ -180,4 +182,37 @@ func newResourceManager(
 		sess:         sess,
 		sdkapi:       svcsdk.New(sess),
 	}, nil
+}
+
+// onError updates resource conditions and returns updated resource
+// it returns nil if no condition is updated.
+func (rm *resourceManager) onError(
+	r *resource,
+	err error,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, err)
+	if !updated {
+		return nil, err
+	}
+	for _, condition := range r1.Conditions() {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&
+			condition.Status == corev1.ConditionTrue {
+			// resource is in Terminal condition
+			// return Terminal error
+			return r1, ackerr.Terminal
+		}
+	}
+	return r1, err
+}
+
+// onSuccess updates resource conditions and returns updated resource
+// it returns the supplied resource if no condition is updated.
+func (rm *resourceManager) onSuccess(
+	r *resource,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, nil)
+	if !updated {
+		return r, nil
+	}
+	return r1, nil
 }

--- a/services/ecr/pkg/resource/repository/sdk.go
+++ b/services/ecr/pkg/resource/repository/sdk.go
@@ -17,6 +17,7 @@ package repository
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -278,4 +279,51 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.Conditions == nil {
 		ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	}
+}
+
+// updateConditions returns updated resource, true; if conditions were updated
+// else it returns nil, false
+func (rm *resourceManager) updateConditions(
+	r *resource,
+	err error,
+) (*resource, bool) {
+	ko := r.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+
+	// Terminal condition
+	var terminalCondition *ackv1alpha1.Condition = nil
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
+			terminalCondition = condition
+			break
+		}
+	}
+
+	if rm.terminalAWSError(err) {
+		if terminalCondition == nil {
+			terminalCondition = &ackv1alpha1.Condition{
+				Type: ackv1alpha1.ConditionTypeTerminal,
+			}
+			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
+		}
+		terminalCondition.Status = corev1.ConditionTrue
+		awsErr, _ := ackerr.AWSError(err)
+		errorMessage := awsErr.Message()
+		terminalCondition.Message = &errorMessage
+	} else if terminalCondition != nil {
+		terminalCondition.Status = corev1.ConditionFalse
+		terminalCondition.Message = nil
+	}
+	if terminalCondition != nil {
+		return &resource{ko}, true // updated
+	}
+	return nil, false // not updated
+}
+
+// terminalAWSError returns awserr, true; if the supplied error is an aws Error type
+// and if the exception indicates that it is a Terminal exception
+// 'Terminal' exception are specified in generator configuration
+func (rm *resourceManager) terminalAWSError(err error) bool {
+	// No terminal_errors specified for this resource in generator config
+	return false
 }

--- a/services/elasticache/generator.yaml
+++ b/services/elasticache/generator.yaml
@@ -3,6 +3,13 @@ resources:
     exceptions:
       codes:
         404: CacheSubnetGroupNotFoundFault
+  ReplicationGroup:
+    update_conditions_custom_method_name: CustomUpdateConditions
+    exceptions:
+      terminal_codes:
+        - InvalidParameter
+        - InvalidParameterValue
+        - InvalidParameterCombination
 operations:
   DescribeReplicationGroups:
     set_output_custom_method_name: CustomDescribeReplicationGroupsSetOutput

--- a/services/elasticache/pkg/resource/cache_subnet_group/manager.go
+++ b/services/elasticache/pkg/resource/cache_subnet_group/manager.go
@@ -18,6 +18,8 @@ package cache_subnet_group
 import (
 	"context"
 	"fmt"
+	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -85,7 +87,7 @@ func (rm *resourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return observed, nil
+	return rm.onSuccess(observed)
 }
 
 // Create attempts to create the supplied AWSResource in the backend AWS
@@ -102,9 +104,9 @@ func (rm *resourceManager) Create(
 	}
 	created, err := rm.sdkCreate(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
-	return created, nil
+	return rm.onSuccess(created)
 }
 
 // Update attempts to mutate the supplied desired AWSResource in the backend AWS
@@ -129,9 +131,9 @@ func (rm *resourceManager) Update(
 	}
 	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
-		return nil, err
+		return rm.onError(latest, err)
 	}
-	return updated, nil
+	return rm.onSuccess(updated)
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
@@ -180,4 +182,37 @@ func newResourceManager(
 		sess:         sess,
 		sdkapi:       svcsdk.New(sess),
 	}, nil
+}
+
+// onError updates resource conditions and returns updated resource
+// it returns nil if no condition is updated.
+func (rm *resourceManager) onError(
+	r *resource,
+	err error,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, err)
+	if !updated {
+		return nil, err
+	}
+	for _, condition := range r1.Conditions() {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&
+			condition.Status == corev1.ConditionTrue {
+			// resource is in Terminal condition
+			// return Terminal error
+			return r1, ackerr.Terminal
+		}
+	}
+	return r1, err
+}
+
+// onSuccess updates resource conditions and returns updated resource
+// it returns the supplied resource if no condition is updated.
+func (rm *resourceManager) onSuccess(
+	r *resource,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, nil)
+	if !updated {
+		return r, nil
+	}
+	return r1, nil
 }

--- a/services/elasticache/pkg/resource/cache_subnet_group/sdk.go
+++ b/services/elasticache/pkg/resource/cache_subnet_group/sdk.go
@@ -17,6 +17,7 @@ package cache_subnet_group
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -326,4 +327,51 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.Conditions == nil {
 		ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	}
+}
+
+// updateConditions returns updated resource, true; if conditions were updated
+// else it returns nil, false
+func (rm *resourceManager) updateConditions(
+	r *resource,
+	err error,
+) (*resource, bool) {
+	ko := r.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+
+	// Terminal condition
+	var terminalCondition *ackv1alpha1.Condition = nil
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
+			terminalCondition = condition
+			break
+		}
+	}
+
+	if rm.terminalAWSError(err) {
+		if terminalCondition == nil {
+			terminalCondition = &ackv1alpha1.Condition{
+				Type: ackv1alpha1.ConditionTypeTerminal,
+			}
+			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
+		}
+		terminalCondition.Status = corev1.ConditionTrue
+		awsErr, _ := ackerr.AWSError(err)
+		errorMessage := awsErr.Message()
+		terminalCondition.Message = &errorMessage
+	} else if terminalCondition != nil {
+		terminalCondition.Status = corev1.ConditionFalse
+		terminalCondition.Message = nil
+	}
+	if terminalCondition != nil {
+		return &resource{ko}, true // updated
+	}
+	return nil, false // not updated
+}
+
+// terminalAWSError returns awserr, true; if the supplied error is an aws Error type
+// and if the exception indicates that it is a Terminal exception
+// 'Terminal' exception are specified in generator configuration
+func (rm *resourceManager) terminalAWSError(err error) bool {
+	// No terminal_errors specified for this resource in generator config
+	return false
 }

--- a/services/elasticache/pkg/resource/replication_group/custom_set_conditions.go
+++ b/services/elasticache/pkg/resource/replication_group/custom_set_conditions.go
@@ -1,0 +1,60 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package replication_group
+
+import (
+	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	svcapitypes "github.com/aws/aws-controllers-k8s/services/elasticache/apis/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// CustomUpdateConditions sets conditions (terminal) on supplied replication group
+// it examines supplied resource to determine conditions.
+// It returns true if conditions are updated
+func (rm *resourceManager) CustomUpdateConditions(
+	ko *svcapitypes.ReplicationGroup,
+	r *resource,
+	err error,
+) bool {
+	rgStatus := r.ko.Status.Status
+	if rgStatus == nil || *rgStatus != "create-failed" {
+		return false
+	}
+	// Terminal condition
+	var terminalCondition *ackv1alpha1.Condition = nil
+	if ko.Status.Conditions == nil {
+		ko.Status.Conditions = []*ackv1alpha1.Condition{}
+	} else {
+		for _, condition := range ko.Status.Conditions {
+			if condition.Type == ackv1alpha1.ConditionTypeTerminal {
+				terminalCondition = condition
+				break
+			}
+		}
+		if terminalCondition != nil && terminalCondition.Status == corev1.ConditionTrue {
+			// some other exception already put the resource in terminal condition
+			return false
+		}
+	}
+	if terminalCondition == nil {
+		terminalCondition = &ackv1alpha1.Condition{
+			Type: ackv1alpha1.ConditionTypeTerminal,
+		}
+		ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
+	}
+	terminalCondition.Status = corev1.ConditionTrue
+	errorMessage := "Replication group status: create-failed"
+	terminalCondition.Message = &errorMessage
+	return true
+}

--- a/services/elasticache/pkg/resource/replication_group/manager.go
+++ b/services/elasticache/pkg/resource/replication_group/manager.go
@@ -18,6 +18,8 @@ package replication_group
 import (
 	"context"
 	"fmt"
+	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -85,7 +87,7 @@ func (rm *resourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return observed, nil
+	return rm.onSuccess(observed)
 }
 
 // Create attempts to create the supplied AWSResource in the backend AWS
@@ -102,9 +104,9 @@ func (rm *resourceManager) Create(
 	}
 	created, err := rm.sdkCreate(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
-	return created, nil
+	return rm.onSuccess(created)
 }
 
 // Update attempts to mutate the supplied desired AWSResource in the backend AWS
@@ -129,9 +131,9 @@ func (rm *resourceManager) Update(
 	}
 	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
-		return nil, err
+		return rm.onError(latest, err)
 	}
-	return updated, nil
+	return rm.onSuccess(updated)
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
@@ -180,4 +182,37 @@ func newResourceManager(
 		sess:         sess,
 		sdkapi:       svcsdk.New(sess),
 	}, nil
+}
+
+// onError updates resource conditions and returns updated resource
+// it returns nil if no condition is updated.
+func (rm *resourceManager) onError(
+	r *resource,
+	err error,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, err)
+	if !updated {
+		return nil, err
+	}
+	for _, condition := range r1.Conditions() {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&
+			condition.Status == corev1.ConditionTrue {
+			// resource is in Terminal condition
+			// return Terminal error
+			return r1, ackerr.Terminal
+		}
+	}
+	return r1, err
+}
+
+// onSuccess updates resource conditions and returns updated resource
+// it returns the supplied resource if no condition is updated.
+func (rm *resourceManager) onSuccess(
+	r *resource,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, nil)
+	if !updated {
+		return r, nil
+	}
+	return r1, nil
 }

--- a/services/elasticache/pkg/resource/replication_group/sdk.go
+++ b/services/elasticache/pkg/resource/replication_group/sdk.go
@@ -17,6 +17,7 @@ package replication_group
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -911,5 +912,65 @@ func (rm *resourceManager) setStatusDefaults(
 	}
 	if ko.Status.Conditions == nil {
 		ko.Status.Conditions = []*ackv1alpha1.Condition{}
+	}
+}
+
+// updateConditions returns updated resource, true; if conditions were updated
+// else it returns nil, false
+func (rm *resourceManager) updateConditions(
+	r *resource,
+	err error,
+) (*resource, bool) {
+	ko := r.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+
+	// Terminal condition
+	var terminalCondition *ackv1alpha1.Condition = nil
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
+			terminalCondition = condition
+			break
+		}
+	}
+
+	if rm.terminalAWSError(err) {
+		if terminalCondition == nil {
+			terminalCondition = &ackv1alpha1.Condition{
+				Type: ackv1alpha1.ConditionTypeTerminal,
+			}
+			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
+		}
+		terminalCondition.Status = corev1.ConditionTrue
+		awsErr, _ := ackerr.AWSError(err)
+		errorMessage := awsErr.Message()
+		terminalCondition.Message = &errorMessage
+	} else if terminalCondition != nil {
+		terminalCondition.Status = corev1.ConditionFalse
+		terminalCondition.Message = nil
+	}
+	// custom update conditions
+	customUpdate := rm.CustomUpdateConditions(ko, r, err)
+	if terminalCondition != nil || customUpdate {
+		return &resource{ko}, true // updated
+	}
+	return nil, false // not updated
+}
+
+// terminalAWSError returns awserr, true; if the supplied error is an aws Error type
+// and if the exception indicates that it is a Terminal exception
+// 'Terminal' exception are specified in generator configuration
+func (rm *resourceManager) terminalAWSError(err error) bool {
+	if err == nil {
+		return false
+	}
+	awsErr, ok := ackerr.AWSError(err)
+	if !ok {
+		return false
+	}
+	switch awsErr.Code() {
+	case "InvalidParameter", "InvalidParameterValue", "InvalidParameterCombination":
+		return true
+	default:
+		return false
 	}
 }

--- a/services/s3/pkg/resource/bucket/manager.go
+++ b/services/s3/pkg/resource/bucket/manager.go
@@ -18,6 +18,8 @@ package bucket
 import (
 	"context"
 	"fmt"
+	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -85,7 +87,7 @@ func (rm *resourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return observed, nil
+	return rm.onSuccess(observed)
 }
 
 // Create attempts to create the supplied AWSResource in the backend AWS
@@ -102,9 +104,9 @@ func (rm *resourceManager) Create(
 	}
 	created, err := rm.sdkCreate(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
-	return created, nil
+	return rm.onSuccess(created)
 }
 
 // Update attempts to mutate the supplied desired AWSResource in the backend AWS
@@ -129,9 +131,9 @@ func (rm *resourceManager) Update(
 	}
 	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
-		return nil, err
+		return rm.onError(latest, err)
 	}
-	return updated, nil
+	return rm.onSuccess(updated)
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
@@ -180,4 +182,37 @@ func newResourceManager(
 		sess:         sess,
 		sdkapi:       svcsdk.New(sess),
 	}, nil
+}
+
+// onError updates resource conditions and returns updated resource
+// it returns nil if no condition is updated.
+func (rm *resourceManager) onError(
+	r *resource,
+	err error,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, err)
+	if !updated {
+		return nil, err
+	}
+	for _, condition := range r1.Conditions() {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&
+			condition.Status == corev1.ConditionTrue {
+			// resource is in Terminal condition
+			// return Terminal error
+			return r1, ackerr.Terminal
+		}
+	}
+	return r1, err
+}
+
+// onSuccess updates resource conditions and returns updated resource
+// it returns the supplied resource if no condition is updated.
+func (rm *resourceManager) onSuccess(
+	r *resource,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, nil)
+	if !updated {
+		return r, nil
+	}
+	return r1, nil
 }

--- a/services/s3/pkg/resource/bucket/sdk.go
+++ b/services/s3/pkg/resource/bucket/sdk.go
@@ -17,6 +17,7 @@ package bucket
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -217,4 +218,51 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.Conditions == nil {
 		ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	}
+}
+
+// updateConditions returns updated resource, true; if conditions were updated
+// else it returns nil, false
+func (rm *resourceManager) updateConditions(
+	r *resource,
+	err error,
+) (*resource, bool) {
+	ko := r.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+
+	// Terminal condition
+	var terminalCondition *ackv1alpha1.Condition = nil
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
+			terminalCondition = condition
+			break
+		}
+	}
+
+	if rm.terminalAWSError(err) {
+		if terminalCondition == nil {
+			terminalCondition = &ackv1alpha1.Condition{
+				Type: ackv1alpha1.ConditionTypeTerminal,
+			}
+			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
+		}
+		terminalCondition.Status = corev1.ConditionTrue
+		awsErr, _ := ackerr.AWSError(err)
+		errorMessage := awsErr.Message()
+		terminalCondition.Message = &errorMessage
+	} else if terminalCondition != nil {
+		terminalCondition.Status = corev1.ConditionFalse
+		terminalCondition.Message = nil
+	}
+	if terminalCondition != nil {
+		return &resource{ko}, true // updated
+	}
+	return nil, false // not updated
+}
+
+// terminalAWSError returns awserr, true; if the supplied error is an aws Error type
+// and if the exception indicates that it is a Terminal exception
+// 'Terminal' exception are specified in generator configuration
+func (rm *resourceManager) terminalAWSError(err error) bool {
+	// No terminal_errors specified for this resource in generator config
+	return false
 }

--- a/services/sns/pkg/resource/platform_application/manager.go
+++ b/services/sns/pkg/resource/platform_application/manager.go
@@ -18,6 +18,8 @@ package platform_application
 import (
 	"context"
 	"fmt"
+	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -85,7 +87,7 @@ func (rm *resourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return observed, nil
+	return rm.onSuccess(observed)
 }
 
 // Create attempts to create the supplied AWSResource in the backend AWS
@@ -102,9 +104,9 @@ func (rm *resourceManager) Create(
 	}
 	created, err := rm.sdkCreate(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
-	return created, nil
+	return rm.onSuccess(created)
 }
 
 // Update attempts to mutate the supplied desired AWSResource in the backend AWS
@@ -129,9 +131,9 @@ func (rm *resourceManager) Update(
 	}
 	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
-		return nil, err
+		return rm.onError(latest, err)
 	}
-	return updated, nil
+	return rm.onSuccess(updated)
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
@@ -180,4 +182,37 @@ func newResourceManager(
 		sess:         sess,
 		sdkapi:       svcsdk.New(sess),
 	}, nil
+}
+
+// onError updates resource conditions and returns updated resource
+// it returns nil if no condition is updated.
+func (rm *resourceManager) onError(
+	r *resource,
+	err error,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, err)
+	if !updated {
+		return nil, err
+	}
+	for _, condition := range r1.Conditions() {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&
+			condition.Status == corev1.ConditionTrue {
+			// resource is in Terminal condition
+			// return Terminal error
+			return r1, ackerr.Terminal
+		}
+	}
+	return r1, err
+}
+
+// onSuccess updates resource conditions and returns updated resource
+// it returns the supplied resource if no condition is updated.
+func (rm *resourceManager) onSuccess(
+	r *resource,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, nil)
+	if !updated {
+		return r, nil
+	}
+	return r1, nil
 }

--- a/services/sns/pkg/resource/platform_endpoint/manager.go
+++ b/services/sns/pkg/resource/platform_endpoint/manager.go
@@ -18,6 +18,8 @@ package platform_endpoint
 import (
 	"context"
 	"fmt"
+	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -85,7 +87,7 @@ func (rm *resourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return observed, nil
+	return rm.onSuccess(observed)
 }
 
 // Create attempts to create the supplied AWSResource in the backend AWS
@@ -102,9 +104,9 @@ func (rm *resourceManager) Create(
 	}
 	created, err := rm.sdkCreate(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
-	return created, nil
+	return rm.onSuccess(created)
 }
 
 // Update attempts to mutate the supplied desired AWSResource in the backend AWS
@@ -129,9 +131,9 @@ func (rm *resourceManager) Update(
 	}
 	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
-		return nil, err
+		return rm.onError(latest, err)
 	}
-	return updated, nil
+	return rm.onSuccess(updated)
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
@@ -180,4 +182,37 @@ func newResourceManager(
 		sess:         sess,
 		sdkapi:       svcsdk.New(sess),
 	}, nil
+}
+
+// onError updates resource conditions and returns updated resource
+// it returns nil if no condition is updated.
+func (rm *resourceManager) onError(
+	r *resource,
+	err error,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, err)
+	if !updated {
+		return nil, err
+	}
+	for _, condition := range r1.Conditions() {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&
+			condition.Status == corev1.ConditionTrue {
+			// resource is in Terminal condition
+			// return Terminal error
+			return r1, ackerr.Terminal
+		}
+	}
+	return r1, err
+}
+
+// onSuccess updates resource conditions and returns updated resource
+// it returns the supplied resource if no condition is updated.
+func (rm *resourceManager) onSuccess(
+	r *resource,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, nil)
+	if !updated {
+		return r, nil
+	}
+	return r1, nil
 }

--- a/services/sns/pkg/resource/platform_endpoint/sdk.go
+++ b/services/sns/pkg/resource/platform_endpoint/sdk.go
@@ -17,6 +17,7 @@ package platform_endpoint
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -141,4 +142,51 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.Conditions == nil {
 		ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	}
+}
+
+// updateConditions returns updated resource, true; if conditions were updated
+// else it returns nil, false
+func (rm *resourceManager) updateConditions(
+	r *resource,
+	err error,
+) (*resource, bool) {
+	ko := r.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+
+	// Terminal condition
+	var terminalCondition *ackv1alpha1.Condition = nil
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
+			terminalCondition = condition
+			break
+		}
+	}
+
+	if rm.terminalAWSError(err) {
+		if terminalCondition == nil {
+			terminalCondition = &ackv1alpha1.Condition{
+				Type: ackv1alpha1.ConditionTypeTerminal,
+			}
+			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
+		}
+		terminalCondition.Status = corev1.ConditionTrue
+		awsErr, _ := ackerr.AWSError(err)
+		errorMessage := awsErr.Message()
+		terminalCondition.Message = &errorMessage
+	} else if terminalCondition != nil {
+		terminalCondition.Status = corev1.ConditionFalse
+		terminalCondition.Message = nil
+	}
+	if terminalCondition != nil {
+		return &resource{ko}, true // updated
+	}
+	return nil, false // not updated
+}
+
+// terminalAWSError returns awserr, true; if the supplied error is an aws Error type
+// and if the exception indicates that it is a Terminal exception
+// 'Terminal' exception are specified in generator configuration
+func (rm *resourceManager) terminalAWSError(err error) bool {
+	// No terminal_errors specified for this resource in generator config
+	return false
 }

--- a/services/sns/pkg/resource/topic/manager.go
+++ b/services/sns/pkg/resource/topic/manager.go
@@ -18,6 +18,8 @@ package topic
 import (
 	"context"
 	"fmt"
+	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -85,7 +87,7 @@ func (rm *resourceManager) ReadOne(
 	if err != nil {
 		return nil, err
 	}
-	return observed, nil
+	return rm.onSuccess(observed)
 }
 
 // Create attempts to create the supplied AWSResource in the backend AWS
@@ -102,9 +104,9 @@ func (rm *resourceManager) Create(
 	}
 	created, err := rm.sdkCreate(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
-	return created, nil
+	return rm.onSuccess(created)
 }
 
 // Update attempts to mutate the supplied desired AWSResource in the backend AWS
@@ -129,9 +131,9 @@ func (rm *resourceManager) Update(
 	}
 	updated, err := rm.sdkUpdate(ctx, desired, latest, diffReporter)
 	if err != nil {
-		return nil, err
+		return rm.onError(latest, err)
 	}
-	return updated, nil
+	return rm.onSuccess(updated)
 }
 
 // Delete attempts to destroy the supplied AWSResource in the backend AWS
@@ -180,4 +182,37 @@ func newResourceManager(
 		sess:         sess,
 		sdkapi:       svcsdk.New(sess),
 	}, nil
+}
+
+// onError updates resource conditions and returns updated resource
+// it returns nil if no condition is updated.
+func (rm *resourceManager) onError(
+	r *resource,
+	err error,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, err)
+	if !updated {
+		return nil, err
+	}
+	for _, condition := range r1.Conditions() {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&
+			condition.Status == corev1.ConditionTrue {
+			// resource is in Terminal condition
+			// return Terminal error
+			return r1, ackerr.Terminal
+		}
+	}
+	return r1, err
+}
+
+// onSuccess updates resource conditions and returns updated resource
+// it returns the supplied resource if no condition is updated.
+func (rm *resourceManager) onSuccess(
+	r *resource,
+) (*resource, error) {
+	r1, updated := rm.updateConditions(r, nil)
+	if !updated {
+		return r, nil
+	}
+	return r1, nil
 }

--- a/services/sns/pkg/resource/topic/sdk.go
+++ b/services/sns/pkg/resource/topic/sdk.go
@@ -17,6 +17,7 @@ package topic
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
@@ -293,4 +294,51 @@ func (rm *resourceManager) setStatusDefaults(
 	if ko.Status.Conditions == nil {
 		ko.Status.Conditions = []*ackv1alpha1.Condition{}
 	}
+}
+
+// updateConditions returns updated resource, true; if conditions were updated
+// else it returns nil, false
+func (rm *resourceManager) updateConditions(
+	r *resource,
+	err error,
+) (*resource, bool) {
+	ko := r.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+
+	// Terminal condition
+	var terminalCondition *ackv1alpha1.Condition = nil
+	for _, condition := range ko.Status.Conditions {
+		if condition.Type == ackv1alpha1.ConditionTypeTerminal {
+			terminalCondition = condition
+			break
+		}
+	}
+
+	if rm.terminalAWSError(err) {
+		if terminalCondition == nil {
+			terminalCondition = &ackv1alpha1.Condition{
+				Type: ackv1alpha1.ConditionTypeTerminal,
+			}
+			ko.Status.Conditions = append(ko.Status.Conditions, terminalCondition)
+		}
+		terminalCondition.Status = corev1.ConditionTrue
+		awsErr, _ := ackerr.AWSError(err)
+		errorMessage := awsErr.Message()
+		terminalCondition.Message = &errorMessage
+	} else if terminalCondition != nil {
+		terminalCondition.Status = corev1.ConditionFalse
+		terminalCondition.Message = nil
+	}
+	if terminalCondition != nil {
+		return &resource{ko}, true // updated
+	}
+	return nil, false // not updated
+}
+
+// terminalAWSError returns awserr, true; if the supplied error is an aws Error type
+// and if the exception indicates that it is a Terminal exception
+// 'Terminal' exception are specified in generator configuration
+func (rm *resourceManager) terminalAWSError(err error) bool {
+	// No terminal_errors specified for this resource in generator config
+	return false
 }


### PR DESCRIPTION
Issue #231 

Description of changes:
Added terminal condition logic during reconciler sync.
Updated templates files for it and generated controllers using
```
SERVICE=apigatewayv2 && make build-controller && \
SERVICE=dynamodb && make build-controller && \
SERVICE=ecr && make build-controller && \
SERVICE=elasticache && make build-controller && \
SERVICE=s3 && make build-controller && \
SERVICE=sns && make build-controller;
```

The updates are independent of pr #411 however commit is based on it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
