### PR TITLE
allow override of GetAttributes input shape

### DIFF
--- a/pkg/generate/config/config.go
+++ b/pkg/generate/config/config.go
@@ -163,6 +163,29 @@ type UnpackAttributesMapConfig struct {
 	// SetPlatformApplicationAttributes API call which accepts multiple
 	// attributes and replaces the supplied attributes map key/values...
 	SetAttributesSingleAttribute bool `json:"set_attributes_single_attribute"`
+	// GetAttributesInput instructs the code generator how to handle the
+	// GetAttributes input shape
+	GetAttributesInput *GetAttributesInputConfig `json:"get_attributes_input,omitempty"`
+}
+
+// GetAttributesInputConfig is used to instruct the code generator how to
+// handle the GetAttributes API operation's Input shape.
+type GetAttributesInputConfig struct {
+	// Overrides is a map of structures instructing the code generator how to
+	// handle the override of a particular field in the Input shape for the
+	// GetAttributes operation. The map keys are the names of the field in the
+	// Input shape to override.
+	Overrides map[string]*MemberConstructorConfig `json:"overrides"`
+}
+
+// MemberConstructorConfig contains override instructions for how to handle the
+// construction of a particular member for a Shape in the API.
+type MemberConstructorConfig struct {
+	// Values contains the value or values of the member to always set the
+	// member to. If the member's type is a []string, the member is set to the
+	// Values list. If the type is a string, the member's value is set to the
+	// first list element in the Values list.
+	Values []string `json:"values"`
 }
 
 // FieldConfig contains instructions to the code generator about how

--- a/pkg/generate/sqs_test.go
+++ b/pkg/generate/sqs_test.go
@@ -153,6 +153,12 @@ func TestSQS_Queue(t *testing.T) {
 	// attributes for and a QueueUrl field. We only care about the QueueUrl
 	// field, since we look for all attributes for a queue.
 	expGetAttrsInput := `
+	{
+		tmpVals := []*string{}
+		tmpVal0 := "All"
+		tmpVals = append(tmpVals, &tmpVal0)
+		res.SetAttributeNames(tmpVals)
+	}
 	if r.ko.Status.QueueURL != nil {
 		res.SetQueueUrl(*r.ko.Status.QueueURL)
 	}

--- a/pkg/generate/testdata/models/apis/sqs/0000-00-00/generator.yaml
+++ b/pkg/generate/testdata/models/apis/sqs/0000-00-00/generator.yaml
@@ -19,3 +19,8 @@ resources:
           is_read_only: true
         QueueArn:
           is_read_only: true
+      get_attributes_input:
+        overrides:
+          AttributeNames:
+            values:
+              - All

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -868,6 +868,14 @@ func (r *CRD) GoCodeGetAttributesSetInput(
 	out := "\n"
 	indent := strings.Repeat("\t", indentLevel)
 
+	inputFieldOverrides := map[string][]string{}
+	attrCfg := r.genCfg.Resources[r.Names.Original].UnpackAttributesMapConfig
+	if attrCfg.GetAttributesInput != nil {
+		for memberName, override := range attrCfg.GetAttributesInput.Overrides {
+			inputFieldOverrides[memberName] = override.Values
+		}
+	}
+
 	for _, memberName := range inputShape.MemberNames() {
 		if r.IsPrimaryARNField(memberName) {
 			// if ko.Status.ACKResourceMetadata != nil && ko.Status.ACKResourceMetadata.ARN != nil {
@@ -894,6 +902,41 @@ func (r *CRD) GoCodeGetAttributesSetInput(
 			out += fmt.Sprintf(
 				"%s}\n", indent,
 			)
+			continue
+		}
+
+		// Some APIs to retrieve the attributes for a resource require passing
+		// specific fields and field values. For example, in order to get all
+		// of an SQS Queue's attributes, the SQS GetQueueAttributes API call's
+		// Input shape's AttributeNames member needs to be set to
+		// []string{"All"}...
+		//
+		// Go code output in this section will look something like this:
+		//
+		// {
+		//     tmpVals := []*string{}
+		//     tmpVal0 := "All"
+		//     tmpVals = append(tmpVals, &tmpVal0)
+		//     res.SetAttributeNames(tmpVals)
+		// }
+		if overrideValues, ok := inputFieldOverrides[memberName]; ok {
+			memberShapeRef := inputShape.MemberRefs[memberName]
+			out += fmt.Sprintf("%s{\n", indent)
+			// We need to output a set of temporary strings that we will take a
+			// reference to when constructing the values of the []*string or
+			// *string members.
+			if memberShapeRef.Shape.Type == "list" {
+				out += fmt.Sprintf("%s\ttmpVals := []*string{}\n", indent)
+				for x, overrideValue := range overrideValues {
+					out += fmt.Sprintf("%s\ttmpVal%d := \"%s\"\n", indent, x, overrideValue)
+					out += fmt.Sprintf("%s\ttmpVals = append(tmpVals, &tmpVal%d)\n", indent, x)
+				}
+				out += fmt.Sprintf("%s\t%s.Set%s(tmpVals)\n", indent, targetVarName, memberName)
+			} else {
+				out += fmt.Sprintf("%s\ttmpVal := \"%s\"\n", indent, overrideValues[0])
+				out += fmt.Sprintf("%s\t%s.Set%s(&tmpVal)\n", indent, targetVarName, memberName)
+			}
+			out += fmt.Sprintf("%s}\n", indent)
 			continue
 		}
 

--- a/services/sqs/generator.yaml
+++ b/services/sqs/generator.yaml
@@ -19,3 +19,8 @@ resources:
           is_read_only: true
         QueueArn:
           is_read_only: true
+      get_attributes_input:
+        overrides:
+          AttributeNames:
+            values:
+              - All


### PR DESCRIPTION
The SQS GetQueueAttributes API call is entirely different from the SNS
GetTopicAttributes call. Whereas the latter is called and returns the
Topic's attributes, the former has a required `[]*string` field on the
Input shape called `AttributeNames` that has to have a single "All"
element in it in order for the API call not to return an error about
malformed Input data :(

This patch introduces new structures in the generator configuration that
allows the code generator to write override values for the Input shape
in order to populate this properly.

Issue #205

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
