### PR TITLE
Fix nil pointer dereference inside reconciler when manager onError returns nil

### DIFF
--- a/services/apigatewayv2/pkg/resource/api/manager.go
+++ b/services/apigatewayv2/pkg/resource/api/manager.go
@@ -189,7 +189,7 @@ func newResourceManager(
 func (rm *resourceManager) onError(
 	r *resource,
 	err error,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
 		return nil, err
@@ -209,7 +209,7 @@ func (rm *resourceManager) onError(
 // it returns the supplied resource if no condition is updated.
 func (rm *resourceManager) onSuccess(
 	r *resource,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, nil)
 	if !updated {
 		return r, nil

--- a/services/apigatewayv2/pkg/resource/api_mapping/manager.go
+++ b/services/apigatewayv2/pkg/resource/api_mapping/manager.go
@@ -189,7 +189,7 @@ func newResourceManager(
 func (rm *resourceManager) onError(
 	r *resource,
 	err error,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
 		return nil, err
@@ -209,7 +209,7 @@ func (rm *resourceManager) onError(
 // it returns the supplied resource if no condition is updated.
 func (rm *resourceManager) onSuccess(
 	r *resource,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, nil)
 	if !updated {
 		return r, nil

--- a/services/apigatewayv2/pkg/resource/authorizer/manager.go
+++ b/services/apigatewayv2/pkg/resource/authorizer/manager.go
@@ -189,7 +189,7 @@ func newResourceManager(
 func (rm *resourceManager) onError(
 	r *resource,
 	err error,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
 		return nil, err
@@ -209,7 +209,7 @@ func (rm *resourceManager) onError(
 // it returns the supplied resource if no condition is updated.
 func (rm *resourceManager) onSuccess(
 	r *resource,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, nil)
 	if !updated {
 		return r, nil

--- a/services/apigatewayv2/pkg/resource/deployment/manager.go
+++ b/services/apigatewayv2/pkg/resource/deployment/manager.go
@@ -189,7 +189,7 @@ func newResourceManager(
 func (rm *resourceManager) onError(
 	r *resource,
 	err error,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
 		return nil, err
@@ -209,7 +209,7 @@ func (rm *resourceManager) onError(
 // it returns the supplied resource if no condition is updated.
 func (rm *resourceManager) onSuccess(
 	r *resource,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, nil)
 	if !updated {
 		return r, nil

--- a/services/apigatewayv2/pkg/resource/domain_name/manager.go
+++ b/services/apigatewayv2/pkg/resource/domain_name/manager.go
@@ -189,7 +189,7 @@ func newResourceManager(
 func (rm *resourceManager) onError(
 	r *resource,
 	err error,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
 		return nil, err
@@ -209,7 +209,7 @@ func (rm *resourceManager) onError(
 // it returns the supplied resource if no condition is updated.
 func (rm *resourceManager) onSuccess(
 	r *resource,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, nil)
 	if !updated {
 		return r, nil

--- a/services/apigatewayv2/pkg/resource/integration/manager.go
+++ b/services/apigatewayv2/pkg/resource/integration/manager.go
@@ -189,7 +189,7 @@ func newResourceManager(
 func (rm *resourceManager) onError(
 	r *resource,
 	err error,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
 		return nil, err
@@ -209,7 +209,7 @@ func (rm *resourceManager) onError(
 // it returns the supplied resource if no condition is updated.
 func (rm *resourceManager) onSuccess(
 	r *resource,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, nil)
 	if !updated {
 		return r, nil

--- a/services/apigatewayv2/pkg/resource/integration_response/manager.go
+++ b/services/apigatewayv2/pkg/resource/integration_response/manager.go
@@ -189,7 +189,7 @@ func newResourceManager(
 func (rm *resourceManager) onError(
 	r *resource,
 	err error,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
 		return nil, err
@@ -209,7 +209,7 @@ func (rm *resourceManager) onError(
 // it returns the supplied resource if no condition is updated.
 func (rm *resourceManager) onSuccess(
 	r *resource,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, nil)
 	if !updated {
 		return r, nil

--- a/services/apigatewayv2/pkg/resource/model/manager.go
+++ b/services/apigatewayv2/pkg/resource/model/manager.go
@@ -189,7 +189,7 @@ func newResourceManager(
 func (rm *resourceManager) onError(
 	r *resource,
 	err error,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
 		return nil, err
@@ -209,7 +209,7 @@ func (rm *resourceManager) onError(
 // it returns the supplied resource if no condition is updated.
 func (rm *resourceManager) onSuccess(
 	r *resource,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, nil)
 	if !updated {
 		return r, nil

--- a/services/apigatewayv2/pkg/resource/route/manager.go
+++ b/services/apigatewayv2/pkg/resource/route/manager.go
@@ -189,7 +189,7 @@ func newResourceManager(
 func (rm *resourceManager) onError(
 	r *resource,
 	err error,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
 		return nil, err
@@ -209,7 +209,7 @@ func (rm *resourceManager) onError(
 // it returns the supplied resource if no condition is updated.
 func (rm *resourceManager) onSuccess(
 	r *resource,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, nil)
 	if !updated {
 		return r, nil

--- a/services/apigatewayv2/pkg/resource/route_response/manager.go
+++ b/services/apigatewayv2/pkg/resource/route_response/manager.go
@@ -189,7 +189,7 @@ func newResourceManager(
 func (rm *resourceManager) onError(
 	r *resource,
 	err error,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
 		return nil, err
@@ -209,7 +209,7 @@ func (rm *resourceManager) onError(
 // it returns the supplied resource if no condition is updated.
 func (rm *resourceManager) onSuccess(
 	r *resource,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, nil)
 	if !updated {
 		return r, nil

--- a/services/apigatewayv2/pkg/resource/stage/manager.go
+++ b/services/apigatewayv2/pkg/resource/stage/manager.go
@@ -189,7 +189,7 @@ func newResourceManager(
 func (rm *resourceManager) onError(
 	r *resource,
 	err error,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
 		return nil, err
@@ -209,7 +209,7 @@ func (rm *resourceManager) onError(
 // it returns the supplied resource if no condition is updated.
 func (rm *resourceManager) onSuccess(
 	r *resource,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, nil)
 	if !updated {
 		return r, nil

--- a/services/apigatewayv2/pkg/resource/vpc_link/manager.go
+++ b/services/apigatewayv2/pkg/resource/vpc_link/manager.go
@@ -189,7 +189,7 @@ func newResourceManager(
 func (rm *resourceManager) onError(
 	r *resource,
 	err error,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
 		return nil, err
@@ -209,7 +209,7 @@ func (rm *resourceManager) onError(
 // it returns the supplied resource if no condition is updated.
 func (rm *resourceManager) onSuccess(
 	r *resource,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, nil)
 	if !updated {
 		return r, nil

--- a/services/dynamodb/pkg/resource/backup/manager.go
+++ b/services/dynamodb/pkg/resource/backup/manager.go
@@ -189,7 +189,7 @@ func newResourceManager(
 func (rm *resourceManager) onError(
 	r *resource,
 	err error,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
 		return nil, err
@@ -209,7 +209,7 @@ func (rm *resourceManager) onError(
 // it returns the supplied resource if no condition is updated.
 func (rm *resourceManager) onSuccess(
 	r *resource,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, nil)
 	if !updated {
 		return r, nil

--- a/services/dynamodb/pkg/resource/global_table/manager.go
+++ b/services/dynamodb/pkg/resource/global_table/manager.go
@@ -189,7 +189,7 @@ func newResourceManager(
 func (rm *resourceManager) onError(
 	r *resource,
 	err error,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
 		return nil, err
@@ -209,7 +209,7 @@ func (rm *resourceManager) onError(
 // it returns the supplied resource if no condition is updated.
 func (rm *resourceManager) onSuccess(
 	r *resource,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, nil)
 	if !updated {
 		return r, nil

--- a/services/dynamodb/pkg/resource/table/manager.go
+++ b/services/dynamodb/pkg/resource/table/manager.go
@@ -189,7 +189,7 @@ func newResourceManager(
 func (rm *resourceManager) onError(
 	r *resource,
 	err error,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
 		return nil, err
@@ -209,7 +209,7 @@ func (rm *resourceManager) onError(
 // it returns the supplied resource if no condition is updated.
 func (rm *resourceManager) onSuccess(
 	r *resource,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, nil)
 	if !updated {
 		return r, nil

--- a/services/ecr/pkg/resource/repository/manager.go
+++ b/services/ecr/pkg/resource/repository/manager.go
@@ -189,7 +189,7 @@ func newResourceManager(
 func (rm *resourceManager) onError(
 	r *resource,
 	err error,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
 		return nil, err
@@ -209,7 +209,7 @@ func (rm *resourceManager) onError(
 // it returns the supplied resource if no condition is updated.
 func (rm *resourceManager) onSuccess(
 	r *resource,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, nil)
 	if !updated {
 		return r, nil

--- a/services/elasticache/pkg/resource/cache_subnet_group/manager.go
+++ b/services/elasticache/pkg/resource/cache_subnet_group/manager.go
@@ -189,7 +189,7 @@ func newResourceManager(
 func (rm *resourceManager) onError(
 	r *resource,
 	err error,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
 		return nil, err
@@ -209,7 +209,7 @@ func (rm *resourceManager) onError(
 // it returns the supplied resource if no condition is updated.
 func (rm *resourceManager) onSuccess(
 	r *resource,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, nil)
 	if !updated {
 		return r, nil

--- a/services/elasticache/pkg/resource/replication_group/manager.go
+++ b/services/elasticache/pkg/resource/replication_group/manager.go
@@ -189,7 +189,7 @@ func newResourceManager(
 func (rm *resourceManager) onError(
 	r *resource,
 	err error,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
 		return nil, err
@@ -209,7 +209,7 @@ func (rm *resourceManager) onError(
 // it returns the supplied resource if no condition is updated.
 func (rm *resourceManager) onSuccess(
 	r *resource,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, nil)
 	if !updated {
 		return r, nil

--- a/services/s3/pkg/resource/bucket/manager.go
+++ b/services/s3/pkg/resource/bucket/manager.go
@@ -189,7 +189,7 @@ func newResourceManager(
 func (rm *resourceManager) onError(
 	r *resource,
 	err error,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
 		return nil, err
@@ -209,7 +209,7 @@ func (rm *resourceManager) onError(
 // it returns the supplied resource if no condition is updated.
 func (rm *resourceManager) onSuccess(
 	r *resource,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, nil)
 	if !updated {
 		return r, nil

--- a/services/sns/pkg/resource/platform_application/manager.go
+++ b/services/sns/pkg/resource/platform_application/manager.go
@@ -189,7 +189,7 @@ func newResourceManager(
 func (rm *resourceManager) onError(
 	r *resource,
 	err error,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
 		return nil, err
@@ -209,7 +209,7 @@ func (rm *resourceManager) onError(
 // it returns the supplied resource if no condition is updated.
 func (rm *resourceManager) onSuccess(
 	r *resource,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, nil)
 	if !updated {
 		return r, nil

--- a/services/sns/pkg/resource/platform_endpoint/manager.go
+++ b/services/sns/pkg/resource/platform_endpoint/manager.go
@@ -189,7 +189,7 @@ func newResourceManager(
 func (rm *resourceManager) onError(
 	r *resource,
 	err error,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
 		return nil, err
@@ -209,7 +209,7 @@ func (rm *resourceManager) onError(
 // it returns the supplied resource if no condition is updated.
 func (rm *resourceManager) onSuccess(
 	r *resource,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, nil)
 	if !updated {
 		return r, nil

--- a/services/sns/pkg/resource/topic/manager.go
+++ b/services/sns/pkg/resource/topic/manager.go
@@ -189,7 +189,7 @@ func newResourceManager(
 func (rm *resourceManager) onError(
 	r *resource,
 	err error,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
 		return nil, err
@@ -209,7 +209,7 @@ func (rm *resourceManager) onError(
 // it returns the supplied resource if no condition is updated.
 func (rm *resourceManager) onSuccess(
 	r *resource,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, nil)
 	if !updated {
 		return r, nil

--- a/templates/pkg/crd_manager.go.tpl
+++ b/templates/pkg/crd_manager.go.tpl
@@ -176,7 +176,7 @@ func newResourceManager(
 func (rm *resourceManager) onError(
 	r *resource,
 	err error,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
 		return nil, err
@@ -196,7 +196,7 @@ func (rm *resourceManager) onError(
 // it returns the supplied resource if no condition is updated.
 func (rm *resourceManager) onSuccess(
 	r *resource,
-) (*resource, error) {
+) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, nil)
 	if !updated {
 		return r, nil


### PR DESCRIPTION
Issue #427 

Description of changes:
Changed the return type of onError and onSuccess methods from:
`(*resource, error)` to `(acktypes.AWSResource, error)` for nil check to work inside reconciler.

Inside reconciler, the value is received into `var latest acktypes.AWSResource` 
and it failed to have the expected execution of 
```
if latest != nil {
```
condition when manager.go `onError()` method return `nil`.
Changing the return type to `(acktypes.AWSResource, error)` resolves the issue.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
