### PR TITLE
place elasticache service controller into dev-preview

### DIFF
--- a/docs/contents/dev-docs/testing.md
+++ b/docs/contents/dev-docs/testing.md
@@ -8,6 +8,7 @@ through the steps to test ACK for the currently supported AWS services:
 - Amazon SNS
 - Amazon API Gateway V2
 - Amazon DynamoDB
+- [Amazon ElastiCache](https://github.com/aws/aws-controllers-k8s/tree/main/services/elasticache)
 
 If you run into any problems when testing one of the above services,
 [raise an issue](https://github.com/aws/aws-controllers-k8s/issues/new/choose)

--- a/docs/contents/services.md
+++ b/docs/contents/services.md
@@ -14,6 +14,7 @@ Controller Release Roadmap](https://github.com/aws/aws-controllers-k8s/projects/
 |Amazon [S3](https://aws.amazon.com/s3/)|`DEVELOPER PREVIEW`|[`s3`](https://github.com/aws/aws-controllers-k8s/tree/main/services/s3)|
 |Amazon [SQS](https://aws.amazon.com/sqs/)|`BUILD`|`sqs`|
 |Amazon [SNS](https://aws.amazon.com/sns/)|`DEVELOPER PREVIEW`|[`sns`](https://github.com/aws/aws-controllers-k8s/tree/main/services/sns)|
+|Amazon [ElastiCache](https://aws.amazon.com/elasticache/)|`DEVELOPER PREVIEW`|[`elasticache`](https://github.com/aws/aws-controllers-k8s/tree/main/services/elasticache)|
 
 !!! note "IMPORTANT"
     There is no single release of the ACK project. The ACK project contains a

--- a/services/elasticache/README.md
+++ b/services/elasticache/README.md
@@ -1,0 +1,3 @@
+The ACK service controller for Amazon ElastiCache supports the following Amazon ElastiCache API resources in `DEVELOPER PREVIEW`:
+- [x] Replication Group
+- [x] Cache Subnet Group


### PR DESCRIPTION
Issue #, if available:

The ACK service controller for Amazon ElastiCache supports the following Amazon ElastiCache API resources in `DEVELOPER PREVIEW`:

- [x] Replication Group
- [x] Cache Subnet Group

Description of changes:
Updated md files and added README file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
