### PR TITLE
break out sdkUpdate into sep templates

### DIFF
--- a/pkg/generate/template.go
+++ b/pkg/generate/template.go
@@ -256,6 +256,10 @@ func (g *Generator) initTemplates() error {
 			"pkg/resource/sdk_find_get_attributes",
 			"pkg/resource/sdk_find_read_many",
 			"pkg/resource/sdk_find_not_implemented",
+			"pkg/resource/sdk_update",
+			"pkg/resource/sdk_update_custom",
+			"pkg/resource/sdk_update_set_attributes",
+			"pkg/resource/sdk_update_not_implemented",
 		}
 		for _, include := range includes {
 			if t, err = IncludeTemplate(t, g.templateBasePath, include); err != nil {

--- a/services/dynamodb/pkg/resource/backup/sdk.go
+++ b/services/dynamodb/pkg/resource/backup/sdk.go
@@ -173,7 +173,7 @@ func (rm *resourceManager) sdkUpdate(
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 	// TODO(jaypipes): Figure this out...
-	return nil, nil
+	return nil, ackerr.NotImplemented
 }
 
 // sdkDelete deletes the supplied resource in the backend AWS service API

--- a/services/s3/pkg/resource/bucket/sdk.go
+++ b/services/s3/pkg/resource/bucket/sdk.go
@@ -177,7 +177,7 @@ func (rm *resourceManager) sdkUpdate(
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 	// TODO(jaypipes): Figure this out...
-	return nil, nil
+	return nil, ackerr.NotImplemented
 }
 
 // sdkDelete deletes the supplied resource in the backend AWS service API

--- a/services/sns/pkg/resource/platform_endpoint/sdk.go
+++ b/services/sns/pkg/resource/platform_endpoint/sdk.go
@@ -117,7 +117,7 @@ func (rm *resourceManager) sdkUpdate(
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
 	// TODO(jaypipes): Figure this out...
-	return nil, nil
+	return nil, ackerr.NotImplemented
 }
 
 // sdkDelete deletes the supplied resource in the backend AWS service API

--- a/templates/pkg/resource/sdk.go.tpl
+++ b/templates/pkg/resource/sdk.go.tpl
@@ -83,115 +83,14 @@ func (rm *resourceManager) newCreateRequestPayload(
 
 // sdkUpdate patches the supplied resource in the backend AWS service API and
 // returns a new resource with updated fields.
-func (rm *resourceManager) sdkUpdate(
-	ctx context.Context,
-	desired *resource,
-	latest *resource,
-	diffReporter *ackcompare.Reporter,
-) (*resource, error) {
-{{- if .CRD.CustomUpdateMethodName }}
-	return rm.{{ .CRD.CustomUpdateMethodName }}(ctx, desired, latest, diffReporter)
+{{ if .CRD.CustomUpdateMethodName }}
+    {{- template "sdk_update_custom" . }}
 {{- else if .CRD.Ops.Update }}
-
-{{ $customMethod := .CRD.GetCustomImplementation .CRD.Ops.Update }}
-{{ if $customMethod }}
-	customResp, customRespErr := rm.{{ $customMethod }}(ctx, desired, latest, diffReporter)
-	if customResp != nil || customRespErr != nil {
-		return customResp, customRespErr
-	}
-{{ end }}
-
-	input, err := rm.newUpdateRequestPayload(desired)
-	if err != nil {
-		return nil, err
-	}
-
-{{ $setCode := GoCodeSetUpdateOutput .CRD "resp" "ko" 1 false }}
-	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.Update.Name }}WithContext(ctx, input)
-	rm.metrics.RecordAPICall("UPDATE", "{{ .CRD.Ops.Update.Name }}", respErr)
-	if respErr != nil {
-		return nil, respErr
-	}
-	// Merge in the information we read from the API call above to the copy of
-	// the original Kubernetes object we passed to the function
-	ko := desired.ko.DeepCopy()
-{{ $setCode }}
-	rm.setStatusDefaults(ko)
-{{ if $setOutputCustomMethodName := .CRD.SetOutputCustomMethodName .CRD.Ops.Update }}
-	// custom set output from response
-	rm.{{ $setOutputCustomMethodName }}(desired, resp, ko)
-{{ end }}
-	return &resource{ko}, nil
+    {{- template "sdk_update" . }}
 {{- else if .CRD.Ops.SetAttributes }}
-	// If any required fields in the input shape are missing, AWS resource is
-	// not created yet. And sdkUpdate should never be called if this is the
-	// case, and it's an error in the generated code if it is...
-	if rm.requiredFieldsMissingFromSetAttributesInput(desired) {
-		panic("Required field in SetAttributes input shape missing!")
-	}
-
-	input, err := rm.newSetAttributesRequestPayload(desired)
-	if err != nil {
-		return nil, err
-	}
-
-	// NOTE(jaypipes): SetAttributes calls return a response but they don't
-	// contain any useful information. Instead, below, we'll be returning a
-	// DeepCopy of the supplied desired state, which should be fine because
-	// that desired state has been constructed from a call to GetAttributes...
-	_, respErr := rm.sdkapi.{{ .CRD.Ops.SetAttributes.Name }}WithContext(ctx, input)
-	rm.metrics.RecordAPICall("SET_ATTRIBUTES", "{{ .CRD.Ops.SetAttributes.Name }}", respErr)
-	if respErr != nil {
-		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceExceptionCode .CRD 404 }}" {
-			// Technically, this means someone deleted the backend resource in
-			// between the time we got a result back from sdkFind() and here...
-			return nil, ackerr.NotFound
-		}
-		return nil, respErr
-	}
-
-	// Merge in the information we read from the API call above to the copy of
-	// the original Kubernetes object we passed to the function
-	ko := desired.ko.DeepCopy()
-	rm.setStatusDefaults(ko)
-	return &resource{ko}, nil
+    {{- template "sdk_update_set_attributes" . }}
 {{- else }}
-	// TODO(jaypipes): Figure this out...
-	return nil, nil
-{{- end }}
-}
-
-{{- if .CRD.Ops.Update }}
-// newUpdateRequestPayload returns an SDK-specific struct for the HTTP request
-// payload of the Update API call for the resource
-func (rm *resourceManager) newUpdateRequestPayload(
-	r *resource,
-) (*svcsdk.{{ .CRD.Ops.Update.InputRef.Shape.ShapeName }}, error) {
-	res := &svcsdk.{{ .CRD.Ops.Update.InputRef.Shape.ShapeName }}{}
-{{ GoCodeSetUpdateInput .CRD "r.ko" "res" 1 }}
-	return res, nil
-}
-{{ end }}
-
-{{- if .CRD.Ops.SetAttributes }}
-// requiredFieldsMissingFromSetAtttributesInput returns true if there are any
-// fields for the SetAttributes Input shape that are required by not present in
-// the resource's Spec or Status
-func (rm *resourceManager) requiredFieldsMissingFromSetAttributesInput(
-	r *resource,
-) bool {
-{{ GoCodeRequiredFieldsMissingFromSetAttributesInput .CRD "r.ko" 1 }}
-}
-
-// newSetAttributesRequestPayload returns SDK-specific struct for the HTTP
-// request payload of the SetAttributes API call for the resource
-func (rm *resourceManager) newSetAttributesRequestPayload(
-	r *resource,
-) (*svcsdk.{{ .CRD.Ops.SetAttributes.InputRef.Shape.ShapeName }}, error) {
-	res := &svcsdk.{{ .CRD.Ops.SetAttributes.InputRef.Shape.ShapeName }}{}
-{{ GoCodeSetAttributesSetInput .CRD "r.ko" "res" 1 }}
-	return res, nil
-}
+    {{- template "sdk_update_not_implemented" . }}
 {{- end }}
 
 // sdkDelete deletes the supplied resource in the backend AWS service API

--- a/templates/pkg/resource/sdk_update.go.tpl
+++ b/templates/pkg/resource/sdk_update.go.tpl
@@ -1,0 +1,48 @@
+{{- define "sdk_update" -}}
+func (rm *resourceManager) sdkUpdate(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+	diffReporter *ackcompare.Reporter,
+) (*resource, error) {
+{{ $customMethod := .CRD.GetCustomImplementation .CRD.Ops.Update }}
+{{ if $customMethod }}
+	customResp, customRespErr := rm.{{ $customMethod }}(ctx, desired, latest, diffReporter)
+	if customResp != nil || customRespErr != nil {
+		return customResp, customRespErr
+	}
+{{ end }}
+
+	input, err := rm.newUpdateRequestPayload(desired)
+	if err != nil {
+		return nil, err
+	}
+
+{{ $setCode := GoCodeSetUpdateOutput .CRD "resp" "ko" 1 false }}
+	{{ if not ( Empty $setCode ) }}resp{{ else }}_{{ end }}, respErr := rm.sdkapi.{{ .CRD.Ops.Update.Name }}WithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "{{ .CRD.Ops.Update.Name }}", respErr)
+	if respErr != nil {
+		return nil, respErr
+	}
+	// Merge in the information we read from the API call above to the copy of
+	// the original Kubernetes object we passed to the function
+	ko := desired.ko.DeepCopy()
+{{ $setCode }}
+	rm.setStatusDefaults(ko)
+{{ if $setOutputCustomMethodName := .CRD.SetOutputCustomMethodName .CRD.Ops.Update }}
+	// custom set output from response
+	rm.{{ $setOutputCustomMethodName }}(desired, resp, ko)
+{{ end }}
+	return &resource{ko}, nil
+}
+
+// newUpdateRequestPayload returns an SDK-specific struct for the HTTP request
+// payload of the Update API call for the resource
+func (rm *resourceManager) newUpdateRequestPayload(
+	r *resource,
+) (*svcsdk.{{ .CRD.Ops.Update.InputRef.Shape.ShapeName }}, error) {
+	res := &svcsdk.{{ .CRD.Ops.Update.InputRef.Shape.ShapeName }}{}
+{{ GoCodeSetUpdateInput .CRD "r.ko" "res" 1 }}
+	return res, nil
+}
+{{- end -}}

--- a/templates/pkg/resource/sdk_update_custom.go.tpl
+++ b/templates/pkg/resource/sdk_update_custom.go.tpl
@@ -1,0 +1,10 @@
+{{- define "sdk_update_custom" -}}
+func (rm *resourceManager) sdkUpdate(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+	diffReporter *ackcompare.Reporter,
+) (*resource, error) {
+	return rm.{{ .CRD.CustomUpdateMethodName }}(ctx, desired, latest, diffReporter)
+}
+{{- end -}}

--- a/templates/pkg/resource/sdk_update_not_implemented.go.tpl
+++ b/templates/pkg/resource/sdk_update_not_implemented.go.tpl
@@ -1,0 +1,11 @@
+{{- define "sdk_update_not_implemented" -}}
+func (rm *resourceManager) sdkUpdate(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+	diffReporter *ackcompare.Reporter,
+) (*resource, error) {
+	// TODO(jaypipes): Figure this out...
+	return nil, ackerr.NotImplemented
+}
+{{- end -}}

--- a/templates/pkg/resource/sdk_update_set_attributes.go.tpl
+++ b/templates/pkg/resource/sdk_update_set_attributes.go.tpl
@@ -1,0 +1,60 @@
+{{- define "sdk_update_set_attributes" -}}
+func (rm *resourceManager) sdkUpdate(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+	diffReporter *ackcompare.Reporter,
+) (*resource, error) {
+	// If any required fields in the input shape are missing, AWS resource is
+	// not created yet. And sdkUpdate should never be called if this is the
+	// case, and it's an error in the generated code if it is...
+	if rm.requiredFieldsMissingFromSetAttributesInput(desired) {
+		panic("Required field in SetAttributes input shape missing!")
+	}
+
+	input, err := rm.newSetAttributesRequestPayload(desired)
+	if err != nil {
+		return nil, err
+	}
+
+	// NOTE(jaypipes): SetAttributes calls return a response but they don't
+	// contain any useful information. Instead, below, we'll be returning a
+	// DeepCopy of the supplied desired state, which should be fine because
+	// that desired state has been constructed from a call to GetAttributes...
+	_, respErr := rm.sdkapi.{{ .CRD.Ops.SetAttributes.Name }}WithContext(ctx, input)
+	rm.metrics.RecordAPICall("SET_ATTRIBUTES", "{{ .CRD.Ops.SetAttributes.Name }}", respErr)
+	if respErr != nil {
+		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceExceptionCode .CRD 404 }}" {
+			// Technically, this means someone deleted the backend resource in
+			// between the time we got a result back from sdkFind() and here...
+			return nil, ackerr.NotFound
+		}
+		return nil, respErr
+	}
+
+	// Merge in the information we read from the API call above to the copy of
+	// the original Kubernetes object we passed to the function
+	ko := desired.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+	return &resource{ko}, nil
+}
+
+// requiredFieldsMissingFromSetAtttributesInput returns true if there are any
+// fields for the SetAttributes Input shape that are required by not present in
+// the resource's Spec or Status
+func (rm *resourceManager) requiredFieldsMissingFromSetAttributesInput(
+	r *resource,
+) bool {
+{{ GoCodeRequiredFieldsMissingFromSetAttributesInput .CRD "r.ko" 1 }}
+}
+
+// newSetAttributesRequestPayload returns SDK-specific struct for the HTTP
+// request payload of the SetAttributes API call for the resource
+func (rm *resourceManager) newSetAttributesRequestPayload(
+	r *resource,
+) (*svcsdk.{{ .CRD.Ops.SetAttributes.InputRef.Shape.ShapeName }}, error) {
+	res := &svcsdk.{{ .CRD.Ops.SetAttributes.InputRef.Shape.ShapeName }}{}
+{{ GoCodeSetAttributesSetInput .CRD "r.ko" "res" 1 }}
+	return res, nil
+}
+{{- end -}}


### PR DESCRIPTION
continues the cleanup of the top-level sdk.go.tpl template file by
breaking the sdkUpdate implementation for "normal" Update, custom
update, and SetAttributes update code paths into separate sub-templates.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
