### PR TITLE
Additional fields with defaults to generate.Config object

### DIFF
--- a/cmd/ack-generate/command/apis.go
+++ b/cmd/ack-generate/command/apis.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/aws/aws-controllers-k8s/pkg/generate"
+	"github.com/aws/aws-controllers-k8s/pkg/generate/config"
 	"github.com/aws/aws-controllers-k8s/pkg/model"
 )
 
@@ -90,7 +91,7 @@ func generateAPIs(cmd *cobra.Command, args []string) error {
 		}
 	}
 	g, err := generate.New(
-		sdkAPI, optGenVersion, optGeneratorConfigPath, optTemplatesDir,
+		sdkAPI, optGenVersion, optGeneratorConfigPath, optTemplatesDir, config.Default,
 	)
 	if err != nil {
 		return err

--- a/cmd/ack-generate/command/controller.go
+++ b/cmd/ack-generate/command/controller.go
@@ -27,6 +27,7 @@ import (
 	k8sversion "k8s.io/apimachinery/pkg/version"
 
 	"github.com/aws/aws-controllers-k8s/pkg/generate"
+	"github.com/aws/aws-controllers-k8s/pkg/generate/config"
 	ackmodel "github.com/aws/aws-controllers-k8s/pkg/model"
 )
 
@@ -80,7 +81,7 @@ func generateController(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	g, err := generate.New(
-		sdkAPI, latestAPIVersion, optGeneratorConfigPath, optTemplatesDir,
+		sdkAPI, latestAPIVersion, optGeneratorConfigPath, optTemplatesDir, config.Default,
 	)
 	if err != nil {
 		return err

--- a/pkg/generate/config/config.go
+++ b/pkg/generate/config/config.go
@@ -22,6 +22,15 @@ import (
 	"github.com/aws/aws-controllers-k8s/pkg/util"
 )
 
+var Default = Config{
+	PrefixConfig: PrefixConfig{
+		SpecField:   ".Spec",
+		StatusField: ".Status",
+	},
+	IncludeACKMetadata:             true,
+	SetManyOutputNotFoundErrReturn: "return nil, ackerr.NotFound",
+}
+
 // Config represents instructions to the ACK code generator for a particular
 // AWS service API
 type Config struct {
@@ -32,6 +41,16 @@ type Config struct {
 	Ignore IgnoreSpec `json:"ignore"`
 	// Contains generator instructions for individual API operations.
 	Operations map[string]OperationConfig `json:"operations"`
+	// PrefixConfig contains the prefixes to access certain fields in the generated
+	// Go code.
+	PrefixConfig PrefixConfig `json:"prefix_config,omitempty"`
+	// IncludeACKMetadata lets you specify whether ACK Metadata should be included
+	// in the status. Default is true.
+	IncludeACKMetadata bool `json:"include_ack_metadata,omitempty"`
+	// SetManyOutputNotFoundErrReturn is the return statement when generated
+	// SetManyOutput function fails with NotFound error.
+	// Default is "return nil, ackerr.NotFound"
+	SetManyOutputNotFoundErrReturn string `json:"set_many_output_notfound_err_return,omitempty"`
 }
 
 // OperationConfig represents instructions to the ACK code generator to
@@ -111,6 +130,15 @@ type ResourceConfig struct {
 	// `resourceManager` struct that will set Conditions on a `resource` struct
 	// depending on the status of the resource.
 	UpdateConditionsCustomMethodName string `json:"update_conditions_custom_method_name,omitempty"`
+}
+
+type PrefixConfig struct {
+	// SpecField stores the string prefix to use for information that will be
+	// sent to AWS. Defaults to `.Spec`
+	SpecField string `json:"spec_field,omitempty"`
+	// StatusField stores the string prefix to use for information fetched from
+	// AWS. Defaults to `.Status`
+	StatusField string `json:"status_field,omitempty"`
 }
 
 // UnpackAttributesMapConfig informs the code generator that the API follows a
@@ -386,14 +414,18 @@ func (c *Config) ListOpMatchFieldNames(
 // path to a config file
 func New(
 	configPath string,
-) (*Config, error) {
-	gc := Config{}
+	defaultConfig Config,
+) (Config, error) {
+	if configPath == "" {
+		return defaultConfig, nil
+	}
 	contents, err := ioutil.ReadFile(configPath)
 	if err != nil {
-		return nil, err
+		return Config{}, err
 	}
+	gc := defaultConfig
 	if err = yaml.Unmarshal(contents, &gc); err != nil {
-		return nil, err
+		return Config{}, err
 	}
-	return &gc, nil
+	return gc, nil
 }

--- a/pkg/generate/ecr_test.go
+++ b/pkg/generate/ecr_test.go
@@ -195,9 +195,6 @@ func TestECRRepository(t *testing.T) {
 	// the DescribeRepositoriesInput.RepositoryNames filter from the CR's
 	// Spec.RepositoryName field.
 	expReadManyOutput := `
-	if len(resp.Repositories) == 0 {
-		return nil, ackerr.NotFound
-	}
 	found := false
 	for _, elem := range resp.Repositories {
 		if elem.CreatedAt != nil {

--- a/pkg/generate/elasticache_test.go
+++ b/pkg/generate/elasticache_test.go
@@ -425,9 +425,6 @@ func TestElasticache_CacheCluster(t *testing.T) {
 	assert.Equal(expReadManyInput, crd.GoCodeSetInput(model.OpTypeList, "r.ko", "res", 1))
 
 	expReadManyOutput := `
-	if len(resp.CacheClusters) == 0 {
-		return nil, ackerr.NotFound
-	}
 	found := false
 	for _, elem := range resp.CacheClusters {
 		if elem.ARN != nil {

--- a/pkg/generate/generator.go
+++ b/pkg/generate/generator.go
@@ -361,14 +361,11 @@ func New(
 	apiVersion string,
 	configPath string,
 	templateBasePath string,
+	defaultConfig ackgenconfig.Config,
 ) (*Generator, error) {
-	var gc *ackgenconfig.Config
-	var err error
-	if configPath != "" {
-		gc, err = ackgenconfig.New(configPath)
-		if err != nil {
-			return nil, err
-		}
+	gc, err := ackgenconfig.New(configPath, defaultConfig)
+	if err != nil {
+		return nil, err
 	}
 
 	return &Generator{
@@ -378,6 +375,6 @@ func New(
 		serviceAlias:     SDKAPI.ServiceID(),
 		apiVersion:       apiVersion,
 		templateBasePath: templateBasePath,
-		cfg:              gc,
+		cfg:              &gc,
 	}, nil
 }

--- a/pkg/generate/rds_test.go
+++ b/pkg/generate/rds_test.go
@@ -683,9 +683,6 @@ func TestRDS_DBInstance(t *testing.T) {
 	// target variable are constructed with cleaned, renamed-friendly names
 	// referring to the generated Kubernetes API type definitions
 	expReadManyOutput := `
-	if len(resp.DBInstances) == 0 {
-		return nil, ackerr.NotFound
-	}
 	found := false
 	for _, elem := range resp.DBInstances {
 		if elem.AllocatedStorage != nil {

--- a/pkg/generate/s3_test.go
+++ b/pkg/generate/s3_test.go
@@ -140,9 +140,6 @@ func TestS3_Bucket(t *testing.T) {
 	assert.Equal(expDeleteInput, crd.GoCodeSetInput(model.OpTypeDelete, "r.ko", "res", 1))
 
 	expReadManyOutput := `
-	if len(resp.Buckets) == 0 {
-		return nil, ackerr.NotFound
-	}
 	found := false
 	for _, elem := range resp.Buckets {
 		if elem.Name != nil {

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -315,6 +315,9 @@ func (r *CRD) UnpackAttributes() {
 // IsPrimaryARNField returns true if the supplied field name is likely the resource's
 // ARN identifier field.
 func (r *CRD) IsPrimaryARNField(fieldName string) bool {
+	if r.genCfg != nil && !r.genCfg.IncludeACKMetadata {
+		return false
+	}
 	return strings.EqualFold(fieldName, "arn") ||
 		strings.EqualFold(fieldName, r.Names.Original+"arn")
 }
@@ -736,14 +739,14 @@ func (r *CRD) GoCodeSetInput(
 		sourceAdaptedVarName := sourceVarName
 		crdField, found = r.SpecFields[renamedName]
 		if found {
-			sourceAdaptedVarName += ".Spec"
+			sourceAdaptedVarName += r.genCfg.PrefixConfig.SpecField
 		} else {
 			crdField, found = r.StatusFields[memberName]
 			if !found {
 				// TODO(jaypipes): check generator config for exceptions?
 				continue
 			}
-			sourceAdaptedVarName += ".Status"
+			sourceAdaptedVarName += r.genCfg.PrefixConfig.StatusField
 		}
 		sourceAdaptedVarName += "." + crdField.Names.Camel
 
@@ -1675,7 +1678,7 @@ func (r *CRD) GoCodeSetOutput(
 		targetAdaptedVarName := targetVarName
 		crdField, found = r.SpecFields[memberName]
 		if found {
-			targetAdaptedVarName += ".Spec"
+			targetAdaptedVarName += r.genCfg.PrefixConfig.SpecField
 			if !performSpecUpdate {
 				continue
 			}
@@ -1685,7 +1688,7 @@ func (r *CRD) GoCodeSetOutput(
 				// TODO(jaypipes): check generator config for exceptions?
 				continue
 			}
-			targetAdaptedVarName += ".Status"
+			targetAdaptedVarName += r.genCfg.PrefixConfig.StatusField
 		}
 		targetMemberShapeRef = crdField.ShapeRef
 		// fieldVarName is the name of the variable that is used for temporary
@@ -1855,16 +1858,6 @@ func (r *CRD) goCodeSetOutputReadMany(
 	// operation by checking for matching values in these fields.
 	matchFieldNames := r.listOpMatchFieldNames()
 
-	//  if len(resp.CacheClusters) == 0 {
-	//      return nil, ackerr.NotFound
-	//  }
-	out += fmt.Sprintf(
-		"%sif len(%s.%s) == 0 {\n",
-		indent, sourceVarName, listShapeName,
-	)
-	out += fmt.Sprintf("%s\treturn nil, ackerr.NotFound\n", indent)
-	out += fmt.Sprintf("%s}\n", indent)
-
 	// found := false
 	out += fmt.Sprintf("%sfound := false\n", indent)
 	// for _, elem := range resp.CacheClusters {
@@ -1922,14 +1915,14 @@ func (r *CRD) goCodeSetOutputReadMany(
 		targetAdaptedVarName := targetVarName
 		crdField, found = r.SpecFields[memberName]
 		if found {
-			targetAdaptedVarName += ".Spec"
+			targetAdaptedVarName += r.genCfg.PrefixConfig.SpecField
 		} else {
 			crdField, found = r.StatusFields[memberName]
 			if !found {
 				// TODO(jaypipes): check generator config for exceptions?
 				continue
 			}
-			targetAdaptedVarName += ".Status"
+			targetAdaptedVarName += r.genCfg.PrefixConfig.StatusField
 		}
 		targetMemberShapeRef = crdField.ShapeRef
 		out += fmt.Sprintf(
@@ -2020,7 +2013,7 @@ func (r *CRD) goCodeSetOutputReadMany(
 	//      return nil, ackerr.NotFound
 	//  }
 	out += fmt.Sprintf("%sif !found {\n", indent)
-	out += fmt.Sprintf("%s\treturn nil, ackerr.NotFound\n", indent)
+	out += fmt.Sprintf("%s\t%s\n", indent, r.genCfg.SetManyOutputNotFoundErrReturn)
 	out += fmt.Sprintf("%s}\n", indent)
 	return out
 }

--- a/pkg/model/sdk_helper.go
+++ b/pkg/model/sdk_helper.go
@@ -44,6 +44,8 @@ var (
 type SDKHelper struct {
 	basePath string
 	loader   *awssdkmodel.Loader
+	// Default is "services.k8s.aws"
+	APIGroupSuffix string
 }
 
 // NewSDKHelper returns a new SDKHelper object
@@ -77,7 +79,7 @@ func (h *SDKHelper) API(serviceAlias string) (*SDKAPI, error) {
 		// Calling API.ServicePackageDoc() ends up resetting the API.imports
 		// unexported map variable...
 		_ = api.ServicePackageDoc()
-		return &SDKAPI{api, nil, nil}, nil
+		return &SDKAPI{api, nil, nil, h.APIGroupSuffix}, nil
 	}
 	return nil, ErrServiceNotFound
 }
@@ -132,6 +134,8 @@ type SDKAPI struct {
 	// Map, keyed by original Shape GoTypeElem(), with the values being a
 	// renamed type name (due to conflicting names)
 	typeRenames map[string]string
+	// Default is "services.k8s.aws"
+	apiGroupSuffix string
 }
 
 // GetPayloads returns a slice of strings of Shape names representing input and
@@ -263,7 +267,11 @@ func (a *SDKAPI) GetServiceFullName() string {
 // e.g. "sns.services.k8s.aws"
 func (a *SDKAPI) APIGroup() string {
 	serviceID := a.ServiceIDClean()
-	return fmt.Sprintf("%s.services.k8s.aws", serviceID)
+	suffix := "services.k8s.aws"
+	if a.apiGroupSuffix != "" {
+		suffix = a.apiGroupSuffix
+	}
+	return fmt.Sprintf("%s.%s", serviceID, suffix)
 }
 
 // SDKAPIInterfaceTypeName returns the name of the aws-sdk-go primary API

--- a/pkg/testutil/schema_helper.go
+++ b/pkg/testutil/schema_helper.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-controllers-k8s/pkg/generate"
+	"github.com/aws/aws-controllers-k8s/pkg/generate/config"
 	"github.com/aws/aws-controllers-k8s/pkg/model"
 )
 
@@ -33,7 +34,7 @@ func NewGeneratorForService(t *testing.T, serviceAlias string) *generate.Generat
 	if _, err := os.Stat(generatorConfigPath); os.IsNotExist(err) {
 		generatorConfigPath = ""
 	}
-	g, err := generate.New(sdkAPI, "v1alpha1", generatorConfigPath, "")
+	g, err := generate.New(sdkAPI, "v1alpha1", generatorConfigPath, "", config.Default)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Description of changes: As part of the ongoing [effort](https://github.com/crossplane/crossplane/issues/1845) about generating Crossplane AWS Provider, there are some small changes where ACK and Crossplane patterns diverge. In CP, we have all the provider-related fields under `spec.forProvider` so that it's separate from CP machinery fields. Same with status, we have `status.atProvider` to differentiate them from other fields. For details, you can see [Managed Resources API Patterns Design Doc](https://github.com/crossplane/crossplane/blob/37013c6/design/one-pager-managed-resource-api-design.md).

I tried to make the change as least intrusive as possible to the existing mechanisms. Please let me know if you think it could be done in a better way.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
