### PR TITLE
Fix incorrect error returned from sdkFind()

### DIFF
--- a/templates/pkg/resource/sdk_find_read_one.go.tpl
+++ b/templates/pkg/resource/sdk_find_read_one.go.tpl
@@ -21,7 +21,7 @@ func (rm *resourceManager) sdkFind(
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "{{ ResourceExceptionCode .CRD 404 }}" {
 			return nil, ackerr.NotFound
 		}
-		return nil, err
+		return nil, respErr
 	}
 
 	// Merge in the information we read from the API call above to the copy of


### PR DESCRIPTION
Issue #, if available: https://github.com/aws/aws-controllers-k8s/issues/451

Description of changes: Fix a somewhat minor bug. This error handling block is checking one error variable, but returning an unrelated one. The unrelated one is nil and will cause seg faults elsewhere.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
