### PR TITLE
add `ack-generate release` command

### DIFF
--- a/cmd/ack-generate/command/controller.go
+++ b/cmd/ack-generate/command/controller.go
@@ -192,24 +192,17 @@ func writeConfigDirs(g *generate.Generator) error {
 			return err
 		}
 	}
-	targets := []string{
-		"controller/deployment",
-		"controller/kustomization",
-		"default/kustomization",
-		"rbac/cluster-role-binding",
-		"rbac/kustomization",
-	}
-	for _, target := range targets {
-		b, err := g.GenerateConfigYAMLFile(target)
+	for _, target := range generate.ConfigFiles {
+		b, err := g.GenerateConfigFile(target)
 		if err != nil {
 			return err
 		}
 		if optDryRun {
-			fmt.Println("============================= config/" + target + ".yaml ======================================")
+			fmt.Println("============================= " + target + " ======================================")
 			fmt.Println(strings.TrimSpace(b.String()))
 			return nil
 		}
-		path := filepath.Join(optControllerOutputPath, "config", target+".yaml")
+		path := filepath.Join(optControllerOutputPath, target)
 		if err := ioutil.WriteFile(path, b.Bytes(), 0666); err != nil {
 			return err
 		}

--- a/cmd/ack-generate/command/release.go
+++ b/cmd/ack-generate/command/release.go
@@ -1,0 +1,129 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package command
+
+import (
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/aws/aws-controllers-k8s/pkg/generate"
+	"github.com/aws/aws-controllers-k8s/pkg/generate/config"
+	ackmodel "github.com/aws/aws-controllers-k8s/pkg/model"
+)
+
+var (
+	optReleaseOutputPath  string
+	optImageRepository    string
+	optServiceAccountName string
+)
+
+var releaseCmd = &cobra.Command{
+	Use:   "release <service> <release_version>",
+	Short: "Generates release artifacts for a specific service controller and release version",
+	RunE:  generateRelease,
+}
+
+func init() {
+	releaseCmd.PersistentFlags().StringVar(
+		&optImageRepository, "image-repository", "amazon/aws-controllers-k8s", "the Docker image repository to use in release artifacts.",
+	)
+	releaseCmd.PersistentFlags().StringVar(
+		&optServiceAccountName, "service-account-name", "default", "The name of the ServiceAccount AND ClusterRole used for ACK service controller",
+	)
+	releaseCmd.PersistentFlags().StringVarP(
+		&optReleaseOutputPath, "output", "o", "", "path to root directory to create generated files. Defaults to "+optServicesDir+"/$service",
+	)
+	rootCmd.AddCommand(releaseCmd)
+}
+
+// generateRelease generates the Helm charts and other release artifacts for a
+// service controller and release version
+func generateRelease(cmd *cobra.Command, args []string) error {
+	if len(args) != 2 {
+		return fmt.Errorf("please specify the service alias and the release version to generate release artifacts for")
+	}
+	svcAlias := strings.ToLower(args[0])
+	if optReleaseOutputPath == "" {
+		optReleaseOutputPath = filepath.Join(optServicesDir, svcAlias)
+	}
+	// TODO(jaypipes): We could do some git-fu here to verify that the release
+	// version supplied hasn't been used (as a Git tag) before...
+	releaseVersion := strings.ToLower(args[1])
+
+	if err := ensureSDKRepo(optCacheDir); err != nil {
+		return err
+	}
+	sdkHelper := ackmodel.NewSDKHelper(sdkDir)
+	sdkAPI, err := sdkHelper.API(svcAlias)
+	if err != nil {
+		newSvcAlias, err := FallBackFindServiceID(sdkDir, svcAlias)
+		if err != nil {
+			return err
+		}
+		sdkAPI, err = sdkHelper.API(newSvcAlias) // retry with serviceID
+		if err != nil {
+			return fmt.Errorf("service %s not found", svcAlias)
+		}
+	}
+	latestAPIVersion, err = getLatestAPIVersion()
+	if err != nil {
+		return err
+	}
+	g, err := generate.New(
+		sdkAPI, latestAPIVersion, optGeneratorConfigPath, optTemplatesDir, config.Default,
+	)
+	if err != nil {
+		return err
+	}
+
+	if err = writeReleaseFiles(g, releaseVersion); err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeReleaseFiles(g *generate.Generator, releaseVersion string) error {
+	configHelmPath := filepath.Join(optReleaseOutputPath, "helm")
+	configHelmTemplatesPath := filepath.Join(optReleaseOutputPath, "helm", "templates")
+	if !optDryRun {
+		if _, err := ensureDir(configHelmPath); err != nil {
+			return err
+		}
+		if _, err := ensureDir(configHelmTemplatesPath); err != nil {
+			return err
+		}
+	}
+	for _, target := range generate.ReleaseFiles {
+		b, err := g.GenerateReleaseFile(
+			target, releaseVersion, optImageRepository, optServiceAccountName,
+		)
+		if err != nil {
+			return err
+		}
+		if optDryRun {
+			fmt.Println("============================= " + target + " ======================================")
+			fmt.Println(strings.TrimSpace(b.String()))
+			continue
+		}
+		path := filepath.Join(optReleaseOutputPath, target)
+		if err := ioutil.WriteFile(path, b.Bytes(), 0666); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/docs/contents/dev-docs/release.md
+++ b/docs/contents/dev-docs/release.md
@@ -1,0 +1,104 @@
+# Release
+
+Here we document the release process for ACK service controllers.
+
+Remember that there is no single ACK binary. Rather, when we build a release
+for ACK, that release is for one or more individual ACK service controllers
+binaries, each of which are installed separately.
+
+This documentation covers the steps involved in building a service controller's
+release artifacts, including the Helm charts and binary Docker images for an
+ACK service controller, publishing those artifacts and tagging the Git source
+repository appropriately to create an official "release".
+
+## What is a release exactly?
+
+A "release" is the combination of a Git tag containing a SemVer version tag
+against this source repository and the collection of *artifacts* that allow the
+individual ACK service controllers included in that Git commit to be easily
+installed via Helm.
+
+The Git tag points at a specific Git commit referencing the exact source code
+that comprises the ACK service controllers in that "release".
+
+The release artifacts include the following for one or more service
+controllers:
+
+* Docker image
+* Helm chart
+
+The Docker image is built and pushed with an image tag that indicates the
+release version for the controller along with the AWS service. For example,
+assume a release semver tag of `v0.1.0` that includes service controllers for
+S3 and SNS. There would be two Docker images built for this release, one each
+containing the ACK service controllers for S3 and SNS. The Docker images would
+have the following image tags: `s3-controller-v0.1.0` and
+`sns-controller-v0.1.0`. Note that the full image name would be
+`amazon/aws-controllers-k8s:s3-v0.1.0`
+
+The Helm chart artifact can be used to install the ACK service controller as a
+Kubernetes Deployment; the Deployment's Pod image will refer to the exact
+Docker image tag matching the release tag.
+
+## Release steps
+
+1. First check out a git branch for your release:
+ 
+```bash
+export RELEASE_VERSION=v0.0.1
+git checkout -b release-$RELEASE_VERSION
+ ```
+
+2. Build the release artifacts for the controllers you wish to include in the
+   release
+
+   Run `scripts/build-controller-release.sh` for each service. For
+   instance, to build release artifacts for the SNS and S3 controllers I would
+   do:
+
+```bash
+for SERVICE in sns s3;\
+    do ./scripts/build-controller-release.sh $SERVICE $RELEASE_VERSION;
+done
+```
+
+3. You can review the release artifacts that were built for each service by
+   looking in the `services/$SERVICE/helm` directory:
+
+    `tree services/$SERVICE/helm`
+
+    or by doing:
+
+    `git diff`
+
+!!! note
+    When you run `scripts/build-controller-release.sh` for a service, it will
+    overwrite any Helm chart files that had previously been generated in the
+    `services/$SERVICE/helm` directory with files that refer to the
+    Docker image with an image tag referring to the release you've just built
+    artifacts for.
+
+4. Commit your code and create a pull request:
+
+```bash
+git commit -a -m "release artifacts for release $RELEASE_VERSION"
+```
+
+5. Get your pull request reviewed and merged.
+
+6. Upon merging the pull request, a Github Action should trigger that does the
+   following:
+
+```bash
+git tag -a $RELEASE_VERSION $( git rev-parse HEAD )
+git push upstream main --tags
+```
+
+which will end up associating a Git tag (and therefore a Github release) with
+the SHA1 commit ID of the source code for the controllers and the release
+artifacts you built for that release version.
+
+The same Github Action should run the `scripts/publish-controller-images.sh`
+script to build the Docker images for the service controllers included in the
+release and push the images to the `amazon/aws-controllers-k8s` image
+repository.

--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+
+# A script that builds relase artifacts for a single ACK service controller for
+# an AWS service API
+
+set -Eo pipefail
+
+SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
+ROOT_DIR="$SCRIPTS_DIR/.."
+BIN_DIR="$ROOT_DIR/bin"
+TEMPLATES_DIR="$ROOT_DIR/templates"
+
+source "$SCRIPTS_DIR/lib/common.sh"
+source "$SCRIPTS_DIR/lib/k8s.sh"
+source "$SCRIPTS_DIR/lib/helm.sh"
+
+check_is_installed controller-gen "You can install controller-gen with the helper scripts/install-controller-gen.sh"
+check_is_installed helm "You can install Helm with the helper scripts/install-helm.sh"
+
+if ! k8s_controller_gen_version_equals "$CONTROLLER_TOOLS_VERSION"; then
+    echo "FATAL: Existing version of controller-gen "`controller-gen --version`", required version is $CONTROLLER_TOOLS_VERSION."
+    echo "FATAL: Please uninstall controller-gen and install the required version with scripts/install-controller-gen.sh."
+    exit 1
+fi
+
+: "${ACK_GENERATE_CACHE_DIR:=~/.cache/aws-controllers-k8s}"
+: "${ACK_GENERATE_BIN_PATH:=$BIN_DIR/ack-generate}"
+: "${ACK_GENERATE_API_VERSION:="v1alpha1"}"
+: "${ACK_GENERATE_CONFIG_PATH:=""}"
+: "${ACK_GENERATE_OUTPUT_PATH:=""}"
+: "${ACK_GENERATE_IMAGE_REPOSITORY:="amazon/aws-controllers-k8s"}"
+: "${ACK_GENERATE_SERVICE_ACCOUNT_NAME:="ack-controller"}"
+
+USAGE="
+Usage:
+  $(basename "$0") <service> <release_version>
+
+<service> should be an AWS service API aliases that you wish to build -- e.g.
+'s3' 'sns' or 'sqs'
+
+<release_version> should be the SemVer version tag for the release -- e.g.
+'v0.1.3'
+
+Environment variables:
+  ACK_GENERATE_CACHE_DIR                Overrides the directory used for caching
+                                        AWS API models used by the ack-generate
+                                        tool.
+                                        Default: $ACK_GENERATE_CACHE_DIR
+  ACK_GENERATE_BIN_PATH:                Overrides the path to the the ack-generate
+                                        binary.
+                                        Default: $ACK_GENERATE_BIN_PATH
+  ACK_GENERATE_CONFIG_PATH:             Specify a path to the generator config YAML
+                                        file to instruct the code generator for the
+                                        service.
+                                        Default: services/{SERVICE}/generator.yaml
+  ACK_GENERATE_OUTPUT_PATH:             Specify a path for the generator to output
+                                        to.
+                                        Default: services/{SERVICE}
+  ACK_GENERATE_IMAGE_REPOSITORY:        Specify a Docker image repository to use
+                                        for release artifacts
+                                        Default: amazon/aws-controllers-k8s
+  ACK_GENERATE_SERVICE_ACCOUNT_NAME:    Name of the Kubernetes Service Account and
+                                        Cluster Role to use in Helm chart.
+                                        Default: $ACK_GENERATE_SERVICE_ACCOUNT_NAME
+  K8S_RBAC_ROLE_NAME:                   Name of the Kubernetes Role to use when
+                                        generating the RBAC manifests for the
+                                        custom resource definitions.
+                                        Default: $K8S_RBAC_ROLE_NAME
+"
+
+if [ $# -ne 2 ]; then
+    echo "ERROR: $(basename "$0") accepts exactly two parameters, the SERVICE and the RELEASE_VERSION" 1>&2
+    echo "$USAGE"
+    exit 1
+fi
+
+if [ ! -f $ACK_GENERATE_BIN_PATH ]; then
+    if is_installed "ack-generate"; then
+        ACK_GENERATE_BIN_PATH=$(which "ack-generate")
+    else
+        echo "ERROR: Unable to find an ack-generate binary.
+Either set the ACK_GENERATE_BIN_PATH to a valid location or
+run:
+ 
+   make build-ack-generate
+ 
+from the root directory or install ack-generate using:
+
+   go get -u github.com/aws/aws-controllers-k8s/cmd/ack-generate" 1>&2
+        exit 1;
+    fi
+fi
+SERVICE=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+RELEASE_VERSION="$2"
+: "${K8S_RBAC_ROLE_NAME:="ack-$SERVICE-controller"}"
+
+# If there's a generator.yaml in the service's directory and the caller hasn't
+# specified an override, use that.
+if [ -z "$ACK_GENERATE_CONFIG_PATH" ]; then
+    if [ -f "$ROOT_DIR/services/$SERVICE/generator.yaml" ]; then
+        ACK_GENERATE_CONFIG_PATH="$ROOT_DIR/services/$SERVICE/generator.yaml"
+    fi
+fi
+
+helm_output_dir="$ROOT_DIR/services/$SERVICE/helm"
+ag_args="$SERVICE $RELEASE_VERSION"
+if [ -n "$ACK_GENERATE_CACHE_DIR" ]; then
+    ag_args="$ag_args --cache-dir $ACK_GENERATE_CACHE_DIR"
+fi
+if [ -n "$ACK_GENERATE_OUTPUT_PATH" ]; then
+    ag_args="$ag_args --output $ACK_GENERATE_OUTPUT_PATH"
+    helm_output_dir="$ACK_GENERATE_OUTPUT_PATH/helm"
+fi
+if [ -n "$ACK_GENERATE_CONFIG_PATH" ]; then
+    ag_args="$ag_args --generator-config-path $ACK_GENERATE_CONFIG_PATH"
+fi
+if [ -n "$ACK_GENERATE_IMAGE_REPOSITORY" ]; then
+    ag_args="$ag_args --image-repository $ACK_GENERATE_IMAGE_REPOSITORY"
+fi
+if [ -n "$ACK_GENERATE_SERVICE_ACCOUNT_NAME" ]; then
+    ag_args="$ag_args --service-account-name $ACK_GENERATE_SERVICE_ACCOUNT_NAME"
+fi
+
+echo "Building release artifacts for $SERVICE-$RELEASE_VERSION"
+$ACK_GENERATE_BIN_PATH release $ag_args
+
+pushd $ROOT_DIR/services/$SERVICE/apis/$ACK_GENERATE_API_VERSION 1>/dev/null
+
+echo "Generating custom resource definitions for $SERVICE"
+controller-gen crd:allowDangerousTypes=true paths=./... output:crd:artifacts:config=$helm_output_dir/crds
+
+popd 1>/dev/null
+
+pushd $ROOT_DIR/services/$SERVICE/pkg/resource 1>/dev/null
+
+echo "Generating RBAC manifests for $SERVICE"
+controller-gen rbac:roleName=$K8S_RBAC_ROLE_NAME paths=./... output:rbac:artifacts:config=$helm_output_dir/templates
+
+popd 1>/dev/null

--- a/scripts/install-helm.sh
+++ b/scripts/install-helm.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# ./scripts/install-helm.sh
+#
+# Installs Helm if not installed. Optional parameter specifies the version of
+# Helm to install. Defaults to the value of the environment variable
+# "HELM_VERSION" and if that is not set, the value of the DEFAULT_HELM_VERSION
+# variable.
+#
+# NOTE: uses `sudo mv` to relocate a downloaded binary to /usr/local/bin/helm
+
+set -Eo pipefail
+
+SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
+ROOT_DIR="$SCRIPTS_DIR/.."
+DEFAULT_HELM_VERSION="3.2.4"
+
+source "$SCRIPTS_DIR/lib/common.sh"
+
+__helm_version="$1"
+if [ "x$__helm_version" == "x" ]; then
+    __helm_version=${HELM_VERSION:-$DEFAULT_HELM_VERSION}
+fi
+if ! is_installed helm; then
+    __platform=$(uname | tr '[:upper:]' '[:lower:]')
+    __tmp_install_dir=$(mktemp -d -t install-helm-XXX)
+    __helm_url="https://get.helm.sh/helm-v$__helm_version-$__platform-amd64.tar.gz"
+    echo -n "installing helm from $__helm_url ... "
+    curl -L $__helm_url | tar zxf - -C $__tmp_install_dir
+    mv $__tmp_install_dir/$__platform-amd64/helm $__tmp_install_dir/.
+    chmod +x $__tmp_install_dir/helm
+    sudo mv $__tmp_install_dir/helm /usr/local/bin/helm
+    echo "ok."
+fi

--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -8,7 +8,9 @@ set -Eo pipefail
 
 SCRIPTS_DIR=$(cd "$(dirname "$0")" || exit 1; pwd)
 ROOT_DIR="$SCRIPTS_DIR/.."
-TEST_E2E_DIR="$ROOT_DIR/test/e2e"
+TEST_DIR="$ROOT_DIR/test"
+TEST_E2E_DIR="$TEST_DIR/e2e"
+TEST_RELEASE_DIR="$TEST_DIR/release"
 
 OPTIND=1
 CLUSTER_NAME_BASE="test"
@@ -136,8 +138,8 @@ CLUSTER_NAME=$(cat "$TMP_DIR"/clustername)
 ## Build and Load Docker Images
 
 if [ -z "$AWS_SERVICE_DOCKER_IMG" ]; then
-    echo -n "building ack-${AWS_SERVICE}-controller docker image ... "
-    DEFAULT_AWS_SERVICE_DOCKER_IMG="ack-${AWS_SERVICE}-controller:${VERSION}"
+    DEFAULT_AWS_SERVICE_DOCKER_IMG="aws-controllers-k8s:${AWS_SERVICE}-${VERSION}"
+    echo -n "building $DEFAULT_AWS_SERVICE_DOCKER_IMG docker image ... "
     ${SCRIPTS_DIR}/build-controller-image.sh -q -s ${AWS_SERVICE} -i ${DEFAULT_AWS_SERVICE_DOCKER_IMG} 1>/dev/null || exit 1
     echo "ok."
     AWS_SERVICE_DOCKER_IMG="${DEFAULT_AWS_SERVICE_DOCKER_IMG}"
@@ -213,4 +215,5 @@ echo "==========================================================================
 
 export KUBECONFIG
 
+$TEST_RELEASE_DIR/test-helm.sh "$AWS_SERVICE" "$VERSION"
 $TEST_E2E_DIR/run-tests.sh $AWS_SERVICE

--- a/scripts/lib/helm.sh
+++ b/scripts/lib/helm.sh
@@ -1,29 +1,5 @@
 #!/usr/bin/env bash
 
-DEFAULT_HELM_VERSION="3.2.4"
-
-# ensure_helm [<helm version>]
-#
-# Installs the helm binary if it isn't present on the system.  Takes an
-# optional parameter for the version of helm to install. Defaults to the value
-# of the HELM_VERSION environment variable and then the value of the
-# DEFAULT_HELM_VERSION variable.  Uses `sudo mv` to place the downloaded binary
-# into your PATH.
-ensure_helm() {
-    local __helm_version="$1"
-    if [ "x$__helm_version" == "x" ]; then
-        __helm_version=${HELM_VERSION:-$DEFAULT_HELM_VERSION}
-    fi
-    if ! is_installed helm; then
-        __platform=$(uname | tr '[:upper:]' '[:lower:]')
-        __tmp_install_dir=$(mktemp -d -t install-helm-XXX)
-        curl -L https://get.helm.sh/helm-v$__helm_version-$__platform-amd64.tar.gz | tar zxf - -C $__tmp_install_dir
-        mv $__tmp_install_dir/$__platform-amd64/helm $__tmp_install_dir/.
-        chmod +x $__tmp_install_dir/helm
-        sudo mv $__tmp_install_dir/helm /usr/local/bin/helm
-    fi
-}
-
 add_helm_repo() {
    if ! should_execute add_helm_repo; then
      return 1

--- a/templates/helm/Chart.yaml.tpl
+++ b/templates/helm/Chart.yaml.tpl
@@ -1,0 +1,16 @@
+apiVersion: v1
+name: ack-{{ .ServiceIDClean }}-controller
+description: A Helm chart for the ACK service controller for {{ .ServiceIDClean }}
+version: {{ .ReleaseVersion }}
+appVersion: {{ .ReleaseVersion }}
+home: https://github.com/aws/aws-controllers-k8s
+icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
+sources:
+  - https://github.com/aws/aws-controllers-k8s
+maintainers:
+  - name: ACK Admins
+    url: https://github.com/orgs/aws/teams/aws-controllers-for-kubernetes-ack-admins
+keywords:
+  - aws
+  - kubernetes
+  - {{ .ServiceIDClean }}

--- a/templates/helm/templates/_helpers.tpl
+++ b/templates/helm/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* The name of the application this chart installs */}}
+{{- define "app.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "app.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* The name and version as used by the chart label */}}
+{{- define "chart.name-version" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/* The name of the service account to use */}}
+{{- define "service-account.name" -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}

--- a/templates/helm/templates/cluster-role-binding.yaml
+++ b/templates/helm/templates/cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "app.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "app.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "service-account.name" . }}
+  namespace: {{ .Release.Namespace }}

--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "app.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "app.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+    k8s-app: {{ include "app.name" . }}
+    helm.sh/chart: {{ include "chart.name-version" . }}
+    control-plane: controller
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "app.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+      {{- range $key, $value := .Values.deployment.annotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      labels:
+        app.kubernetes.io/name: {{ include "app.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: Helm
+        k8s-app: {{ include "app.name" . }}
+{{- range $key, $value := .Values.deployment.labels }}
+        {{ $key }}: {{ $value | quote }}
+{{- end }}
+    spec:
+      containers:
+      - command:
+        - ./bin/controller
+        args:
+        - --aws-account-id
+        - "$(AWS_ACCOUNT_ID)"
+        - --aws-region
+        - "$(AWS_REGION)"
+        - --enable-development-logging
+        - "$(ACK_ENABLE_DEVELOPMENT_LOGGING)"
+        - --log-level
+        - "$(ACK_LOG_LEVEL)"
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        name: controller
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        env:
+        - name: K8S_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      terminationGracePeriodSeconds: 10

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -1,0 +1,36 @@
+# Default values for ack-{{ .ServiceIDClean }}-controller.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: {{ .ImageRepository }}
+  tag: {{ .ServiceIDClean }}-{{ .ReleaseVersion }}
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+nameOverride: ""
+fullnameOverride: ""
+
+deployment:
+  annotations: {}
+  labels: {}
+
+resources:
+  requests:
+    memory: "64Mi"
+    cpu: "50m"
+  limits:
+    memory: "128Mi"
+    cpu: "100m"
+
+aws:
+  # If specified, use the AWS region for AWS API calls
+  region: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  name: {{ .ServiceAccountName }}
+  annotations: {}
+    # eks.amazonaws.com/role-arn: arn:aws:iam::AWS_ACCOUNT_ID:role/IAM_ROLE_NAME

--- a/test/release/test-helm.sh
+++ b/test/release/test-helm.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# This test script generates the Helm Chart for a supplied ACK service
+# controller and specified release version, installs the ACK service controller
+# for S3 using the generated Helm chart and then uninstalls the controller
+# using Helm.
+#
+# You should have already created a Kubernetes cluster (perhaps using
+# ./scripts/provision-kind-cluster.sh) and exported the KUBECONFIG
+# appropriately before running this script.
+
+set -eo pipefail
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="$THIS_DIR/../.."
+SCRIPTS_DIR="$ROOT_DIR/scripts"
+BUILD_DIR="$ROOT_DIR/build"
+
+source "$SCRIPTS_DIR/lib/common.sh"
+
+check_is_installed helm "You can install helm with the helper scripts/install-helm.sh"
+
+USAGE="
+Usage:
+  $(basename "$0") <service> <release_version>
+
+<service> should be an AWS service for which you wish to run tests -- e.g.
+'s3' 'sns' or 'sqs'
+
+<release_version> should be the SemVer version string to build a Helm chart
+for. This release version string should match the name of the Docker image that
+has previously been built.
+"
+
+SERVICE="$1"
+RELEASE_VERSION="$2"
+K8S_NAMESPACE="ack-system-test-helm"
+
+CHART_DIR="$BUILD_DIR/release/$RELEASE_VERSION/$SERVICE"
+
+echo "testing Helm release for $SERVICE for release version $RELEASE_VERSION."
+mkdir -p $CHART_DIR
+
+# We need to do this to prevent "unable to open go.mod" errors from
+# ack-generate...
+pushd $ROOT_DIR 1>/dev/null
+
+ACK_GENERATE_IMAGE_REPOSITORY="aws-controllers-k8s" \
+    ACK_GENERATE_SERVICE_ACCOUNT_NAME="ack-$SERVICE-controller-helm-test" \
+    ACK_GENERATE_OUTPUT_PATH="$CHART_DIR" \
+    K8S_RBAC_ROLE_NAME="ack-$SERVICE-controller-helm-test" \
+    $SCRIPTS_DIR/build-controller-release.sh "$SERVICE" "$RELEASE_VERSION"
+
+popd 1>/dev/null
+
+kubectl create namespace "$K8S_NAMESPACE"
+
+pushd $CHART_DIR/helm 1>/dev/null
+
+echo -n "installing the helm chart for ack-$SERVICE-controller in namespace $K8S_NAMESPACE ... "
+helm install --namespace "$K8S_NAMESPACE" ack-$SERVICE-controller-helm-test . 1>/dev/null || exit 1
+echo "ok."
+
+echo -n "uninstalling the helm chart for ack-$SERVICE-controller in namespace $K8S_NAMESPACE ... "
+helm uninstall --namespace "$K8S_NAMESPACE" ack-$SERVICE-controller-helm-test 1>/dev/null || exit 1
+echo "ok."


### PR DESCRIPTION
Adds a new `ack-generate release <SERVICE> <VERSION>` command that
generates a Helm chart for a specific service controller and release
version combination.

The Helm chart that is generated installs the Docker image for the
ACK controller for that service and release version. For example, if you
run:

```bash
ack-generate release s3 v0.0.1
```

the Helm chart generated will be placed in
`/services/s3/helm/Chart.yaml` and the image referred to from the
Deployment created in that chart will be
`amazon/aws-controllers-k8s:s3-v0.0.1`.

Also includes documentation on the release steps and a test of the Helm
installation process.

Issue #366 
Issue #456 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
