### PR TITLE
Add prechecks in apigwv2 e2e tests.

### DIFF
--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -23,7 +23,7 @@ DEFAULT_AWS_CLI_VERSION="2.0.52"
 daws() {
     aws_cli_img_version=${ACK_AWS_CLI_IMAGE_VERSION:-$DEFAULT_AWS_CLI_VERSION}
     aws_cli_img="amazon/aws-cli:$aws_cli_img_version"
-    docker run --rm -v ~/.aws:/root/.aws "$aws_cli_img" "$@"
+    docker run --rm -v ~/.aws:/root/.aws  -v $(pwd):/aws "$aws_cli_img" "$@"
 }
 
 # aws_check_credentials() calls the STS::GetCallerIdentity API call and


### PR DESCRIPTION
Issue #394 , if available:

Description of changes:
* Making daws use local file system for aws commands that need to upload file. Assuming this won't harm any other e2e test
* Adding prechecks in resource setup for apigwv2 e2e tests.
* I know we are using awscliv2 now but still checking exit status for both 255 & 254 for NotFoundExceptions.

```
vijat@186590cff3cf aws-controllers-k8s % ./scripts/kind-build-test.sh -s apigatewayv2 -p -r arn:aws:iam::309117047740:role/Admin-k8s -c /Users/vijat/Documents/gocode/src/github.com/vijtrip2/aws-controllers-k8s/scripts/lib/../../build/tmp-ack-test-5765e6b8-68b12ea9
checking AWS credentials ... ok.
building ack-apigatewayv2-controller docker image ... ok.
loading the images into the cluster ... ok.
loading CRD manifests for apigatewayv2 into the cluster ... ok.
loading RBAC manifests for apigatewayv2 into the cluster ... ok.
loading service controller Deployment for apigatewayv2 into the cluster ...ok.
generating AWS temporary credentials and adding to env vars map ... ok.
======================================================================================================
To poke around your test cluster manually:
export KUBECONFIG=/Users/vijat/Documents/gocode/src/github.com/vijtrip2/aws-controllers-k8s/scripts/lib/../../build/tmp-ack-test-5765e6b8-68b12ea9/kubeconfig
kubectl get pods -A
======================================================================================================
e2e took 198 second(s)
To resume test with the same cluster use: "-c /Users/vijat/Documents/gocode/src/github.com/vijtrip2/aws-controllers-k8s/scripts/lib/../../build/tmp-ack-test-5765e6b8-68b12ea9"
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
