### PR TITLE
kind-build-test.sh add colons in getopts for -i and -v

### DIFF
--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -80,7 +80,7 @@ Options:
 "
 
 # Process our input arguments
-while getopts "ps:r:ic:v" opt; do
+while getopts "ps:r:i:c:v:" opt; do
   case ${opt} in
     p ) # PRESERVE K8s Cluster
         PRESERVE=true


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Fix parameter inputs in `kind-build-test.sh`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
