### PR TITLE
Add `compare` configuration to support ignoring specific fields when comparing CRs

### DIFF
--- a/pkg/generate/config/config.go
+++ b/pkg/generate/config/config.go
@@ -134,6 +134,16 @@ type ResourceConfig struct {
 	// SpecFields is a list of instructions about additional Spec fields
 	// on this Resource
 	SpecFields []*SpecFieldConfig `json:"spec_fields"`
+	// Compare contains instructions for the code generation to generate custom
+	// comparison logic.
+	Compare *CompareConfig `json:"compare,omitempty"`
+}
+
+// CompareConfig informs instruct the code generator on how to compare two different
+// two objects of the same type
+type CompareConfig struct {
+	// Ignore is a list of field paths to ignore when comparing two objects
+	Ignore []string `json:"ignore"`
 }
 
 // SpecFieldConfig instructs the code generator how to handle an additional
@@ -366,7 +376,7 @@ func (c *Config) OverrideValues(operationName string) (map[string]string, bool) 
 	return oConfig.OverrideValues, ok
 }
 
-// AdditionSpec gives map of operation and their MemberFields to
+// SpecFieldConfigs gives map of operation and their MemberFields to
 // add to spec.
 func (c *Config) SpecFieldConfigs(resourceName string) ([]*SpecFieldConfig, bool) {
 	if c == nil {
@@ -377,6 +387,22 @@ func (c *Config) SpecFieldConfigs(resourceName string) ([]*SpecFieldConfig, bool
 		return nil, false
 	}
 	return resourceConfig.SpecFields, ok
+}
+
+// GetCompareIgnoredFields returns the list of field path to ignore when
+// comparing two differnt objects
+func (c *Config) GetCompareIgnoredFields(resName string) []string {
+	if c == nil {
+		return nil
+	}
+	rConfig, ok := c.Resources[resName]
+	if !ok {
+		return nil
+	}
+	if rConfig.Compare == nil {
+		return nil
+	}
+	return rConfig.Compare.Ignore
 }
 
 // IsIgnoredResource returns true if Operation Name is configured to be ignored

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -280,6 +280,11 @@ func (r *CRD) UnpacksAttributesMap() bool {
 	return r.genCfg.UnpacksAttributesMap(r.Names.Original)
 }
 
+// CompareIgnoredFields returns the list of fields compare logic should ignore
+func (r *CRD) CompareIgnoredFields() []string {
+	return r.genCfg.GetCompareIgnoredFields(r.Names.Original)
+}
+
 // SetAttributesSingleAttribute returns true if the supplied resource name has
 // a SetAttributes operation that only actually changes a single attribute at a
 // time. See: SNS SetTopicAttributes API call, which is entirely different from


### PR DESCRIPTION
Issue N/A

Description of changes:
- Adding `Compare` field to the generator configuration, to support custom comparison logic for CR objects.
- Adding `Ignore` field to the Compare configuration, to instruct the generator to ignore certain fields when comparing two different CRs

Configuration example:
```yaml
# lambda/generator.yaml
resources:
  Function:
    exceptions:
      codes:
        404: ResourceNotFoundException
    list_operation:
      match_fields:
        - FunctionName
    compare:
      ignore:
        - 'Spec.Code.s3Bucket'
        - 'Spec.Code.s3Key'
        - 'Status.Code.Location'
        - 'Status.Code.Type'

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
