### PR TITLE
Add kustomization for crds

### DIFF
--- a/services/apigatewayv2/config/crd/kustomization.yaml
+++ b/services/apigatewayv2/config/crd/kustomization.yaml
@@ -1,0 +1,13 @@
+resources:
+  - bases/apigatewayv2.services.k8s.aws_apimappings.yaml
+  - bases/apigatewayv2.services.k8s.aws_apis.yaml
+  - bases/apigatewayv2.services.k8s.aws_authorizers.yaml
+  - bases/apigatewayv2.services.k8s.aws_deployments.yaml
+  - bases/apigatewayv2.services.k8s.aws_domainnames.yaml
+  - bases/apigatewayv2.services.k8s.aws_integrationresponses.yaml
+  - bases/apigatewayv2.services.k8s.aws_integrations.yaml
+  - bases/apigatewayv2.services.k8s.aws_models.yaml
+  - bases/apigatewayv2.services.k8s.aws_routeresponses.yaml
+  - bases/apigatewayv2.services.k8s.aws_routes.yaml
+  - bases/apigatewayv2.services.k8s.aws_stages.yaml
+  - bases/apigatewayv2.services.k8s.aws_vpclinks.yaml

--- a/services/apigatewayv2/config/default/kustomization.yaml
+++ b/services/apigatewayv2/config/default/kustomization.yaml
@@ -13,7 +13,7 @@
 #  someName: someValue
 
 bases:
-# - ../crd
+- ../crd
 - ../rbac
 - ../controller
 

--- a/services/dynamodb/config/crd/kustomization.yaml
+++ b/services/dynamodb/config/crd/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - bases/dynamodb.services.k8s.aws_backups.yaml
+  - bases/dynamodb.services.k8s.aws_globaltables.yaml
+  - bases/dynamodb.services.k8s.aws_tables.yaml

--- a/services/dynamodb/config/default/kustomization.yaml
+++ b/services/dynamodb/config/default/kustomization.yaml
@@ -13,7 +13,7 @@
 #  someName: someValue
 
 bases:
-# - ../crd
+- ../crd
 - ../rbac
 - ../controller
 

--- a/services/ecr/config/crd/kustomization.yaml
+++ b/services/ecr/config/crd/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - bases/ecr.services.k8s.aws_repositories.yaml

--- a/services/ecr/config/default/kustomization.yaml
+++ b/services/ecr/config/default/kustomization.yaml
@@ -13,7 +13,7 @@
 #  someName: someValue
 
 bases:
-# - ../crd
+- ../crd
 - ../rbac
 - ../controller
 

--- a/services/elasticache/config/crd/kustomization.yaml
+++ b/services/elasticache/config/crd/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - bases/elasticache.services.k8s.aws_cachesubnetgroups.yaml
+  - bases/elasticache.services.k8s.aws_replicationgroups.yaml
+  - bases/elasticache.services.k8s.aws_snapshots.yaml

--- a/services/elasticache/config/default/kustomization.yaml
+++ b/services/elasticache/config/default/kustomization.yaml
@@ -13,7 +13,7 @@
 #  someName: someValue
 
 bases:
-# - ../crd
+- ../crd
 - ../rbac
 - ../controller
 

--- a/services/s3/config/crd/kustomization.yaml
+++ b/services/s3/config/crd/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - bases/s3.services.k8s.aws_buckets.yaml

--- a/services/s3/config/default/kustomization.yaml
+++ b/services/s3/config/default/kustomization.yaml
@@ -13,7 +13,7 @@
 #  someName: someValue
 
 bases:
-# - ../crd
+- ../crd
 - ../rbac
 - ../controller
 

--- a/services/sfn/config/crd/kustomization.yaml
+++ b/services/sfn/config/crd/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - bases/sfn.services.k8s.aws_activities.yaml
+  - bases/sfn.services.k8s.aws_statemachines.yaml

--- a/services/sfn/config/default/kustomization.yaml
+++ b/services/sfn/config/default/kustomization.yaml
@@ -13,7 +13,7 @@
 #  someName: someValue
 
 bases:
-# - ../crd
+- ../crd
 - ../rbac
 - ../controller
 

--- a/services/sns/config/crd/kustomization.yaml
+++ b/services/sns/config/crd/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - bases/sns.services.k8s.aws_platformapplications.yaml
+  - bases/sns.services.k8s.aws_platformendpoints.yaml
+  - bases/sns.services.k8s.aws_topics.yaml


### PR DESCRIPTION
Closes https://github.com/aws/aws-controllers-k8s/issues/468

Description of changes:

Now when you run `kustomize build services/${SERVICE}/config/default` crds are generated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
