### PR TITLE
Pass a struct value sample to `cmpopts.IgnoreFields` instead of a value pointer

### DIFF
--- a/templates/pkg/resource/descriptor.go.tpl
+++ b/templates/pkg/resource/descriptor.go.tpl
@@ -64,7 +64,7 @@ func (d *resourceDescriptor) Equal(
 	bc := b.(*resource)
 	opts := []cmp.Option{cmpopts.EquateEmpty()}
 	{{- if .CRD.CompareIgnoredFields }}
-	opts = append(opts, cmpopts.IgnoreFields(ac,
+	opts = append(opts, cmpopts.IgnoreFields(*ac.ko,
 		{{- range $fieldPath := .CRD.CompareIgnoredFields }}
 		{{ printf "%q" $fieldPath }},
 		{{- end }}
@@ -89,7 +89,7 @@ func (d *resourceDescriptor) Diff(
 		cmp.AllowUnexported(svcapitypes.{{ .CRD.Kind }}{}),
 	}
 	{{- if .CRD.CompareIgnoredFields }}
-	opts = append(opts, cmpopts.IgnoreFields(ac,
+	opts = append(opts, cmpopts.IgnoreFields(*ac.ko,
 		{{- range $fieldPath := .CRD.CompareIgnoredFields }}
 		{{ printf "%q" $fieldPath }},
 		{{- end }}


### PR DESCRIPTION
Issue N/A, followup to: #465 

While debugging the lambda controller i found an issue regarding `cmpopts.IgnoreFields` usage (oops 😄 )
 
Description of changes:
Fix `cmpopts` usage by passing a struct value sample to `cmpopts.IgnoreFields` instead of a value pointer

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
