### PR TITLE
update install docs and add helm package script

### DIFF
--- a/docs/contents/user-docs/install.md
+++ b/docs/contents/user-docs/install.md
@@ -1,37 +1,56 @@
 # Install
 
-In the following we walk you through installing an AWS service controller.
+In the following we walk you through installing an ACK service controller.
+
+## Docker images
+
+!!! note "No single ACK Docker image"
+    Note that there is no single ACK Docker image. Instead, there are Docker
+    images for each individual ACK service controller that manages resources
+    for a particular AWS API.
+
+Each ACK service controller is packaged into a separate container image,
+published on the [`amazon/aws-controllers-k8s` DockerHub repository][0].
+
+[0]: https://hub.docker.com/r/amazon/aws-controllers-k8s
+
+Individual ACK service controllers are tagged with `$SERVICE-$VERSION` Docker
+image tags, allowing you to download/test specific ACK service controllers. For
+example, if you wanted to test the `v0.1.0` release image of the ACK service
+controller for S3, you would pull the `amazon/aws-controllers-k8s:s3-v0.1.0`
+image.
 
 ## Helm (recommended)
 
-The recommended way to install an AWS service controller for Kubernetes is to
-use Helm 3.
+The recommended way to install an ACK service controller for Kubernetes is to
+use Helm 3. Please ensure you have installed Helm 3 to your local environment
+before running these steps.
 
-Before installing an AWS service controller, ensure you have added the
+Before installing an ACK service controller, ensure you have added the
 AWS Controllers for Kubernetes Helm repository:
 
 ```
 helm repo add ack https://aws.github.io/aws-controllers-k8s
 ```
 
-Each AWS service controller is packaged into a separate container image, published on a public AWS Elastic Container Registry repository. Likewise,
-each AWS service controller has a separate Helm chart that installs—as a
-Kubernetes `Deployment`—the AWS service controller, necessary custom resource
-definitions (CRDs), Kubernetes RBAC manifests, and other supporting artifacts.
+Likewise, each ACK service controller has a separate Helm chart that
+installs—as a Kubernetes `Deployment`—the ACK service controller, necessary
+custom resource definitions (CRDs), Kubernetes RBAC manifests, and other
+supporting artifacts.
 
-You may install a particular AWS service controller using the `helm install`
+You may install a particular ACK service controller using the `helm install`
 CLI command:
 
 ```
-helm install [--namespace $KUBERNETES_NAMESPACE] ack/$SERVICE_ALIAS
+helm install [--namespace $KUBERNETES_NAMESPACE] ack/ack-$SERVICE-controller
 ```
 
-for example, if you wanted to install the AWS S3 service controller into the
-"ack-system" Kubernetes namespace, you would execute:
+for example, if you wanted to install the latest ACK service controller for S3
+into the "ack-system" Kubernetes namespace, you would execute:
 
 
 ```sh
-helm install --namespace ack-system ack/s3
+helm install --namespace ack-system ack/ack-s3-controller
 ```
 
 ## Static Kubernetes manifests
@@ -41,13 +60,13 @@ static Kubernetes manifests.
 
 Static Kubernetes manifests that install individual service controllers are
 attached as artifacts to releases of AWS Controllers for Kubernetes. Select a
-release from the [list of
-releases](https://github.com/aws/aws-controllers-k8s/releases) for AWS
-Controllers for Kubernetes.
+release from the [list of releases][1] for AWS Controllers for Kubernetes.
+
+[1]: https://github.com/aws/aws-controllers-k8s/releases
 
 You will see a list of Assets for the release. One of those Assets will be
-named `services/$SERVICE_ALIAS/all-resources.yaml`. For example, for the AWS S3
-service controller, there will be an Asset named
+named `services/$SERVICE/all-resources.yaml`. For example, for the ACK service
+controller for S3, there will be an Asset named
 `services/s3/all-resources.yaml` attached to the release. Click on the link to
 download the YAML file. This YAML file may be fed to `kubectl apply -f`
 directly to install the service controller, any CRDs that it manages, and all

--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-# A script that builds relase artifacts for a single ACK service controller for
-# an AWS service API
+# A script that builds release artifacts for a single ACK service controller
+# for an AWS service API
 
 set -Eo pipefail
 

--- a/scripts/helm-package-controller.sh
+++ b/scripts/helm-package-controller.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# A script that creates a Helm chart package for a specific ACK service
+# controller
+
+set -Eo pipefail
+
+SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
+ROOT_DIR="$SCRIPTS_DIR/.."
+BUILD_DIR="$ROOT_DIR/build"
+
+source "$SCRIPTS_DIR/lib/common.sh"
+
+check_is_installed helm "You can install Helm with the helper scripts/install-helm.sh"
+
+USAGE="
+Usage:
+  $(basename "$0") <service>
+
+<service> should be an AWS service API aliases that you wish to build -- e.g.
+'s3' 'sns' or 'sqs'
+
+Environment variables:
+  CHART_INPUT_PATH:         Specify a path for the Helm chart to use as input.
+                            Default: services/{SERVICE}/helm
+  PACKAGE_OUTPUT_PATH:      Specify a path for the Helm chart package to output to.
+                            Default: $BUILD_DIR/release/{SERVICE}
+"
+
+if [ $# -ne 1 ]; then
+    echo "ERROR: $(basename "$0") accepts one parameter, the SERVICE" 1>&2
+    echo "$USAGE"
+    exit 1
+fi
+
+SERVICE=$(echo "$1" | tr '[:upper:]' '[:lower:]')
+
+: "${PACKAGE_OUTPUT_PATH:="$BUILD_DIR/release/$SERVICE"}"
+: "${CHART_INPUT_PATH:="$ROOT_DIR/services/$SERVICE/helm"}"
+
+if [[ ! -d "$CHART_INPUT_PATH" ]]; then
+    echo "Chart input path: $CHART_INPUT_PATH does not exist."
+    exit 1
+fi
+
+mkdir -p $PACKAGE_OUTPUT_PATH
+
+helm package $CHART_INPUT_PATH --destination $PACKAGE_OUTPUT_PATH

--- a/scripts/publish-controller-image.sh
+++ b/scripts/publish-controller-image.sh
@@ -32,9 +32,6 @@ Options:
 # Process our input arguments
 while getopts "r:s:i:" opt; do
   case ${opt} in
-    q ) # Build image quietly
-        QUIET=true
-      ;;
     r ) # Docker repository name
         DOCKER_REPOSITORY="${OPTARG}"
       ;;


### PR DESCRIPTION
Updates the user installation docs to better highlight the way our
Docker images are tagged and how to properly install with Helm.

Adds a new `scripts/helm-package-controller.sh` script that runs the
`helm package` command against a service controller's generated Helm
chart to create the tarball package that is needed to place in the Helm
repository we'll be indexing in our gh-pages branch of the
aws-controllers-k8s source repository.

Issue #366 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
