### PR TITLE
Fix ClusterRole ref name in cluster-role-binding.yml

### DIFF
--- a/templates/helm/templates/cluster-role-binding.yaml
+++ b/templates/helm/templates/cluster-role-binding.yaml
@@ -5,7 +5,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "app.fullname" . }}
+  name: {{ include "app.name" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "service-account.name" . }}

--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         {{ $key }}: {{ $value | quote }}
 {{- end }}
     spec:
+      serviceAccountName: {{ include "service-account.name" . }}
       containers:
       - command:
         - ./bin/controller


### PR DESCRIPTION
- Add service account name for controller deployment pod specs
- Use `app.name` instead of `app.fullname` for ClusterRole refName

Issue #366 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
