### PR TITLE
Use service related names for ServiceAccount names in ./scripts/build-controller-release.sh

### DIFF
--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -29,7 +29,6 @@ fi
 : "${ACK_GENERATE_CONFIG_PATH:=""}"
 : "${ACK_GENERATE_OUTPUT_PATH:=""}"
 : "${ACK_GENERATE_IMAGE_REPOSITORY:="amazon/aws-controllers-k8s"}"
-: "${ACK_GENERATE_SERVICE_ACCOUNT_NAME:="ack-controller"}"
 
 USAGE="
 Usage:
@@ -93,6 +92,7 @@ fi
 SERVICE=$(echo "$1" | tr '[:upper:]' '[:lower:]')
 RELEASE_VERSION="$2"
 : "${K8S_RBAC_ROLE_NAME:="ack-$SERVICE-controller"}"
+: "${ACK_GENERATE_SERVICE_ACCOUNT_NAME:="ack-$SERVICE-controller"}"
 
 # If there's a generator.yaml in the service's directory and the caller hasn't
 # specified an override, use that.


### PR DESCRIPTION
Issue #366

Description of changes:
- Use service related names for `ServiceAccount` k8s resource naming

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
