### PR TITLE
Add cross region resource management smoke tests

### DIFF
--- a/scripts/lib/aws/sns.sh
+++ b/scripts/lib/aws/sns.sh
@@ -10,6 +10,14 @@ SCRIPTS_DIR="$ROOT_DIR/scripts"
 # sns_topic_exists() returns 0 if an SNS topic with the supplied ARN
 # exists, 1 otherwise.
 #
+# sns_topic_exists TOPIC_NAME [ AWS_REGION ] [ AWS_PROFILE ]
+#
+# Arguments:
+#
+#   TOPIC_NAME      required string for the name of the topic to check
+#   AWS_REGION      alternate region to use
+#   AWS_PROFILE     alternate profile to use
+#
 # Usage:
 #
 #   if ! sns_topic_exists "$topic_arn"; then
@@ -17,7 +25,18 @@ SCRIPTS_DIR="$ROOT_DIR/scripts"
 #   fi
 sns_topic_exists() {
     __topic_arn="$1"
-    daws sns get-topic-attributes --topic-arn "$topic_arn" --output json >/dev/null 2>&1
+    __region_args=""
+    __region="$2"
+    if [[ -n "$__region" ]]; then
+        __region_args=" --region $__region"
+    fi
+    __profile_args=""
+    __profile="$3"
+    if [[ -n "$__profile" ]]; then
+        __profile_args=" --profile $__profile"
+    fi
+
+    daws sns get-topic-attributes --topic-arn "$__topic_arn" $__region_args $__profile_args --output json >/dev/null 2>&1
     if [[ $? -eq 254 ]]; then
         return 1
     else

--- a/test/e2e/sns/cross-region.sh
+++ b/test/e2e/sns/cross-region.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="$THIS_DIR/../../.."
+SCRIPTS_DIR="$ROOT_DIR/scripts"
+
+source "$SCRIPTS_DIR/lib/common.sh"
+source "$SCRIPTS_DIR/lib/k8s.sh"
+source "$SCRIPTS_DIR/lib/aws/sns.sh"
+source "$SCRIPTS_DIR/lib/testutil.sh"
+
+AWS_ACCOUNT_ID=$( aws_account_id )
+TESTING_NAMESPACE=${TESTING_NAMESPACE:-"testing-$RANDOM"}
+AWS_REGION_OVERRIDE=${AWS_REGION_OVERRIDE:-"eu-west-3"}
+AWS_REGION_DEFAULT=${AWS_REGION_DEFAULT:-"eu-central-1"}
+
+test_name="$( filenoext "${BASH_SOURCE[0]}" )"
+service_name="sns"
+ack_ctrl_pod_id=$( controller_pod_id )
+debug_msg "executing test: $service_name/$test_name"
+
+topic_name="ack-test-smoke-$service_name"
+resource_name="topics/$topic_name"
+topic_arn_override_region="arn:aws:sns:$AWS_REGION_OVERRIDE:$AWS_ACCOUNT_ID:$topic_name"
+topic_arn_default_region="arn:aws:sns:$AWS_REGION_DEFAULT:$AWS_ACCOUNT_ID:$topic_name"
+
+
+# PRE-CHECKS
+if sns_topic_exists "$topic_arn_override_region" "$AWS_REGION_OVERRIDE"; then
+    echo "FAIL: expected $topic_name to not exist in SNS in region $AWS_REGION_OVERRIDE. Did previous test run cleanup?"
+    exit 1
+fi
+
+if sns_topic_exists "$topic_arn_default_region" "$AWS_REGION_DEFAULT"; then
+    echo "FAIL: expected $topic_name to not exist in SNS in region $AWS_REGION_DEFAULT. Did previous test run cleanup?"
+    exit 1
+fi
+
+if k8s_resource_exists "$resource_name"; then
+    echo "FAIL: expected $resource_name to not exist. Did previous test run cleanup?"
+    exit 1
+fi
+
+# Create the testing namespace
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: $TESTING_NAMESPACE
+  annotations:
+    services.k8s.aws/default-region: "$AWS_REGION_DEFAULT"
+EOF
+
+# TEST ACTIONS and ASSERTIONS
+
+# TEST Creating resource in the namespace default region
+cat <<EOF | kubectl apply -f -
+apiVersion: sns.services.k8s.aws/v1alpha1
+kind: Topic
+metadata:
+  name: $topic_name
+  namespace: $TESTING_NAMESPACE
+spec:
+  name: $topic_name
+EOF
+
+sleep 15
+
+debug_msg "checking topic $topic_name created in SNS in region $AWS_REGION_DEFAULT"
+
+if ! sns_topic_exists "$topic_arn_default_region" "$AWS_REGION_DEFAULT"; then
+    echo "FAIL: expected $topic_name to have been created in SNS in region $AWS_REGION_DEFAULT"
+    kubectl logs -n ack-system "$ack_ctrl_pod_id"
+    exit 1
+fi
+
+kubectl -n "$TESTING_NAMESPACE" delete "$resource_name" 2>/dev/null
+assert_equal "0" "$?" "Expected success from kubectl delete but got $?" || exit 1
+
+sleep 15
+
+if sns_topic_exists "$topic_arn_default_region" "$AWS_REGION_DEFAULT"; then
+    echo "FAIL: expected $topic_name to be deleted in SNS in region $AWS_REGION_DEFAULT"
+    exit 1
+fi
+
+# TEST Overriding the resource region using CR Annotations
+
+cat <<EOF | kubectl apply -f -
+apiVersion: sns.services.k8s.aws/v1alpha1
+kind: Topic
+metadata:
+  name: $topic_name
+  namespace: $TESTING_NAMESPACE
+  annotations:
+    services.k8s.aws/region: $AWS_REGION_OVERRIDE
+spec:
+  name: $topic_name
+EOF
+
+sleep 15
+
+debug_msg "checking topic $topic_name created in SNS in region $AWS_REGION_OVERRIDE"
+if ! sns_topic_exists "$topic_arn_override_region" "$AWS_REGION_OVERRIDE"; then
+    echo "FAIL: expected $topic_name to have been created in SNS in region $AWS_REGION_OVERRIDE"
+    kubectl logs -n ack-system "$ack_ctrl_pod_id"
+    exit 1
+fi
+
+kubectl -n "$TESTING_NAMESPACE" delete "$resource_name" 2>/dev/null
+assert_equal "0" "$?" "Expected success from kubectl delete but got $?" || exit 1
+
+sleep 15
+
+if sns_topic_exists "$topic_arn_override_region" "$AWS_REGION_OVERRIDE"; then
+    echo "FAIL: expected $topic_name to be deleted in SNS in region $AWS_REGION_OVERRIDE"
+    exit 1
+fi
+
+kubectl delete namespace $TESTING_NAMESPACE 2>/dev/null
+assert_equal "0" "$?" "Expected success from kubectl delete namespace but got $?" || exit 1
+
+assert_pod_not_restarted $ack_ctrl_pod_id


### PR DESCRIPTION
Issue #81

Description of changes:
- Add AWS_REGION and AWS_PROFILE arguments to `sns_topic_exists`
- Add `sns/cross-region.sh` script to test cross region feature

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
