### PR TITLE
Add FieldPaths to ignore rules

### DIFF
--- a/pkg/generate/config/config.go
+++ b/pkg/generate/config/config.go
@@ -82,6 +82,12 @@ type IgnoreSpec struct {
 	// Set of shapes to ignore when constructing API type definitions and
 	// associated SDK code for structs that have these shapes as members
 	ShapeNames []string `json:"shape_names"`
+	// Set of field paths to ignore. The name here should be the original name of
+	// the field as it appears in AWS SDK objects. You can refer to a field by
+	// giving its "<shape_name>.<field_name>". For example,
+	// "ImageScanningConfiguration.ScanOnPush". For top level fields, you can
+	// leave the shape_name empty, like ".RepositoryName"
+	FieldPaths []string `json:"field_paths"`
 }
 
 // ResourceConfig represents instructions to the ACK code generator

--- a/pkg/generate/config/config.go
+++ b/pkg/generate/config/config.go
@@ -84,9 +84,7 @@ type IgnoreSpec struct {
 	ShapeNames []string `json:"shape_names"`
 	// Set of field paths to ignore. The name here should be the original name of
 	// the field as it appears in AWS SDK objects. You can refer to a field by
-	// giving its "<shape_name>.<field_name>". For example,
-	// "ImageScanningConfiguration.ScanOnPush". For top level fields, you can
-	// leave the shape_name empty, like ".RepositoryName"
+	// giving its "<shape_name>.<field_name>". For example, "CreateApiInput.Name".
 	FieldPaths []string `json:"field_paths"`
 }
 

--- a/pkg/generate/config/config.go
+++ b/pkg/generate/config/config.go
@@ -355,15 +355,6 @@ func (c *Config) SetAttributesSingleAttribute(resourceName string) bool {
 	return resGenConfig.UnpackAttributesMapConfig.SetAttributesSingleAttribute
 }
 
-// IsIgnoredShape returns true if the supplied shape name should be ignored by the
-// code generator, false otherwise
-func (c *Config) IsIgnoredShape(shapeName string) bool {
-	if c == nil || len(c.Ignore.ShapeNames) == 0 {
-		return false
-	}
-	return util.InStrings(shapeName, c.Ignore.ShapeNames)
-}
-
 // OverrideValues gives list of member values to override.
 func (c *Config) OverrideValues(operationName string) (map[string]string, bool) {
 	if c == nil {

--- a/pkg/generate/generator.go
+++ b/pkg/generate/generator.go
@@ -358,11 +358,26 @@ func (g *Generator) ApplyIgnoreRules() {
 		return
 	}
 	for _, name := range g.cfg.Ignore.ShapeNames {
-		delete(g.SDKAPI.API.Shapes, name)
+		for sdkShapeId, shape := range g.SDKAPI.API.Shapes {
+			if shape.ShapeName == name {
+				delete(g.SDKAPI.API.Shapes, sdkShapeId)
+				continue
+			}
+			for sdkMemberId, memberRef := range shape.MemberRefs {
+				if memberRef.ShapeName == name {
+					delete(shape.MemberRefs, sdkMemberId)
+				}
+			}
+		}
 	}
-	for _, shape := range g.SDKAPI.API.Shapes {
-		for _, name := range g.cfg.Ignore.ShapeNames {
-			delete(shape.MemberRefs, name)
+	for sdkShapeName, sdkShape := range g.SDKAPI.API.Shapes {
+		for _, fieldpath := range g.cfg.Ignore.FieldPaths {
+			shape := strings.Split(fieldpath, ".")[0]
+			field := strings.Split(fieldpath, ".")[1]
+			if sdkShapeName != shape {
+				continue
+			}
+			delete(sdkShape.MemberRefs, field)
 		}
 	}
 }

--- a/pkg/generate/rds_test.go
+++ b/pkg/generate/rds_test.go
@@ -403,51 +403,51 @@ func TestRDS_DBInstance(t *testing.T) {
 		ko.Status.DBParameterGroups = f14
 	}
 	if resp.DBInstance.DBSubnetGroup != nil {
-		f16 := &svcapitypes.DBSubnetGroup_SDK{}
+		f15 := &svcapitypes.DBSubnetGroup_SDK{}
 		if resp.DBInstance.DBSubnetGroup.DBSubnetGroupArn != nil {
-			f16.DBSubnetGroupARN = resp.DBInstance.DBSubnetGroup.DBSubnetGroupArn
+			f15.DBSubnetGroupARN = resp.DBInstance.DBSubnetGroup.DBSubnetGroupArn
 		}
 		if resp.DBInstance.DBSubnetGroup.DBSubnetGroupDescription != nil {
-			f16.DBSubnetGroupDescription = resp.DBInstance.DBSubnetGroup.DBSubnetGroupDescription
+			f15.DBSubnetGroupDescription = resp.DBInstance.DBSubnetGroup.DBSubnetGroupDescription
 		}
 		if resp.DBInstance.DBSubnetGroup.DBSubnetGroupName != nil {
-			f16.DBSubnetGroupName = resp.DBInstance.DBSubnetGroup.DBSubnetGroupName
+			f15.DBSubnetGroupName = resp.DBInstance.DBSubnetGroup.DBSubnetGroupName
 		}
 		if resp.DBInstance.DBSubnetGroup.SubnetGroupStatus != nil {
-			f16.SubnetGroupStatus = resp.DBInstance.DBSubnetGroup.SubnetGroupStatus
+			f15.SubnetGroupStatus = resp.DBInstance.DBSubnetGroup.SubnetGroupStatus
 		}
 		if resp.DBInstance.DBSubnetGroup.Subnets != nil {
-			f16f4 := []*svcapitypes.Subnet{}
-			for _, f16f4iter := range resp.DBInstance.DBSubnetGroup.Subnets {
-				f16f4elem := &svcapitypes.Subnet{}
-				if f16f4iter.SubnetAvailabilityZone != nil {
-					f16f4elemf0 := &svcapitypes.AvailabilityZone{}
-					if f16f4iter.SubnetAvailabilityZone.Name != nil {
-						f16f4elemf0.Name = f16f4iter.SubnetAvailabilityZone.Name
+			f15f4 := []*svcapitypes.Subnet{}
+			for _, f15f4iter := range resp.DBInstance.DBSubnetGroup.Subnets {
+				f15f4elem := &svcapitypes.Subnet{}
+				if f15f4iter.SubnetAvailabilityZone != nil {
+					f15f4elemf0 := &svcapitypes.AvailabilityZone{}
+					if f15f4iter.SubnetAvailabilityZone.Name != nil {
+						f15f4elemf0.Name = f15f4iter.SubnetAvailabilityZone.Name
 					}
-					f16f4elem.SubnetAvailabilityZone = f16f4elemf0
+					f15f4elem.SubnetAvailabilityZone = f15f4elemf0
 				}
-				if f16f4iter.SubnetIdentifier != nil {
-					f16f4elem.SubnetIdentifier = f16f4iter.SubnetIdentifier
+				if f15f4iter.SubnetIdentifier != nil {
+					f15f4elem.SubnetIdentifier = f15f4iter.SubnetIdentifier
 				}
-				if f16f4iter.SubnetOutpost != nil {
-					f16f4elemf2 := &svcapitypes.Outpost{}
-					if f16f4iter.SubnetOutpost.Arn != nil {
-						f16f4elemf2.ARN = f16f4iter.SubnetOutpost.Arn
+				if f15f4iter.SubnetOutpost != nil {
+					f15f4elemf2 := &svcapitypes.Outpost{}
+					if f15f4iter.SubnetOutpost.Arn != nil {
+						f15f4elemf2.ARN = f15f4iter.SubnetOutpost.Arn
 					}
-					f16f4elem.SubnetOutpost = f16f4elemf2
+					f15f4elem.SubnetOutpost = f15f4elemf2
 				}
-				if f16f4iter.SubnetStatus != nil {
-					f16f4elem.SubnetStatus = f16f4iter.SubnetStatus
+				if f15f4iter.SubnetStatus != nil {
+					f15f4elem.SubnetStatus = f15f4iter.SubnetStatus
 				}
-				f16f4 = append(f16f4, f16f4elem)
+				f15f4 = append(f15f4, f15f4elem)
 			}
-			f16.Subnets = f16f4
+			f15.Subnets = f15f4
 		}
 		if resp.DBInstance.DBSubnetGroup.VpcId != nil {
-			f16.VPCID = resp.DBInstance.DBSubnetGroup.VpcId
+			f15.VPCID = resp.DBInstance.DBSubnetGroup.VpcId
 		}
-		ko.Status.DBSubnetGroup = f16
+		ko.Status.DBSubnetGroup = f15
 	}
 	if resp.DBInstance.DbInstancePort != nil {
 		ko.Status.DBInstancePort = resp.DBInstance.DbInstancePort
@@ -456,46 +456,46 @@ func TestRDS_DBInstance(t *testing.T) {
 		ko.Status.DBIResourceID = resp.DBInstance.DbiResourceId
 	}
 	if resp.DBInstance.DomainMemberships != nil {
-		f20 := []*svcapitypes.DomainMembership{}
-		for _, f20iter := range resp.DBInstance.DomainMemberships {
-			f20elem := &svcapitypes.DomainMembership{}
-			if f20iter.Domain != nil {
-				f20elem.Domain = f20iter.Domain
+		f19 := []*svcapitypes.DomainMembership{}
+		for _, f19iter := range resp.DBInstance.DomainMemberships {
+			f19elem := &svcapitypes.DomainMembership{}
+			if f19iter.Domain != nil {
+				f19elem.Domain = f19iter.Domain
 			}
-			if f20iter.FQDN != nil {
-				f20elem.FQDN = f20iter.FQDN
+			if f19iter.FQDN != nil {
+				f19elem.FQDN = f19iter.FQDN
 			}
-			if f20iter.IAMRoleName != nil {
-				f20elem.IAMRoleName = f20iter.IAMRoleName
+			if f19iter.IAMRoleName != nil {
+				f19elem.IAMRoleName = f19iter.IAMRoleName
 			}
-			if f20iter.Status != nil {
-				f20elem.Status = f20iter.Status
+			if f19iter.Status != nil {
+				f19elem.Status = f19iter.Status
 			}
-			f20 = append(f20, f20elem)
+			f19 = append(f19, f19elem)
 		}
-		ko.Status.DomainMemberships = f20
+		ko.Status.DomainMemberships = f19
 	}
 	if resp.DBInstance.EnabledCloudwatchLogsExports != nil {
-		f21 := []*string{}
-		for _, f21iter := range resp.DBInstance.EnabledCloudwatchLogsExports {
-			var f21elem string
-			f21elem = *f21iter
-			f21 = append(f21, &f21elem)
+		f20 := []*string{}
+		for _, f20iter := range resp.DBInstance.EnabledCloudwatchLogsExports {
+			var f20elem string
+			f20elem = *f20iter
+			f20 = append(f20, &f20elem)
 		}
-		ko.Status.EnabledCloudwatchLogsExports = f21
+		ko.Status.EnabledCloudwatchLogsExports = f20
 	}
 	if resp.DBInstance.Endpoint != nil {
-		f22 := &svcapitypes.Endpoint{}
+		f21 := &svcapitypes.Endpoint{}
 		if resp.DBInstance.Endpoint.Address != nil {
-			f22.Address = resp.DBInstance.Endpoint.Address
+			f21.Address = resp.DBInstance.Endpoint.Address
 		}
 		if resp.DBInstance.Endpoint.HostedZoneId != nil {
-			f22.HostedZoneID = resp.DBInstance.Endpoint.HostedZoneId
+			f21.HostedZoneID = resp.DBInstance.Endpoint.HostedZoneId
 		}
 		if resp.DBInstance.Endpoint.Port != nil {
-			f22.Port = resp.DBInstance.Endpoint.Port
+			f21.Port = resp.DBInstance.Endpoint.Port
 		}
-		ko.Status.Endpoint = f22
+		ko.Status.Endpoint = f21
 	}
 	if resp.DBInstance.EnhancedMonitoringResourceArn != nil {
 		ko.Status.EnhancedMonitoringResourceARN = resp.DBInstance.EnhancedMonitoringResourceArn
@@ -510,131 +510,131 @@ func TestRDS_DBInstance(t *testing.T) {
 		ko.Status.LatestRestorableTime = &metav1.Time{*resp.DBInstance.LatestRestorableTime}
 	}
 	if resp.DBInstance.ListenerEndpoint != nil {
-		f32 := &svcapitypes.Endpoint{}
+		f31 := &svcapitypes.Endpoint{}
 		if resp.DBInstance.ListenerEndpoint.Address != nil {
-			f32.Address = resp.DBInstance.ListenerEndpoint.Address
+			f31.Address = resp.DBInstance.ListenerEndpoint.Address
 		}
 		if resp.DBInstance.ListenerEndpoint.HostedZoneId != nil {
-			f32.HostedZoneID = resp.DBInstance.ListenerEndpoint.HostedZoneId
+			f31.HostedZoneID = resp.DBInstance.ListenerEndpoint.HostedZoneId
 		}
 		if resp.DBInstance.ListenerEndpoint.Port != nil {
-			f32.Port = resp.DBInstance.ListenerEndpoint.Port
+			f31.Port = resp.DBInstance.ListenerEndpoint.Port
 		}
-		ko.Status.ListenerEndpoint = f32
+		ko.Status.ListenerEndpoint = f31
 	}
 	if resp.DBInstance.OptionGroupMemberships != nil {
-		f38 := []*svcapitypes.OptionGroupMembership{}
-		for _, f38iter := range resp.DBInstance.OptionGroupMemberships {
-			f38elem := &svcapitypes.OptionGroupMembership{}
-			if f38iter.OptionGroupName != nil {
-				f38elem.OptionGroupName = f38iter.OptionGroupName
+		f37 := []*svcapitypes.OptionGroupMembership{}
+		for _, f37iter := range resp.DBInstance.OptionGroupMemberships {
+			f37elem := &svcapitypes.OptionGroupMembership{}
+			if f37iter.OptionGroupName != nil {
+				f37elem.OptionGroupName = f37iter.OptionGroupName
 			}
-			if f38iter.Status != nil {
-				f38elem.Status = f38iter.Status
+			if f37iter.Status != nil {
+				f37elem.Status = f37iter.Status
 			}
-			f38 = append(f38, f38elem)
+			f37 = append(f37, f37elem)
 		}
-		ko.Status.OptionGroupMemberships = f38
+		ko.Status.OptionGroupMemberships = f37
 	}
 	if resp.DBInstance.PendingModifiedValues != nil {
-		f39 := &svcapitypes.PendingModifiedValues{}
+		f38 := &svcapitypes.PendingModifiedValues{}
 		if resp.DBInstance.PendingModifiedValues.AllocatedStorage != nil {
-			f39.AllocatedStorage = resp.DBInstance.PendingModifiedValues.AllocatedStorage
+			f38.AllocatedStorage = resp.DBInstance.PendingModifiedValues.AllocatedStorage
 		}
 		if resp.DBInstance.PendingModifiedValues.BackupRetentionPeriod != nil {
-			f39.BackupRetentionPeriod = resp.DBInstance.PendingModifiedValues.BackupRetentionPeriod
+			f38.BackupRetentionPeriod = resp.DBInstance.PendingModifiedValues.BackupRetentionPeriod
 		}
 		if resp.DBInstance.PendingModifiedValues.CACertificateIdentifier != nil {
-			f39.CACertificateIdentifier = resp.DBInstance.PendingModifiedValues.CACertificateIdentifier
+			f38.CACertificateIdentifier = resp.DBInstance.PendingModifiedValues.CACertificateIdentifier
 		}
 		if resp.DBInstance.PendingModifiedValues.DBInstanceClass != nil {
-			f39.DBInstanceClass = resp.DBInstance.PendingModifiedValues.DBInstanceClass
+			f38.DBInstanceClass = resp.DBInstance.PendingModifiedValues.DBInstanceClass
 		}
 		if resp.DBInstance.PendingModifiedValues.DBInstanceIdentifier != nil {
-			f39.DBInstanceIdentifier = resp.DBInstance.PendingModifiedValues.DBInstanceIdentifier
+			f38.DBInstanceIdentifier = resp.DBInstance.PendingModifiedValues.DBInstanceIdentifier
 		}
 		if resp.DBInstance.PendingModifiedValues.DBSubnetGroupName != nil {
-			f39.DBSubnetGroupName = resp.DBInstance.PendingModifiedValues.DBSubnetGroupName
+			f38.DBSubnetGroupName = resp.DBInstance.PendingModifiedValues.DBSubnetGroupName
 		}
 		if resp.DBInstance.PendingModifiedValues.EngineVersion != nil {
-			f39.EngineVersion = resp.DBInstance.PendingModifiedValues.EngineVersion
+			f38.EngineVersion = resp.DBInstance.PendingModifiedValues.EngineVersion
 		}
 		if resp.DBInstance.PendingModifiedValues.Iops != nil {
-			f39.IOPS = resp.DBInstance.PendingModifiedValues.Iops
+			f38.IOPS = resp.DBInstance.PendingModifiedValues.Iops
 		}
 		if resp.DBInstance.PendingModifiedValues.LicenseModel != nil {
-			f39.LicenseModel = resp.DBInstance.PendingModifiedValues.LicenseModel
+			f38.LicenseModel = resp.DBInstance.PendingModifiedValues.LicenseModel
 		}
 		if resp.DBInstance.PendingModifiedValues.MasterUserPassword != nil {
-			f39.MasterUserPassword = resp.DBInstance.PendingModifiedValues.MasterUserPassword
+			f38.MasterUserPassword = resp.DBInstance.PendingModifiedValues.MasterUserPassword
 		}
 		if resp.DBInstance.PendingModifiedValues.MultiAZ != nil {
-			f39.MultiAZ = resp.DBInstance.PendingModifiedValues.MultiAZ
+			f38.MultiAZ = resp.DBInstance.PendingModifiedValues.MultiAZ
 		}
 		if resp.DBInstance.PendingModifiedValues.PendingCloudwatchLogsExports != nil {
-			f39f11 := &svcapitypes.PendingCloudwatchLogsExports{}
+			f38f11 := &svcapitypes.PendingCloudwatchLogsExports{}
 			if resp.DBInstance.PendingModifiedValues.PendingCloudwatchLogsExports.LogTypesToDisable != nil {
-				f39f11f0 := []*string{}
-				for _, f39f11f0iter := range resp.DBInstance.PendingModifiedValues.PendingCloudwatchLogsExports.LogTypesToDisable {
-					var f39f11f0elem string
-					f39f11f0elem = *f39f11f0iter
-					f39f11f0 = append(f39f11f0, &f39f11f0elem)
+				f38f11f0 := []*string{}
+				for _, f38f11f0iter := range resp.DBInstance.PendingModifiedValues.PendingCloudwatchLogsExports.LogTypesToDisable {
+					var f38f11f0elem string
+					f38f11f0elem = *f38f11f0iter
+					f38f11f0 = append(f38f11f0, &f38f11f0elem)
 				}
-				f39f11.LogTypesToDisable = f39f11f0
+				f38f11.LogTypesToDisable = f38f11f0
 			}
 			if resp.DBInstance.PendingModifiedValues.PendingCloudwatchLogsExports.LogTypesToEnable != nil {
-				f39f11f1 := []*string{}
-				for _, f39f11f1iter := range resp.DBInstance.PendingModifiedValues.PendingCloudwatchLogsExports.LogTypesToEnable {
-					var f39f11f1elem string
-					f39f11f1elem = *f39f11f1iter
-					f39f11f1 = append(f39f11f1, &f39f11f1elem)
+				f38f11f1 := []*string{}
+				for _, f38f11f1iter := range resp.DBInstance.PendingModifiedValues.PendingCloudwatchLogsExports.LogTypesToEnable {
+					var f38f11f1elem string
+					f38f11f1elem = *f38f11f1iter
+					f38f11f1 = append(f38f11f1, &f38f11f1elem)
 				}
-				f39f11.LogTypesToEnable = f39f11f1
+				f38f11.LogTypesToEnable = f38f11f1
 			}
-			f39.PendingCloudwatchLogsExports = f39f11
+			f38.PendingCloudwatchLogsExports = f38f11
 		}
 		if resp.DBInstance.PendingModifiedValues.Port != nil {
-			f39.Port = resp.DBInstance.PendingModifiedValues.Port
+			f38.Port = resp.DBInstance.PendingModifiedValues.Port
 		}
 		if resp.DBInstance.PendingModifiedValues.ProcessorFeatures != nil {
-			f39f13 := []*svcapitypes.ProcessorFeature{}
-			for _, f39f13iter := range resp.DBInstance.PendingModifiedValues.ProcessorFeatures {
-				f39f13elem := &svcapitypes.ProcessorFeature{}
-				if f39f13iter.Name != nil {
-					f39f13elem.Name = f39f13iter.Name
+			f38f13 := []*svcapitypes.ProcessorFeature{}
+			for _, f38f13iter := range resp.DBInstance.PendingModifiedValues.ProcessorFeatures {
+				f38f13elem := &svcapitypes.ProcessorFeature{}
+				if f38f13iter.Name != nil {
+					f38f13elem.Name = f38f13iter.Name
 				}
-				if f39f13iter.Value != nil {
-					f39f13elem.Value = f39f13iter.Value
+				if f38f13iter.Value != nil {
+					f38f13elem.Value = f38f13iter.Value
 				}
-				f39f13 = append(f39f13, f39f13elem)
+				f38f13 = append(f38f13, f38f13elem)
 			}
-			f39.ProcessorFeatures = f39f13
+			f38.ProcessorFeatures = f38f13
 		}
 		if resp.DBInstance.PendingModifiedValues.StorageType != nil {
-			f39.StorageType = resp.DBInstance.PendingModifiedValues.StorageType
+			f38.StorageType = resp.DBInstance.PendingModifiedValues.StorageType
 		}
-		ko.Status.PendingModifiedValues = f39
+		ko.Status.PendingModifiedValues = f38
 	}
 	if resp.DBInstance.PerformanceInsightsEnabled != nil {
 		ko.Status.PerformanceInsightsEnabled = resp.DBInstance.PerformanceInsightsEnabled
 	}
 	if resp.DBInstance.ReadReplicaDBClusterIdentifiers != nil {
+		f47 := []*string{}
+		for _, f47iter := range resp.DBInstance.ReadReplicaDBClusterIdentifiers {
+			var f47elem string
+			f47elem = *f47iter
+			f47 = append(f47, &f47elem)
+		}
+		ko.Status.ReadReplicaDBClusterIdentifiers = f47
+	}
+	if resp.DBInstance.ReadReplicaDBInstanceIdentifiers != nil {
 		f48 := []*string{}
-		for _, f48iter := range resp.DBInstance.ReadReplicaDBClusterIdentifiers {
+		for _, f48iter := range resp.DBInstance.ReadReplicaDBInstanceIdentifiers {
 			var f48elem string
 			f48elem = *f48iter
 			f48 = append(f48, &f48elem)
 		}
-		ko.Status.ReadReplicaDBClusterIdentifiers = f48
-	}
-	if resp.DBInstance.ReadReplicaDBInstanceIdentifiers != nil {
-		f49 := []*string{}
-		for _, f49iter := range resp.DBInstance.ReadReplicaDBInstanceIdentifiers {
-			var f49elem string
-			f49elem = *f49iter
-			f49 = append(f49, &f49elem)
-		}
-		ko.Status.ReadReplicaDBInstanceIdentifiers = f49
+		ko.Status.ReadReplicaDBInstanceIdentifiers = f48
 	}
 	if resp.DBInstance.ReadReplicaSourceDBInstanceIdentifier != nil {
 		ko.Status.ReadReplicaSourceDBInstanceIdentifier = resp.DBInstance.ReadReplicaSourceDBInstanceIdentifier
@@ -643,38 +643,38 @@ func TestRDS_DBInstance(t *testing.T) {
 		ko.Status.SecondaryAvailabilityZone = resp.DBInstance.SecondaryAvailabilityZone
 	}
 	if resp.DBInstance.StatusInfos != nil {
-		f52 := []*svcapitypes.DBInstanceStatusInfo{}
-		for _, f52iter := range resp.DBInstance.StatusInfos {
-			f52elem := &svcapitypes.DBInstanceStatusInfo{}
-			if f52iter.Message != nil {
-				f52elem.Message = f52iter.Message
+		f51 := []*svcapitypes.DBInstanceStatusInfo{}
+		for _, f51iter := range resp.DBInstance.StatusInfos {
+			f51elem := &svcapitypes.DBInstanceStatusInfo{}
+			if f51iter.Message != nil {
+				f51elem.Message = f51iter.Message
 			}
-			if f52iter.Normal != nil {
-				f52elem.Normal = f52iter.Normal
+			if f51iter.Normal != nil {
+				f51elem.Normal = f51iter.Normal
 			}
-			if f52iter.Status != nil {
-				f52elem.Status = f52iter.Status
+			if f51iter.Status != nil {
+				f51elem.Status = f51iter.Status
 			}
-			if f52iter.StatusType != nil {
-				f52elem.StatusType = f52iter.StatusType
+			if f51iter.StatusType != nil {
+				f51elem.StatusType = f51iter.StatusType
 			}
-			f52 = append(f52, f52elem)
+			f51 = append(f51, f51elem)
 		}
-		ko.Status.StatusInfos = f52
+		ko.Status.StatusInfos = f51
 	}
 	if resp.DBInstance.VpcSecurityGroups != nil {
-		f57 := []*svcapitypes.VPCSecurityGroupMembership{}
-		for _, f57iter := range resp.DBInstance.VpcSecurityGroups {
-			f57elem := &svcapitypes.VPCSecurityGroupMembership{}
-			if f57iter.Status != nil {
-				f57elem.Status = f57iter.Status
+		f56 := []*svcapitypes.VPCSecurityGroupMembership{}
+		for _, f56iter := range resp.DBInstance.VpcSecurityGroups {
+			f56elem := &svcapitypes.VPCSecurityGroupMembership{}
+			if f56iter.Status != nil {
+				f56elem.Status = f56iter.Status
 			}
-			if f57iter.VpcSecurityGroupId != nil {
-				f57elem.VPCSecurityGroupID = f57iter.VpcSecurityGroupId
+			if f56iter.VpcSecurityGroupId != nil {
+				f56elem.VPCSecurityGroupID = f56iter.VpcSecurityGroupId
 			}
-			f57 = append(f57, f57elem)
+			f56 = append(f56, f56elem)
 		}
-		ko.Status.VPCSecurityGroups = f57
+		ko.Status.VPCSecurityGroups = f56
 	}
 `
 	assert.Equal(expCreateOutput, crd.GoCodeSetOutput(model.OpTypeCreate, "resp", "ko", 1, false))
@@ -760,51 +760,51 @@ func TestRDS_DBInstance(t *testing.T) {
 			ko.Status.DBParameterGroups = f14
 		}
 		if elem.DBSubnetGroup != nil {
-			f16 := &svcapitypes.DBSubnetGroup_SDK{}
+			f15 := &svcapitypes.DBSubnetGroup_SDK{}
 			if elem.DBSubnetGroup.DBSubnetGroupArn != nil {
-				f16.DBSubnetGroupARN = elem.DBSubnetGroup.DBSubnetGroupArn
+				f15.DBSubnetGroupARN = elem.DBSubnetGroup.DBSubnetGroupArn
 			}
 			if elem.DBSubnetGroup.DBSubnetGroupDescription != nil {
-				f16.DBSubnetGroupDescription = elem.DBSubnetGroup.DBSubnetGroupDescription
+				f15.DBSubnetGroupDescription = elem.DBSubnetGroup.DBSubnetGroupDescription
 			}
 			if elem.DBSubnetGroup.DBSubnetGroupName != nil {
-				f16.DBSubnetGroupName = elem.DBSubnetGroup.DBSubnetGroupName
+				f15.DBSubnetGroupName = elem.DBSubnetGroup.DBSubnetGroupName
 			}
 			if elem.DBSubnetGroup.SubnetGroupStatus != nil {
-				f16.SubnetGroupStatus = elem.DBSubnetGroup.SubnetGroupStatus
+				f15.SubnetGroupStatus = elem.DBSubnetGroup.SubnetGroupStatus
 			}
 			if elem.DBSubnetGroup.Subnets != nil {
-				f16f4 := []*svcapitypes.Subnet{}
-				for _, f16f4iter := range elem.DBSubnetGroup.Subnets {
-					f16f4elem := &svcapitypes.Subnet{}
-					if f16f4iter.SubnetAvailabilityZone != nil {
-						f16f4elemf0 := &svcapitypes.AvailabilityZone{}
-						if f16f4iter.SubnetAvailabilityZone.Name != nil {
-							f16f4elemf0.Name = f16f4iter.SubnetAvailabilityZone.Name
+				f15f4 := []*svcapitypes.Subnet{}
+				for _, f15f4iter := range elem.DBSubnetGroup.Subnets {
+					f15f4elem := &svcapitypes.Subnet{}
+					if f15f4iter.SubnetAvailabilityZone != nil {
+						f15f4elemf0 := &svcapitypes.AvailabilityZone{}
+						if f15f4iter.SubnetAvailabilityZone.Name != nil {
+							f15f4elemf0.Name = f15f4iter.SubnetAvailabilityZone.Name
 						}
-						f16f4elem.SubnetAvailabilityZone = f16f4elemf0
+						f15f4elem.SubnetAvailabilityZone = f15f4elemf0
 					}
-					if f16f4iter.SubnetIdentifier != nil {
-						f16f4elem.SubnetIdentifier = f16f4iter.SubnetIdentifier
+					if f15f4iter.SubnetIdentifier != nil {
+						f15f4elem.SubnetIdentifier = f15f4iter.SubnetIdentifier
 					}
-					if f16f4iter.SubnetOutpost != nil {
-						f16f4elemf2 := &svcapitypes.Outpost{}
-						if f16f4iter.SubnetOutpost.Arn != nil {
-							f16f4elemf2.ARN = f16f4iter.SubnetOutpost.Arn
+					if f15f4iter.SubnetOutpost != nil {
+						f15f4elemf2 := &svcapitypes.Outpost{}
+						if f15f4iter.SubnetOutpost.Arn != nil {
+							f15f4elemf2.ARN = f15f4iter.SubnetOutpost.Arn
 						}
-						f16f4elem.SubnetOutpost = f16f4elemf2
+						f15f4elem.SubnetOutpost = f15f4elemf2
 					}
-					if f16f4iter.SubnetStatus != nil {
-						f16f4elem.SubnetStatus = f16f4iter.SubnetStatus
+					if f15f4iter.SubnetStatus != nil {
+						f15f4elem.SubnetStatus = f15f4iter.SubnetStatus
 					}
-					f16f4 = append(f16f4, f16f4elem)
+					f15f4 = append(f15f4, f15f4elem)
 				}
-				f16.Subnets = f16f4
+				f15.Subnets = f15f4
 			}
 			if elem.DBSubnetGroup.VpcId != nil {
-				f16.VPCID = elem.DBSubnetGroup.VpcId
+				f15.VPCID = elem.DBSubnetGroup.VpcId
 			}
-			ko.Status.DBSubnetGroup = f16
+			ko.Status.DBSubnetGroup = f15
 		}
 		if elem.DbInstancePort != nil {
 			ko.Status.DBInstancePort = elem.DbInstancePort
@@ -816,46 +816,46 @@ func TestRDS_DBInstance(t *testing.T) {
 			ko.Spec.DeletionProtection = elem.DeletionProtection
 		}
 		if elem.DomainMemberships != nil {
-			f20 := []*svcapitypes.DomainMembership{}
-			for _, f20iter := range elem.DomainMemberships {
-				f20elem := &svcapitypes.DomainMembership{}
-				if f20iter.Domain != nil {
-					f20elem.Domain = f20iter.Domain
+			f19 := []*svcapitypes.DomainMembership{}
+			for _, f19iter := range elem.DomainMemberships {
+				f19elem := &svcapitypes.DomainMembership{}
+				if f19iter.Domain != nil {
+					f19elem.Domain = f19iter.Domain
 				}
-				if f20iter.FQDN != nil {
-					f20elem.FQDN = f20iter.FQDN
+				if f19iter.FQDN != nil {
+					f19elem.FQDN = f19iter.FQDN
 				}
-				if f20iter.IAMRoleName != nil {
-					f20elem.IAMRoleName = f20iter.IAMRoleName
+				if f19iter.IAMRoleName != nil {
+					f19elem.IAMRoleName = f19iter.IAMRoleName
 				}
-				if f20iter.Status != nil {
-					f20elem.Status = f20iter.Status
+				if f19iter.Status != nil {
+					f19elem.Status = f19iter.Status
 				}
-				f20 = append(f20, f20elem)
+				f19 = append(f19, f19elem)
 			}
-			ko.Status.DomainMemberships = f20
+			ko.Status.DomainMemberships = f19
 		}
 		if elem.EnabledCloudwatchLogsExports != nil {
-			f21 := []*string{}
-			for _, f21iter := range elem.EnabledCloudwatchLogsExports {
-				var f21elem string
-				f21elem = *f21iter
-				f21 = append(f21, &f21elem)
+			f20 := []*string{}
+			for _, f20iter := range elem.EnabledCloudwatchLogsExports {
+				var f20elem string
+				f20elem = *f20iter
+				f20 = append(f20, &f20elem)
 			}
-			ko.Status.EnabledCloudwatchLogsExports = f21
+			ko.Status.EnabledCloudwatchLogsExports = f20
 		}
 		if elem.Endpoint != nil {
-			f22 := &svcapitypes.Endpoint{}
+			f21 := &svcapitypes.Endpoint{}
 			if elem.Endpoint.Address != nil {
-				f22.Address = elem.Endpoint.Address
+				f21.Address = elem.Endpoint.Address
 			}
 			if elem.Endpoint.HostedZoneId != nil {
-				f22.HostedZoneID = elem.Endpoint.HostedZoneId
+				f21.HostedZoneID = elem.Endpoint.HostedZoneId
 			}
 			if elem.Endpoint.Port != nil {
-				f22.Port = elem.Endpoint.Port
+				f21.Port = elem.Endpoint.Port
 			}
-			ko.Status.Endpoint = f22
+			ko.Status.Endpoint = f21
 		}
 		if elem.Engine != nil {
 			ko.Spec.Engine = elem.Engine
@@ -885,17 +885,17 @@ func TestRDS_DBInstance(t *testing.T) {
 			ko.Spec.LicenseModel = elem.LicenseModel
 		}
 		if elem.ListenerEndpoint != nil {
-			f32 := &svcapitypes.Endpoint{}
+			f31 := &svcapitypes.Endpoint{}
 			if elem.ListenerEndpoint.Address != nil {
-				f32.Address = elem.ListenerEndpoint.Address
+				f31.Address = elem.ListenerEndpoint.Address
 			}
 			if elem.ListenerEndpoint.HostedZoneId != nil {
-				f32.HostedZoneID = elem.ListenerEndpoint.HostedZoneId
+				f31.HostedZoneID = elem.ListenerEndpoint.HostedZoneId
 			}
 			if elem.ListenerEndpoint.Port != nil {
-				f32.Port = elem.ListenerEndpoint.Port
+				f31.Port = elem.ListenerEndpoint.Port
 			}
-			ko.Status.ListenerEndpoint = f32
+			ko.Status.ListenerEndpoint = f31
 		}
 		if elem.MasterUsername != nil {
 			ko.Spec.MasterUsername = elem.MasterUsername
@@ -913,97 +913,97 @@ func TestRDS_DBInstance(t *testing.T) {
 			ko.Spec.MultiAZ = elem.MultiAZ
 		}
 		if elem.OptionGroupMemberships != nil {
-			f38 := []*svcapitypes.OptionGroupMembership{}
-			for _, f38iter := range elem.OptionGroupMemberships {
-				f38elem := &svcapitypes.OptionGroupMembership{}
-				if f38iter.OptionGroupName != nil {
-					f38elem.OptionGroupName = f38iter.OptionGroupName
+			f37 := []*svcapitypes.OptionGroupMembership{}
+			for _, f37iter := range elem.OptionGroupMemberships {
+				f37elem := &svcapitypes.OptionGroupMembership{}
+				if f37iter.OptionGroupName != nil {
+					f37elem.OptionGroupName = f37iter.OptionGroupName
 				}
-				if f38iter.Status != nil {
-					f38elem.Status = f38iter.Status
+				if f37iter.Status != nil {
+					f37elem.Status = f37iter.Status
 				}
-				f38 = append(f38, f38elem)
+				f37 = append(f37, f37elem)
 			}
-			ko.Status.OptionGroupMemberships = f38
+			ko.Status.OptionGroupMemberships = f37
 		}
 		if elem.PendingModifiedValues != nil {
-			f39 := &svcapitypes.PendingModifiedValues{}
+			f38 := &svcapitypes.PendingModifiedValues{}
 			if elem.PendingModifiedValues.AllocatedStorage != nil {
-				f39.AllocatedStorage = elem.PendingModifiedValues.AllocatedStorage
+				f38.AllocatedStorage = elem.PendingModifiedValues.AllocatedStorage
 			}
 			if elem.PendingModifiedValues.BackupRetentionPeriod != nil {
-				f39.BackupRetentionPeriod = elem.PendingModifiedValues.BackupRetentionPeriod
+				f38.BackupRetentionPeriod = elem.PendingModifiedValues.BackupRetentionPeriod
 			}
 			if elem.PendingModifiedValues.CACertificateIdentifier != nil {
-				f39.CACertificateIdentifier = elem.PendingModifiedValues.CACertificateIdentifier
+				f38.CACertificateIdentifier = elem.PendingModifiedValues.CACertificateIdentifier
 			}
 			if elem.PendingModifiedValues.DBInstanceClass != nil {
-				f39.DBInstanceClass = elem.PendingModifiedValues.DBInstanceClass
+				f38.DBInstanceClass = elem.PendingModifiedValues.DBInstanceClass
 			}
 			if elem.PendingModifiedValues.DBInstanceIdentifier != nil {
-				f39.DBInstanceIdentifier = elem.PendingModifiedValues.DBInstanceIdentifier
+				f38.DBInstanceIdentifier = elem.PendingModifiedValues.DBInstanceIdentifier
 			}
 			if elem.PendingModifiedValues.DBSubnetGroupName != nil {
-				f39.DBSubnetGroupName = elem.PendingModifiedValues.DBSubnetGroupName
+				f38.DBSubnetGroupName = elem.PendingModifiedValues.DBSubnetGroupName
 			}
 			if elem.PendingModifiedValues.EngineVersion != nil {
-				f39.EngineVersion = elem.PendingModifiedValues.EngineVersion
+				f38.EngineVersion = elem.PendingModifiedValues.EngineVersion
 			}
 			if elem.PendingModifiedValues.Iops != nil {
-				f39.IOPS = elem.PendingModifiedValues.Iops
+				f38.IOPS = elem.PendingModifiedValues.Iops
 			}
 			if elem.PendingModifiedValues.LicenseModel != nil {
-				f39.LicenseModel = elem.PendingModifiedValues.LicenseModel
+				f38.LicenseModel = elem.PendingModifiedValues.LicenseModel
 			}
 			if elem.PendingModifiedValues.MasterUserPassword != nil {
-				f39.MasterUserPassword = elem.PendingModifiedValues.MasterUserPassword
+				f38.MasterUserPassword = elem.PendingModifiedValues.MasterUserPassword
 			}
 			if elem.PendingModifiedValues.MultiAZ != nil {
-				f39.MultiAZ = elem.PendingModifiedValues.MultiAZ
+				f38.MultiAZ = elem.PendingModifiedValues.MultiAZ
 			}
 			if elem.PendingModifiedValues.PendingCloudwatchLogsExports != nil {
-				f39f11 := &svcapitypes.PendingCloudwatchLogsExports{}
+				f38f11 := &svcapitypes.PendingCloudwatchLogsExports{}
 				if elem.PendingModifiedValues.PendingCloudwatchLogsExports.LogTypesToDisable != nil {
-					f39f11f0 := []*string{}
-					for _, f39f11f0iter := range elem.PendingModifiedValues.PendingCloudwatchLogsExports.LogTypesToDisable {
-						var f39f11f0elem string
-						f39f11f0elem = *f39f11f0iter
-						f39f11f0 = append(f39f11f0, &f39f11f0elem)
+					f38f11f0 := []*string{}
+					for _, f38f11f0iter := range elem.PendingModifiedValues.PendingCloudwatchLogsExports.LogTypesToDisable {
+						var f38f11f0elem string
+						f38f11f0elem = *f38f11f0iter
+						f38f11f0 = append(f38f11f0, &f38f11f0elem)
 					}
-					f39f11.LogTypesToDisable = f39f11f0
+					f38f11.LogTypesToDisable = f38f11f0
 				}
 				if elem.PendingModifiedValues.PendingCloudwatchLogsExports.LogTypesToEnable != nil {
-					f39f11f1 := []*string{}
-					for _, f39f11f1iter := range elem.PendingModifiedValues.PendingCloudwatchLogsExports.LogTypesToEnable {
-						var f39f11f1elem string
-						f39f11f1elem = *f39f11f1iter
-						f39f11f1 = append(f39f11f1, &f39f11f1elem)
+					f38f11f1 := []*string{}
+					for _, f38f11f1iter := range elem.PendingModifiedValues.PendingCloudwatchLogsExports.LogTypesToEnable {
+						var f38f11f1elem string
+						f38f11f1elem = *f38f11f1iter
+						f38f11f1 = append(f38f11f1, &f38f11f1elem)
 					}
-					f39f11.LogTypesToEnable = f39f11f1
+					f38f11.LogTypesToEnable = f38f11f1
 				}
-				f39.PendingCloudwatchLogsExports = f39f11
+				f38.PendingCloudwatchLogsExports = f38f11
 			}
 			if elem.PendingModifiedValues.Port != nil {
-				f39.Port = elem.PendingModifiedValues.Port
+				f38.Port = elem.PendingModifiedValues.Port
 			}
 			if elem.PendingModifiedValues.ProcessorFeatures != nil {
-				f39f13 := []*svcapitypes.ProcessorFeature{}
-				for _, f39f13iter := range elem.PendingModifiedValues.ProcessorFeatures {
-					f39f13elem := &svcapitypes.ProcessorFeature{}
-					if f39f13iter.Name != nil {
-						f39f13elem.Name = f39f13iter.Name
+				f38f13 := []*svcapitypes.ProcessorFeature{}
+				for _, f38f13iter := range elem.PendingModifiedValues.ProcessorFeatures {
+					f38f13elem := &svcapitypes.ProcessorFeature{}
+					if f38f13iter.Name != nil {
+						f38f13elem.Name = f38f13iter.Name
 					}
-					if f39f13iter.Value != nil {
-						f39f13elem.Value = f39f13iter.Value
+					if f38f13iter.Value != nil {
+						f38f13elem.Value = f38f13iter.Value
 					}
-					f39f13 = append(f39f13, f39f13elem)
+					f38f13 = append(f38f13, f38f13elem)
 				}
-				f39.ProcessorFeatures = f39f13
+				f38.ProcessorFeatures = f38f13
 			}
 			if elem.PendingModifiedValues.StorageType != nil {
-				f39.StorageType = elem.PendingModifiedValues.StorageType
+				f38.StorageType = elem.PendingModifiedValues.StorageType
 			}
-			ko.Status.PendingModifiedValues = f39
+			ko.Status.PendingModifiedValues = f38
 		}
 		if elem.PerformanceInsightsEnabled != nil {
 			ko.Status.PerformanceInsightsEnabled = elem.PerformanceInsightsEnabled
@@ -1021,18 +1021,18 @@ func TestRDS_DBInstance(t *testing.T) {
 			ko.Spec.PreferredMaintenanceWindow = elem.PreferredMaintenanceWindow
 		}
 		if elem.ProcessorFeatures != nil {
-			f45 := []*svcapitypes.ProcessorFeature{}
-			for _, f45iter := range elem.ProcessorFeatures {
-				f45elem := &svcapitypes.ProcessorFeature{}
-				if f45iter.Name != nil {
-					f45elem.Name = f45iter.Name
+			f44 := []*svcapitypes.ProcessorFeature{}
+			for _, f44iter := range elem.ProcessorFeatures {
+				f44elem := &svcapitypes.ProcessorFeature{}
+				if f44iter.Name != nil {
+					f44elem.Name = f44iter.Name
 				}
-				if f45iter.Value != nil {
-					f45elem.Value = f45iter.Value
+				if f44iter.Value != nil {
+					f44elem.Value = f44iter.Value
 				}
-				f45 = append(f45, f45elem)
+				f44 = append(f44, f44elem)
 			}
-			ko.Spec.ProcessorFeatures = f45
+			ko.Spec.ProcessorFeatures = f44
 		}
 		if elem.PromotionTier != nil {
 			ko.Spec.PromotionTier = elem.PromotionTier
@@ -1041,22 +1041,22 @@ func TestRDS_DBInstance(t *testing.T) {
 			ko.Spec.PubliclyAccessible = elem.PubliclyAccessible
 		}
 		if elem.ReadReplicaDBClusterIdentifiers != nil {
+			f47 := []*string{}
+			for _, f47iter := range elem.ReadReplicaDBClusterIdentifiers {
+				var f47elem string
+				f47elem = *f47iter
+				f47 = append(f47, &f47elem)
+			}
+			ko.Status.ReadReplicaDBClusterIdentifiers = f47
+		}
+		if elem.ReadReplicaDBInstanceIdentifiers != nil {
 			f48 := []*string{}
-			for _, f48iter := range elem.ReadReplicaDBClusterIdentifiers {
+			for _, f48iter := range elem.ReadReplicaDBInstanceIdentifiers {
 				var f48elem string
 				f48elem = *f48iter
 				f48 = append(f48, &f48elem)
 			}
-			ko.Status.ReadReplicaDBClusterIdentifiers = f48
-		}
-		if elem.ReadReplicaDBInstanceIdentifiers != nil {
-			f49 := []*string{}
-			for _, f49iter := range elem.ReadReplicaDBInstanceIdentifiers {
-				var f49elem string
-				f49elem = *f49iter
-				f49 = append(f49, &f49elem)
-			}
-			ko.Status.ReadReplicaDBInstanceIdentifiers = f49
+			ko.Status.ReadReplicaDBInstanceIdentifiers = f48
 		}
 		if elem.ReadReplicaSourceDBInstanceIdentifier != nil {
 			ko.Status.ReadReplicaSourceDBInstanceIdentifier = elem.ReadReplicaSourceDBInstanceIdentifier
@@ -1065,24 +1065,24 @@ func TestRDS_DBInstance(t *testing.T) {
 			ko.Status.SecondaryAvailabilityZone = elem.SecondaryAvailabilityZone
 		}
 		if elem.StatusInfos != nil {
-			f52 := []*svcapitypes.DBInstanceStatusInfo{}
-			for _, f52iter := range elem.StatusInfos {
-				f52elem := &svcapitypes.DBInstanceStatusInfo{}
-				if f52iter.Message != nil {
-					f52elem.Message = f52iter.Message
+			f51 := []*svcapitypes.DBInstanceStatusInfo{}
+			for _, f51iter := range elem.StatusInfos {
+				f51elem := &svcapitypes.DBInstanceStatusInfo{}
+				if f51iter.Message != nil {
+					f51elem.Message = f51iter.Message
 				}
-				if f52iter.Normal != nil {
-					f52elem.Normal = f52iter.Normal
+				if f51iter.Normal != nil {
+					f51elem.Normal = f51iter.Normal
 				}
-				if f52iter.Status != nil {
-					f52elem.Status = f52iter.Status
+				if f51iter.Status != nil {
+					f51elem.Status = f51iter.Status
 				}
-				if f52iter.StatusType != nil {
-					f52elem.StatusType = f52iter.StatusType
+				if f51iter.StatusType != nil {
+					f51elem.StatusType = f51iter.StatusType
 				}
-				f52 = append(f52, f52elem)
+				f51 = append(f51, f51elem)
 			}
-			ko.Status.StatusInfos = f52
+			ko.Status.StatusInfos = f51
 		}
 		if elem.StorageEncrypted != nil {
 			ko.Spec.StorageEncrypted = elem.StorageEncrypted
@@ -1097,18 +1097,18 @@ func TestRDS_DBInstance(t *testing.T) {
 			ko.Spec.Timezone = elem.Timezone
 		}
 		if elem.VpcSecurityGroups != nil {
-			f57 := []*svcapitypes.VPCSecurityGroupMembership{}
-			for _, f57iter := range elem.VpcSecurityGroups {
-				f57elem := &svcapitypes.VPCSecurityGroupMembership{}
-				if f57iter.Status != nil {
-					f57elem.Status = f57iter.Status
+			f56 := []*svcapitypes.VPCSecurityGroupMembership{}
+			for _, f56iter := range elem.VpcSecurityGroups {
+				f56elem := &svcapitypes.VPCSecurityGroupMembership{}
+				if f56iter.Status != nil {
+					f56elem.Status = f56iter.Status
 				}
-				if f57iter.VpcSecurityGroupId != nil {
-					f57elem.VPCSecurityGroupID = f57iter.VpcSecurityGroupId
+				if f56iter.VpcSecurityGroupId != nil {
+					f56elem.VPCSecurityGroupID = f56iter.VpcSecurityGroupId
 				}
-				f57 = append(f57, f57elem)
+				f56 = append(f56, f56elem)
 			}
-			ko.Status.VPCSecurityGroups = f57
+			ko.Status.VPCSecurityGroups = f56
 		}
 		found = true
 		break

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -757,9 +757,6 @@ func (r *CRD) GoCodeSetInput(
 
 		memberShapeRef, _ := inputShape.MemberRefs[memberName]
 		memberShape := memberShapeRef.Shape
-		if r.genCfg.IsIgnoredShape(memberShape.ShapeName) {
-			continue
-		}
 
 		// we construct variables containing temporary storage for sub-elements
 		// and sub-fields that are structs. Names of fields are "f" appended by
@@ -1258,9 +1255,6 @@ func (r *CRD) goCodeSetInputForContainer(
 			for memberIndex, memberName := range shape.MemberNames() {
 				memberShapeRef := shape.MemberRefs[memberName]
 				memberShape := memberShapeRef.Shape
-				if r.genCfg.IsIgnoredShape(memberShape.ShapeName) {
-					continue
-				}
 				cleanMemberNames := names.New(memberName)
 				cleanMemberName := cleanMemberNames.Camel
 				memberVarName := fmt.Sprintf("%sf%d", targetVarName, memberIndex)
@@ -1671,9 +1665,6 @@ func (r *CRD) GoCodeSetOutput(
 		}
 
 		sourceMemberShape := sourceMemberShapeRef.Shape
-		if r.genCfg.IsIgnoredShape(sourceMemberShape.ShapeName) {
-			continue
-		}
 
 		// Determine whether the input shape's field is in the Spec or the
 		// Status struct and set the source variable appropriately.
@@ -1873,9 +1864,6 @@ func (r *CRD) goCodeSetOutputReadMany(
 	for memberIndex, memberName := range sourceElemShape.MemberNames() {
 		sourceMemberShapeRef := sourceElemShape.MemberRefs[memberName]
 		sourceMemberShape := sourceMemberShapeRef.Shape
-		if r.genCfg.IsIgnoredShape(sourceMemberShape.ShapeName) {
-			continue
-		}
 		sourceAdaptedVarName := "elem." + memberName
 		if r.IsPrimaryARNField(memberName) {
 			out += fmt.Sprintf(
@@ -2199,9 +2187,6 @@ func (r *CRD) goCodeSetOutputForContainer(
 				memberVarName := fmt.Sprintf("%sf%d", targetVarName, memberIndex)
 				memberShapeRef := sourceShape.MemberRefs[memberName]
 				memberShape := memberShapeRef.Shape
-				if r.genCfg.IsIgnoredShape(memberShape.ShapeName) {
-					continue
-				}
 				cleanNames := names.New(memberName)
 				sourceAdaptedVarName := sourceVarName + "." + memberName
 				out += fmt.Sprintf(

--- a/pkg/model/sdk_helper.go
+++ b/pkg/model/sdk_helper.go
@@ -221,9 +221,6 @@ func (a *SDKAPI) GetTypeRenames(cfg *ackgenconfig.Config) map[string]string {
 			// Neither are exceptions
 			continue
 		}
-		if cfg.IsIgnoredShape(shapeName) {
-			continue
-		}
 		tdefNames := names.New(shapeName)
 		if a.HasConflictingTypeName(shapeName, cfg) {
 			tdefNames.Camel += ConflictingNameSuffix


### PR DESCRIPTION
Description of changes: This PR adds a new ignore rule to `Config` object where users can define which specific field they want to ignore, like `CreateApiInput.Name`. It also moves the shape ignore rule to the same function that is run only once during the beginning.

Tested this with APIGatewayv2 resources generated [here](https://github.com/crossplane/provider-aws/pull/416).

This is necessary for Crossplane code generation where we need to ignore the field we use [external-name annotation](https://crossplane.io/docs/v0.14/introduction/managed-resources.html#external-name) for and the fields that are required but could be referenced; those fields should be marked as non-required since they could be fulfilled by the controller after reference resolution. For the referenced fields, we could possibly have another config rule where we can point the fields that can be referenced and use that information to generate the two additional fields (`*Ref` and `*Selector` fields) but I'd like to defer that to another PR. Ignoring field paths is necessary for external-name annotation anyway.

Fixes #510 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
