### PR TITLE
Generate kustomization for crds

### DIFF
--- a/cmd/ack-generate/command/controller.go
+++ b/cmd/ack-generate/command/controller.go
@@ -181,6 +181,7 @@ func writeConfigDirs(g *generate.Generator) error {
 	configDefaultPath := filepath.Join(optControllerOutputPath, "config", "default")
 	configControllerPath := filepath.Join(optControllerOutputPath, "config", "controller")
 	configRBACPath := filepath.Join(optControllerOutputPath, "config", "rbac")
+	configCRDPath := filepath.Join(optControllerOutputPath, "config", "crd")
 	if !optDryRun {
 		if _, err := ensureDir(configDefaultPath); err != nil {
 			return err
@@ -189,6 +190,9 @@ func writeConfigDirs(g *generate.Generator) error {
 			return err
 		}
 		if _, err := ensureDir(configRBACPath); err != nil {
+			return err
+		}
+		if _, err := ensureDir(configCRDPath); err != nil {
 			return err
 		}
 	}

--- a/pkg/generate/template.go
+++ b/pkg/generate/template.go
@@ -154,7 +154,7 @@ type templateMetaVars struct {
 	// SDKAPIInterfaceTypeName is the name of the interface type used by the
 	// aws-sdk-go services/$SERVICE/api.go file
 	SDKAPIInterfaceTypeName string
-	//CRDConfigs will go here
+	//CRDNames contains all crds names lowercased and in plural
 	CRDNames []string
 }
 
@@ -210,6 +210,7 @@ func (g *Generator) templateMetaVars() templateMetaVars {
 	}
 }
 
+// crdNames returns all crd names lowercased and in plural
 func (g *Generator) crdNames() []string {
 	var crdConfigs []string
 

--- a/pkg/generate/template.go
+++ b/pkg/generate/template.go
@@ -49,6 +49,7 @@ var (
 		"config/default/kustomization.yaml",
 		"config/rbac/cluster-role-binding.yaml",
 		"config/rbac/kustomization.yaml",
+		"config/crd/kustomization.yaml",
 	}
 
 	// These are files we straight copy without template variable interpolation
@@ -153,6 +154,8 @@ type templateMetaVars struct {
 	// SDKAPIInterfaceTypeName is the name of the interface type used by the
 	// aws-sdk-go services/$SERVICE/api.go file
 	SDKAPIInterfaceTypeName string
+	//CRDConfigs will go here
+	CRDNames []string
 }
 
 // TemplateAPIVars contains template variables for templates that output Go
@@ -203,7 +206,19 @@ func (g *Generator) templateMetaVars() templateMetaVars {
 		APIGroup:                g.SDKAPI.APIGroup(),
 		APIVersion:              g.apiVersion,
 		SDKAPIInterfaceTypeName: g.SDKAPI.SDKAPIInterfaceTypeName(),
+		CRDNames:                g.crdNames(),
 	}
+}
+
+func (g *Generator) crdNames() []string {
+	var crdConfigs []string
+
+	crds, _ := g.GetCRDs()
+	for _, crd := range crds {
+		crdConfigs = append(crdConfigs, strings.ToLower(crd.Plural))
+	}
+
+	return crdConfigs
 }
 
 // templateAPIVars returns a templateAPIVars struct populated with information

--- a/templates/config/crd/kustomization.yaml.tpl
+++ b/templates/config/crd/kustomization.yaml.tpl
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+{{- range .CRDNames }}
+  - bases/{{ $.APIGroup }}_{{ . }}.yaml 
+{{- end }}

--- a/templates/config/default/kustomization.yaml.tpl
+++ b/templates/config/default/kustomization.yaml.tpl
@@ -13,7 +13,7 @@
 #  someName: someValue
 
 bases:
-# - ../crd
+- ../crd
 - ../rbac
 - ../controller
 


### PR DESCRIPTION
Closes #468
Related to https://github.com/aws/aws-controllers-k8s/pull/469

Description of changes:

`ack-generate` now creates a `kustomization.yaml` in `${SERVICE}/config/crd` with all the crds manifests under `crd/bases`.
Now running `kustomize build services/${SERVICE}/config/default` will render crds.

Re-running `ack-generate` for all services will be required and makes https://github.com/aws/aws-controllers-k8s/pull/469 unnecessary.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
