### PR TITLE
 Re-generate all services via ack-generate by running make build-controller

### DIFF
--- a/services/apigatewayv2/config/crd/kustomization.yaml
+++ b/services/apigatewayv2/config/crd/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - bases/apigatewayv2.services.k8s.aws_apis.yaml
+  - bases/apigatewayv2.services.k8s.aws_apimappings.yaml
+  - bases/apigatewayv2.services.k8s.aws_authorizers.yaml
+  - bases/apigatewayv2.services.k8s.aws_deployments.yaml
+  - bases/apigatewayv2.services.k8s.aws_domainnames.yaml
+  - bases/apigatewayv2.services.k8s.aws_integrations.yaml
+  - bases/apigatewayv2.services.k8s.aws_integrationresponses.yaml
+  - bases/apigatewayv2.services.k8s.aws_models.yaml
+  - bases/apigatewayv2.services.k8s.aws_routes.yaml
+  - bases/apigatewayv2.services.k8s.aws_routeresponses.yaml
+  - bases/apigatewayv2.services.k8s.aws_stages.yaml
+  - bases/apigatewayv2.services.k8s.aws_vpclinks.yaml

--- a/services/apigatewayv2/config/default/kustomization.yaml
+++ b/services/apigatewayv2/config/default/kustomization.yaml
@@ -13,7 +13,7 @@
 #  someName: someValue
 
 bases:
-# - ../crd
+- ../crd
 - ../rbac
 - ../controller
 

--- a/services/apigatewayv2/pkg/resource/api/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/api/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.API{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.API{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/apigatewayv2/pkg/resource/api/sdk.go
+++ b/services/apigatewayv2/pkg/resource/api/sdk.go
@@ -62,7 +62,7 @@ func (rm *resourceManager) sdkFind(
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
 		}
-		return nil, err
+		return nil, respErr
 	}
 
 	// Merge in the information we read from the API call above to the copy of

--- a/services/apigatewayv2/pkg/resource/api_mapping/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/api_mapping/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.APIMapping{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.APIMapping{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/apigatewayv2/pkg/resource/api_mapping/sdk.go
+++ b/services/apigatewayv2/pkg/resource/api_mapping/sdk.go
@@ -62,7 +62,7 @@ func (rm *resourceManager) sdkFind(
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
 		}
-		return nil, err
+		return nil, respErr
 	}
 
 	// Merge in the information we read from the API call above to the copy of

--- a/services/apigatewayv2/pkg/resource/authorizer/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/authorizer/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.Authorizer{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.Authorizer{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/apigatewayv2/pkg/resource/authorizer/sdk.go
+++ b/services/apigatewayv2/pkg/resource/authorizer/sdk.go
@@ -62,7 +62,7 @@ func (rm *resourceManager) sdkFind(
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
 		}
-		return nil, err
+		return nil, respErr
 	}
 
 	// Merge in the information we read from the API call above to the copy of

--- a/services/apigatewayv2/pkg/resource/deployment/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/deployment/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.Deployment{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.Deployment{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/apigatewayv2/pkg/resource/deployment/sdk.go
+++ b/services/apigatewayv2/pkg/resource/deployment/sdk.go
@@ -62,7 +62,7 @@ func (rm *resourceManager) sdkFind(
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
 		}
-		return nil, err
+		return nil, respErr
 	}
 
 	// Merge in the information we read from the API call above to the copy of

--- a/services/apigatewayv2/pkg/resource/domain_name/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/domain_name/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.DomainName{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.DomainName{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/apigatewayv2/pkg/resource/domain_name/sdk.go
+++ b/services/apigatewayv2/pkg/resource/domain_name/sdk.go
@@ -62,7 +62,7 @@ func (rm *resourceManager) sdkFind(
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
 		}
-		return nil, err
+		return nil, respErr
 	}
 
 	// Merge in the information we read from the API call above to the copy of

--- a/services/apigatewayv2/pkg/resource/integration/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/integration/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.Integration{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.Integration{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/apigatewayv2/pkg/resource/integration/sdk.go
+++ b/services/apigatewayv2/pkg/resource/integration/sdk.go
@@ -62,7 +62,7 @@ func (rm *resourceManager) sdkFind(
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
 		}
-		return nil, err
+		return nil, respErr
 	}
 
 	// Merge in the information we read from the API call above to the copy of

--- a/services/apigatewayv2/pkg/resource/integration_response/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/integration_response/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.IntegrationResponse{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.IntegrationResponse{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/apigatewayv2/pkg/resource/integration_response/sdk.go
+++ b/services/apigatewayv2/pkg/resource/integration_response/sdk.go
@@ -62,7 +62,7 @@ func (rm *resourceManager) sdkFind(
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
 		}
-		return nil, err
+		return nil, respErr
 	}
 
 	// Merge in the information we read from the API call above to the copy of

--- a/services/apigatewayv2/pkg/resource/model/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/model/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.Model{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.Model{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/apigatewayv2/pkg/resource/model/sdk.go
+++ b/services/apigatewayv2/pkg/resource/model/sdk.go
@@ -62,7 +62,7 @@ func (rm *resourceManager) sdkFind(
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
 		}
-		return nil, err
+		return nil, respErr
 	}
 
 	// Merge in the information we read from the API call above to the copy of

--- a/services/apigatewayv2/pkg/resource/route/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/route/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.Route{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.Route{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/apigatewayv2/pkg/resource/route/sdk.go
+++ b/services/apigatewayv2/pkg/resource/route/sdk.go
@@ -62,7 +62,7 @@ func (rm *resourceManager) sdkFind(
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
 		}
-		return nil, err
+		return nil, respErr
 	}
 
 	// Merge in the information we read from the API call above to the copy of

--- a/services/apigatewayv2/pkg/resource/route_response/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/route_response/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.RouteResponse{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.RouteResponse{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/apigatewayv2/pkg/resource/route_response/sdk.go
+++ b/services/apigatewayv2/pkg/resource/route_response/sdk.go
@@ -62,7 +62,7 @@ func (rm *resourceManager) sdkFind(
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
 		}
-		return nil, err
+		return nil, respErr
 	}
 
 	// Merge in the information we read from the API call above to the copy of

--- a/services/apigatewayv2/pkg/resource/stage/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/stage/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.Stage{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.Stage{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/apigatewayv2/pkg/resource/stage/sdk.go
+++ b/services/apigatewayv2/pkg/resource/stage/sdk.go
@@ -62,7 +62,7 @@ func (rm *resourceManager) sdkFind(
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
 		}
-		return nil, err
+		return nil, respErr
 	}
 
 	// Merge in the information we read from the API call above to the copy of

--- a/services/apigatewayv2/pkg/resource/vpc_link/descriptor.go
+++ b/services/apigatewayv2/pkg/resource/vpc_link/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.VPCLink{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.VPCLink{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/apigatewayv2/pkg/resource/vpc_link/sdk.go
+++ b/services/apigatewayv2/pkg/resource/vpc_link/sdk.go
@@ -62,7 +62,7 @@ func (rm *resourceManager) sdkFind(
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFoundException" {
 			return nil, ackerr.NotFound
 		}
-		return nil, err
+		return nil, respErr
 	}
 
 	// Merge in the information we read from the API call above to the copy of

--- a/services/dynamodb/config/crd/kustomization.yaml
+++ b/services/dynamodb/config/crd/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - bases/dynamodb.services.k8s.aws_backups.yaml
+  - bases/dynamodb.services.k8s.aws_globaltables.yaml
+  - bases/dynamodb.services.k8s.aws_tables.yaml

--- a/services/dynamodb/config/default/kustomization.yaml
+++ b/services/dynamodb/config/default/kustomization.yaml
@@ -13,7 +13,7 @@
 #  someName: someValue
 
 bases:
-# - ../crd
+- ../crd
 - ../rbac
 - ../controller
 

--- a/services/dynamodb/pkg/resource/backup/descriptor.go
+++ b/services/dynamodb/pkg/resource/backup/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.Backup{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.Backup{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/dynamodb/pkg/resource/backup/sdk.go
+++ b/services/dynamodb/pkg/resource/backup/sdk.go
@@ -62,7 +62,7 @@ func (rm *resourceManager) sdkFind(
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "UNKNOWN" {
 			return nil, ackerr.NotFound
 		}
-		return nil, err
+		return nil, respErr
 	}
 
 	// Merge in the information we read from the API call above to the copy of

--- a/services/dynamodb/pkg/resource/global_table/descriptor.go
+++ b/services/dynamodb/pkg/resource/global_table/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.GlobalTable{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.GlobalTable{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/dynamodb/pkg/resource/global_table/sdk.go
+++ b/services/dynamodb/pkg/resource/global_table/sdk.go
@@ -62,7 +62,7 @@ func (rm *resourceManager) sdkFind(
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "UNKNOWN" {
 			return nil, ackerr.NotFound
 		}
-		return nil, err
+		return nil, respErr
 	}
 
 	// Merge in the information we read from the API call above to the copy of

--- a/services/dynamodb/pkg/resource/table/descriptor.go
+++ b/services/dynamodb/pkg/resource/table/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.Table{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.Table{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/dynamodb/pkg/resource/table/sdk.go
+++ b/services/dynamodb/pkg/resource/table/sdk.go
@@ -62,7 +62,7 @@ func (rm *resourceManager) sdkFind(
 		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "ResourceNotFoundException" {
 			return nil, ackerr.NotFound
 		}
-		return nil, err
+		return nil, respErr
 	}
 
 	// Merge in the information we read from the API call above to the copy of

--- a/services/ecr/config/crd/kustomization.yaml
+++ b/services/ecr/config/crd/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - bases/ecr.services.k8s.aws_repositories.yaml

--- a/services/ecr/config/default/kustomization.yaml
+++ b/services/ecr/config/default/kustomization.yaml
@@ -13,7 +13,7 @@
 #  someName: someValue
 
 bases:
-# - ../crd
+- ../crd
 - ../rbac
 - ../controller
 

--- a/services/ecr/pkg/resource/repository/descriptor.go
+++ b/services/ecr/pkg/resource/repository/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.Repository{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.Repository{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/ecr/pkg/resource/repository/sdk.go
+++ b/services/ecr/pkg/resource/repository/sdk.go
@@ -62,9 +62,6 @@ func (rm *resourceManager) sdkFind(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 
-	if len(resp.Repositories) == 0 {
-		return nil, ackerr.NotFound
-	}
 	found := false
 	for _, elem := range resp.Repositories {
 		if elem.CreatedAt != nil {

--- a/services/elasticache/config/crd/kustomization.yaml
+++ b/services/elasticache/config/crd/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - bases/elasticache.services.k8s.aws_cachesubnetgroups.yaml
+  - bases/elasticache.services.k8s.aws_replicationgroups.yaml
+  - bases/elasticache.services.k8s.aws_snapshots.yaml

--- a/services/elasticache/config/default/kustomization.yaml
+++ b/services/elasticache/config/default/kustomization.yaml
@@ -13,7 +13,7 @@
 #  someName: someValue
 
 bases:
-# - ../crd
+- ../crd
 - ../rbac
 - ../controller
 

--- a/services/elasticache/pkg/resource/cache_subnet_group/descriptor.go
+++ b/services/elasticache/pkg/resource/cache_subnet_group/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.CacheSubnetGroup{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.CacheSubnetGroup{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/elasticache/pkg/resource/cache_subnet_group/sdk.go
+++ b/services/elasticache/pkg/resource/cache_subnet_group/sdk.go
@@ -62,9 +62,6 @@ func (rm *resourceManager) sdkFind(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 
-	if len(resp.CacheSubnetGroups) == 0 {
-		return nil, ackerr.NotFound
-	}
 	found := false
 	for _, elem := range resp.CacheSubnetGroups {
 		if elem.ARN != nil {

--- a/services/elasticache/pkg/resource/replication_group/descriptor.go
+++ b/services/elasticache/pkg/resource/replication_group/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.ReplicationGroup{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.ReplicationGroup{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/elasticache/pkg/resource/replication_group/sdk.go
+++ b/services/elasticache/pkg/resource/replication_group/sdk.go
@@ -62,9 +62,6 @@ func (rm *resourceManager) sdkFind(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 
-	if len(resp.ReplicationGroups) == 0 {
-		return nil, ackerr.NotFound
-	}
 	found := false
 	for _, elem := range resp.ReplicationGroups {
 		if elem.ARN != nil {

--- a/services/elasticache/pkg/resource/snapshot/descriptor.go
+++ b/services/elasticache/pkg/resource/snapshot/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.Snapshot{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.Snapshot{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/elasticache/pkg/resource/snapshot/sdk.go
+++ b/services/elasticache/pkg/resource/snapshot/sdk.go
@@ -62,9 +62,6 @@ func (rm *resourceManager) sdkFind(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 
-	if len(resp.Snapshots) == 0 {
-		return nil, ackerr.NotFound
-	}
 	found := false
 	for _, elem := range resp.Snapshots {
 		if elem.ARN != nil {

--- a/services/s3/config/crd/kustomization.yaml
+++ b/services/s3/config/crd/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - bases/s3.services.k8s.aws_buckets.yaml

--- a/services/s3/config/default/kustomization.yaml
+++ b/services/s3/config/default/kustomization.yaml
@@ -13,7 +13,7 @@
 #  someName: someValue
 
 bases:
-# - ../crd
+- ../crd
 - ../rbac
 - ../controller
 

--- a/services/s3/pkg/resource/bucket/descriptor.go
+++ b/services/s3/pkg/resource/bucket/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.Bucket{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.Bucket{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/s3/pkg/resource/bucket/sdk.go
+++ b/services/s3/pkg/resource/bucket/sdk.go
@@ -62,9 +62,6 @@ func (rm *resourceManager) sdkFind(
 	// the original Kubernetes object we passed to the function
 	ko := r.ko.DeepCopy()
 
-	if len(resp.Buckets) == 0 {
-		return nil, ackerr.NotFound
-	}
 	found := false
 	for _, elem := range resp.Buckets {
 		if elem.Name != nil {

--- a/services/sfn/config/crd/kustomization.yaml
+++ b/services/sfn/config/crd/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - bases/sfn.services.k8s.aws_activities.yaml
+  - bases/sfn.services.k8s.aws_statemachines.yaml

--- a/services/sfn/config/default/kustomization.yaml
+++ b/services/sfn/config/default/kustomization.yaml
@@ -13,7 +13,7 @@
 #  someName: someValue
 
 bases:
-# - ../crd
+- ../crd
 - ../rbac
 - ../controller
 

--- a/services/sfn/pkg/resource/activity/descriptor.go
+++ b/services/sfn/pkg/resource/activity/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.Activity{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.Activity{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/sfn/pkg/resource/state_machine/descriptor.go
+++ b/services/sfn/pkg/resource/state_machine/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.StateMachine{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.StateMachine{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/sns/config/crd/kustomization.yaml
+++ b/services/sns/config/crd/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - bases/sns.services.k8s.aws_platformapplications.yaml
+  - bases/sns.services.k8s.aws_platformendpoints.yaml
+  - bases/sns.services.k8s.aws_topics.yaml

--- a/services/sns/config/default/kustomization.yaml
+++ b/services/sns/config/default/kustomization.yaml
@@ -13,7 +13,7 @@
 #  someName: someValue
 
 bases:
-# - ../crd
+- ../crd
 - ../rbac
 - ../controller
 

--- a/services/sns/pkg/resource/platform_application/descriptor.go
+++ b/services/sns/pkg/resource/platform_application/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.PlatformApplication{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.PlatformApplication{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/sns/pkg/resource/platform_endpoint/descriptor.go
+++ b/services/sns/pkg/resource/platform_endpoint/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.PlatformEndpoint{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.PlatformEndpoint{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 

--- a/services/sns/pkg/resource/topic/descriptor.go
+++ b/services/sns/pkg/resource/topic/descriptor.go
@@ -75,8 +75,8 @@ func (d *resourceDescriptor) Equal(
 ) bool {
 	ac := a.(*resource)
 	bc := b.(*resource)
-	opts := cmpopts.EquateEmpty()
-	return cmp.Equal(ac.ko, bc.ko, opts)
+	opts := []cmp.Option{cmpopts.EquateEmpty()}
+	return cmp.Equal(ac.ko, bc.ko, opts...)
 }
 
 // Diff returns a Reporter which provides the difference between two supplied
@@ -90,7 +90,11 @@ func (d *resourceDescriptor) Diff(
 	ac := a.(*resource)
 	bc := b.(*resource)
 	var diffReporter ackcompare.Reporter
-	cmp.Equal(ac.ko, bc.ko, cmp.Reporter(&diffReporter), cmp.AllowUnexported(svcapitypes.Topic{}))
+	opts := []cmp.Option{
+		cmp.Reporter(&diffReporter),
+		cmp.AllowUnexported(svcapitypes.Topic{}),
+	}
+	cmp.Equal(ac.ko, bc.ko, opts...)
 	return &diffReporter
 }
 


### PR DESCRIPTION
Description of changes:

Regenerate all services via `ack-generate` by running `make build-controller SERVICE=<service>`
This action:
1. Generate `kustomization.yaml` files under `config/crd` using as resource all crds under `config/crd/bases`
2. Uncomment `crds` in all `config/default/kustomization.yaml` files
3. Update generated code by `ack-generate`, some of these changes come from https://github.com/aws/aws-controllers-k8s/pull/412


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
