### PR TITLE
Generate ack-$SERVICE-[reader|writer] Roles

### DIFF
--- a/docs/contents/user-docs/irsa.md
+++ b/docs/contents/user-docs/irsa.md
@@ -1,0 +1,38 @@
+# Setting up ACK with IAM Roles for Service Accounts
+
+[IAM Roles for Service Accounts][0], or IRSA, is a system that automates the
+provisioning and rotation of IAM temporary credentials (called a Web Identity)
+that a Kubernetes `ServiceAccount` can use to call AWS APIs.
+
+The primary advantage of IRSA is that Kubernetes `Pods` which use the
+`ServiceAccount` associated with an IAM Role can have a reduced IAM permission
+footprint than the IAM Role in use for the Kubernetes EC2 worker node (known as
+the EC2 Instance Profile Role). This security concept is known as **Least
+Privilege**.
+
+For example, assume you have a broadly-scoped IAM Role with permissions to
+access the Instance Metadata Service (IMDS) from the EC2 worker node. If you do
+not want Kubernetes `Pods` running on that EC2 Instance to have access to IMDS,
+you can create a different IAM Role with a reduced permission set and associate
+this reduced-scope IAM Role with the Kubernetes `ServiceAccount` the `Pod`
+uses. IRSA will ensure that a special file is injected (and rotated
+periodically) into the `Pod` that contains a JSON Web Token (JWT) that
+encapsulates a request for temporary credentials to assume the IAM Role with
+reduced permissions.
+
+When AWS clients or SDKs connect to an AWS API, they detect the existence of
+this special token file and call the [`STS::AssumeRoleWithWebIdentity`][2] API
+to assume the IAM Role with reduced permissions.
+
+!!! note "EKS is not required to use IRSA"
+
+    Note that you do *not* need to be using the Amazon EKS service in order to
+    use IRSA. There are [instructions][1] on the
+    amazon-eks-pod-identity-webhook repository for setting up IRSA on your own
+    Kubernetes installation.
+
+## 
+
+[0]: https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
+[1]: https://github.com/aws/amazon-eks-pod-identity-webhook/blob/master/SELF_HOSTED_SETUP.md
+[2]: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html

--- a/pkg/generate/template.go
+++ b/pkg/generate/template.go
@@ -48,6 +48,8 @@ var (
 		"config/controller/kustomization.yaml",
 		"config/default/kustomization.yaml",
 		"config/rbac/cluster-role-binding.yaml",
+		"config/rbac/role-reader.yaml",
+		"config/rbac/role-writer.yaml",
 		"config/rbac/kustomization.yaml",
 		"config/crd/kustomization.yaml",
 	}
@@ -62,6 +64,8 @@ var (
 	releaseTemplateFiles = []string{
 		"helm/Chart.yaml",
 		"helm/values.yaml",
+		"helm/templates/role-reader.yaml",
+		"helm/templates/role-writer.yaml",
 	}
 	// ReleaseFiles is the set of template files that are generated for Helm
 	// chart releases artifacts.

--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -135,5 +135,10 @@ pushd $ROOT_DIR/services/$SERVICE/pkg/resource 1>/dev/null
 
 echo "Generating RBAC manifests for $SERVICE"
 controller-gen rbac:roleName=$K8S_RBAC_ROLE_NAME paths=./... output:rbac:artifacts:config=$helm_output_dir/templates
+# controller-gen rbac outputs a ClusterRole definition in a
+# $config_output_dir/rbac/role.yaml file. We have some other standard Role
+# files for a reader and writer role, so here we rename the `role.yaml` file to
+# `cluster-role-controller.yaml` to better reflect what is in that file.
+mv $helm_output_dir/templates/role.yaml $helm_output_dir/templates/cluster-role-controller.yaml
 
 popd 1>/dev/null

--- a/scripts/install-helm.sh
+++ b/scripts/install-helm.sh
@@ -26,7 +26,7 @@ if ! is_installed helm; then
     __tmp_install_dir=$(mktemp -d -t install-helm-XXX)
     __helm_url="https://get.helm.sh/helm-v$__helm_version-$__platform-amd64.tar.gz"
     echo -n "installing helm from $__helm_url ... "
-    curl -L $__helm_url | tar zxf - -C $__tmp_install_dir
+    curl -q -L $__helm_url | tar zxf - -C $__tmp_install_dir
     mv $__tmp_install_dir/$__platform-amd64/helm $__tmp_install_dir/.
     chmod +x $__tmp_install_dir/helm
     sudo mv $__tmp_install_dir/helm /usr/local/bin/helm

--- a/templates/config/rbac/cluster-role-binding.yaml.tpl
+++ b/templates/config/rbac/cluster-role-binding.yaml.tpl
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ack-controller-rolebinding
+  name: ack-{{ .ServiceIDClean }}-controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ack-controller
+  name: ack-{{ .ServiceIDClean }}-controller
 subjects:
 - kind: ServiceAccount
   name: default

--- a/templates/config/rbac/kustomization.yaml.tpl
+++ b/templates/config/rbac/kustomization.yaml.tpl
@@ -1,3 +1,5 @@
 resources:
-- role.yaml
 - cluster-role-binding.yaml
+- cluster-role-controller.yaml
+- role-reader.yaml
+- role-writer.yaml

--- a/templates/config/rbac/role-reader.yaml.tpl
+++ b/templates/config/rbac/role-reader.yaml.tpl
@@ -1,0 +1,18 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: ack-{{ .ServiceIDClean }}-reader
+  namespace: default
+rules:
+- apiGroups:
+  - {{ .APIGroup }}
+  resources:
+{{- range $crdName := .CRDNames }}
+  - {{ $crdName }}
+{{- end }}
+  verbs:
+  - get
+  - list
+  - watch

--- a/templates/config/rbac/role-writer.yaml.tpl
+++ b/templates/config/rbac/role-writer.yaml.tpl
@@ -1,0 +1,32 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: ack-{{ .ServiceIDClean }}-writer
+  namespace: default
+rules:
+- apiGroups:
+  - {{ .APIGroup }}
+  resources:
+{{- range $crdName := .CRDNames }}
+  - {{ $crdName }}
+{{- end }}
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - {{ .APIGroup }}
+  resources:
+{{- range $crdName := .CRDNames }}
+  - {{ $crdName }}
+{{- end }}
+  verbs:
+  - get
+  - patch
+  - update

--- a/templates/helm/templates/role-reader.yaml.tpl
+++ b/templates/helm/templates/role-reader.yaml.tpl
@@ -1,0 +1,18 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: ack-{{ .ServiceIDClean }}-reader
+  namespace: {{ "{{ .Release.Namespace }}" }}
+rules:
+- apiGroups:
+  - {{ .APIGroup }}
+  resources:
+{{- range $crdName := .CRDNames }}
+  - {{ $crdName }}
+{{- end }}
+  verbs:
+  - get
+  - list
+  - watch

--- a/templates/helm/templates/role-writer.yaml.tpl
+++ b/templates/helm/templates/role-writer.yaml.tpl
@@ -1,0 +1,32 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: ack-{{ .ServiceIDClean }}-writer
+  namespace: {{ "{{ .Release.Namespace }}" }}
+rules:
+- apiGroups:
+  - {{ .APIGroup }}
+  resources:
+{{- range $crdName := .CRDNames }}
+  - {{ $crdName }}
+{{ end }}
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - {{ .APIGroup }}
+  resources:
+{{- range $crdName := .CRDNames }}
+  - {{ $crdName }}
+{{- end }}
+  verbs:
+  - get
+  - patch
+  - update


### PR DESCRIPTION
Our documentation mentions standardized Roles called
`ack-$SERVICE-reader` and `ack-$SERVICE-writer` that can be bound to
users in order to give them read or read/write permissions to operate on
CRDs of a particular service controller.

However, until this PR, we weren't actually generating these Roles. This
PR adds the generation of those standardized Role resources and modifies
the documentation for configuring Kubernetes RoleBindings to match the
`ack-$SERVICE-reader` and `ack-$SERVICE-writer` Roles we are now
producing.

Issue #366 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
