### PR TITLE
regenerate controllers for new RBAC files

### DIFF
--- a/services/apigatewayv2/config/rbac/cluster-role-binding.yaml
+++ b/services/apigatewayv2/config/rbac/cluster-role-binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ack-controller-rolebinding
+  name: ack-apigatewayv2-controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ack-controller
+  name: ack-apigatewayv2-controller
 subjects:
 - kind: ServiceAccount
   name: default

--- a/services/apigatewayv2/config/rbac/cluster-role-controller.yaml
+++ b/services/apigatewayv2/config/rbac/cluster-role-controller.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: ack-controller
+  name: ack-apigatewayv2-controller
 rules:
 - apiGroups:
   - ""

--- a/services/apigatewayv2/config/rbac/kustomization.yaml
+++ b/services/apigatewayv2/config/rbac/kustomization.yaml
@@ -1,3 +1,5 @@
 resources:
-- role.yaml
 - cluster-role-binding.yaml
+- cluster-role-controller.yaml
+- role-reader.yaml
+- role-writer.yaml

--- a/services/apigatewayv2/config/rbac/role-reader.yaml
+++ b/services/apigatewayv2/config/rbac/role-reader.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: ack-apigatewayv2-reader
+  namespace: default
+rules:
+- apiGroups:
+  - apigatewayv2.services.k8s.aws
+  resources:
+  - apis
+  - apimappings
+  - authorizers
+  - deployments
+  - domainnames
+  - integrations
+  - integrationresponses
+  - models
+  - routes
+  - routeresponses
+  - stages
+  - vpclinks
+  verbs:
+  - get
+  - list
+  - watch

--- a/services/apigatewayv2/config/rbac/role-writer.yaml
+++ b/services/apigatewayv2/config/rbac/role-writer.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: ack-apigatewayv2-writer
+  namespace: default
+rules:
+- apiGroups:
+  - apigatewayv2.services.k8s.aws
+  resources:
+  - apis
+  - apimappings
+  - authorizers
+  - deployments
+  - domainnames
+  - integrations
+  - integrationresponses
+  - models
+  - routes
+  - routeresponses
+  - stages
+  - vpclinks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apigatewayv2.services.k8s.aws
+  resources:
+  - apis
+  - apimappings
+  - authorizers
+  - deployments
+  - domainnames
+  - integrations
+  - integrationresponses
+  - models
+  - routes
+  - routeresponses
+  - stages
+  - vpclinks
+  verbs:
+  - get
+  - patch
+  - update

--- a/services/dynamodb/config/rbac/cluster-role-binding.yaml
+++ b/services/dynamodb/config/rbac/cluster-role-binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ack-controller-rolebinding
+  name: ack-dynamodb-controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ack-controller
+  name: ack-dynamodb-controller
 subjects:
 - kind: ServiceAccount
   name: default

--- a/services/dynamodb/config/rbac/cluster-role-controller.yaml
+++ b/services/dynamodb/config/rbac/cluster-role-controller.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: ack-controller
+  name: ack-dynamodb-controller
 rules:
 - apiGroups:
   - ""

--- a/services/dynamodb/config/rbac/kustomization.yaml
+++ b/services/dynamodb/config/rbac/kustomization.yaml
@@ -1,3 +1,5 @@
 resources:
-- role.yaml
 - cluster-role-binding.yaml
+- cluster-role-controller.yaml
+- role-reader.yaml
+- role-writer.yaml

--- a/services/dynamodb/config/rbac/role-reader.yaml
+++ b/services/dynamodb/config/rbac/role-reader.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: ack-dynamodb-reader
+  namespace: default
+rules:
+- apiGroups:
+  - dynamodb.services.k8s.aws
+  resources:
+  - backups
+  - globaltables
+  - tables
+  verbs:
+  - get
+  - list
+  - watch

--- a/services/dynamodb/config/rbac/role-writer.yaml
+++ b/services/dynamodb/config/rbac/role-writer.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: ack-dynamodb-writer
+  namespace: default
+rules:
+- apiGroups:
+  - dynamodb.services.k8s.aws
+  resources:
+  - backups
+  - globaltables
+  - tables
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - dynamodb.services.k8s.aws
+  resources:
+  - backups
+  - globaltables
+  - tables
+  verbs:
+  - get
+  - patch
+  - update

--- a/services/ecr/config/rbac/cluster-role-binding.yaml
+++ b/services/ecr/config/rbac/cluster-role-binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ack-controller-rolebinding
+  name: ack-ecr-controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ack-controller
+  name: ack-ecr-controller
 subjects:
 - kind: ServiceAccount
   name: default

--- a/services/ecr/config/rbac/cluster-role-controller.yaml
+++ b/services/ecr/config/rbac/cluster-role-controller.yaml
@@ -1,0 +1,44 @@
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: ack-ecr-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ecr.services.k8s.aws
+  resources:
+  - repositories
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ecr.services.k8s.aws
+  resources:
+  - repositories/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/services/ecr/config/rbac/kustomization.yaml
+++ b/services/ecr/config/rbac/kustomization.yaml
@@ -1,3 +1,5 @@
 resources:
-- role.yaml
 - cluster-role-binding.yaml
+- cluster-role-controller.yaml
+- role-reader.yaml
+- role-writer.yaml

--- a/services/ecr/config/rbac/role-reader.yaml
+++ b/services/ecr/config/rbac/role-reader.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: ack-ecr-reader
+  namespace: default
+rules:
+- apiGroups:
+  - ecr.services.k8s.aws
+  resources:
+  - repositories
+  verbs:
+  - get
+  - list
+  - watch

--- a/services/ecr/config/rbac/role-writer.yaml
+++ b/services/ecr/config/rbac/role-writer.yaml
@@ -1,27 +1,11 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   creationTimestamp: null
-  name: ack-controller
+  name: ack-ecr-writer
+  namespace: default
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
 - apiGroups:
   - ecr.services.k8s.aws
   resources:
@@ -37,7 +21,7 @@ rules:
 - apiGroups:
   - ecr.services.k8s.aws
   resources:
-  - repositories/status
+  - repositories
   verbs:
   - get
   - patch

--- a/services/elasticache/config/rbac/cluster-role-binding.yaml
+++ b/services/elasticache/config/rbac/cluster-role-binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ack-controller-rolebinding
+  name: ack-elasticache-controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ack-controller
+  name: ack-elasticache-controller
 subjects:
 - kind: ServiceAccount
   name: default

--- a/services/elasticache/config/rbac/cluster-role-controller.yaml
+++ b/services/elasticache/config/rbac/cluster-role-controller.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: ack-controller
+  name: ack-elasticache-controller
 rules:
 - apiGroups:
   - ""

--- a/services/elasticache/config/rbac/kustomization.yaml
+++ b/services/elasticache/config/rbac/kustomization.yaml
@@ -1,3 +1,5 @@
 resources:
-- role.yaml
 - cluster-role-binding.yaml
+- cluster-role-controller.yaml
+- role-reader.yaml
+- role-writer.yaml

--- a/services/elasticache/config/rbac/role-reader.yaml
+++ b/services/elasticache/config/rbac/role-reader.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: ack-elasticache-reader
+  namespace: default
+rules:
+- apiGroups:
+  - elasticache.services.k8s.aws
+  resources:
+  - cacheparametergroups
+  - cachesubnetgroups
+  - replicationgroups
+  - snapshots
+  verbs:
+  - get
+  - list
+  - watch

--- a/services/elasticache/config/rbac/role-writer.yaml
+++ b/services/elasticache/config/rbac/role-writer.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: ack-elasticache-writer
+  namespace: default
+rules:
+- apiGroups:
+  - elasticache.services.k8s.aws
+  resources:
+  - cacheparametergroups
+  - cachesubnetgroups
+  - replicationgroups
+  - snapshots
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - elasticache.services.k8s.aws
+  resources:
+  - cacheparametergroups
+  - cachesubnetgroups
+  - replicationgroups
+  - snapshots
+  verbs:
+  - get
+  - patch
+  - update

--- a/services/s3/config/rbac/cluster-role-binding.yaml
+++ b/services/s3/config/rbac/cluster-role-binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ack-controller-rolebinding
+  name: ack-s3-controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ack-controller
+  name: ack-s3-controller
 subjects:
 - kind: ServiceAccount
   name: default

--- a/services/s3/config/rbac/cluster-role-controller.yaml
+++ b/services/s3/config/rbac/cluster-role-controller.yaml
@@ -1,0 +1,44 @@
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: ack-s3-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - s3.services.k8s.aws
+  resources:
+  - buckets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - s3.services.k8s.aws
+  resources:
+  - buckets/status
+  verbs:
+  - get
+  - patch
+  - update

--- a/services/s3/config/rbac/kustomization.yaml
+++ b/services/s3/config/rbac/kustomization.yaml
@@ -1,3 +1,5 @@
 resources:
-- role.yaml
 - cluster-role-binding.yaml
+- cluster-role-controller.yaml
+- role-reader.yaml
+- role-writer.yaml

--- a/services/s3/config/rbac/role-reader.yaml
+++ b/services/s3/config/rbac/role-reader.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: ack-s3-reader
+  namespace: default
+rules:
+- apiGroups:
+  - s3.services.k8s.aws
+  resources:
+  - buckets
+  verbs:
+  - get
+  - list
+  - watch

--- a/services/s3/config/rbac/role-writer.yaml
+++ b/services/s3/config/rbac/role-writer.yaml
@@ -1,27 +1,11 @@
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   creationTimestamp: null
-  name: ack-controller
+  name: ack-s3-writer
+  namespace: default
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - configmaps
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
 - apiGroups:
   - s3.services.k8s.aws
   resources:
@@ -37,7 +21,7 @@ rules:
 - apiGroups:
   - s3.services.k8s.aws
   resources:
-  - buckets/status
+  - buckets
   verbs:
   - get
   - patch

--- a/services/sfn/config/rbac/cluster-role-binding.yaml
+++ b/services/sfn/config/rbac/cluster-role-binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ack-controller-rolebinding
+  name: ack-sfn-controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ack-controller
+  name: ack-sfn-controller
 subjects:
 - kind: ServiceAccount
   name: default

--- a/services/sfn/config/rbac/cluster-role-controller.yaml
+++ b/services/sfn/config/rbac/cluster-role-controller.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: ack-controller
+  name: ack-sfn-controller
 rules:
 - apiGroups:
   - ""
@@ -23,9 +23,9 @@ rules:
   - list
   - watch
 - apiGroups:
-  - sns.services.k8s.aws
+  - sfn.services.k8s.aws
   resources:
-  - platformapplications
+  - activities
   verbs:
   - create
   - delete
@@ -35,37 +35,17 @@ rules:
   - update
   - watch
 - apiGroups:
-  - sns.services.k8s.aws
+  - sfn.services.k8s.aws
   resources:
-  - platformapplications/status
+  - activities/status
   verbs:
   - get
   - patch
   - update
 - apiGroups:
-  - sns.services.k8s.aws
+  - sfn.services.k8s.aws
   resources:
-  - platformendpoints
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - sns.services.k8s.aws
-  resources:
-  - platformendpoints/status
-  verbs:
-  - get
-  - patch
-  - update
-- apiGroups:
-  - sns.services.k8s.aws
-  resources:
-  - topics
+  - statemachines
   verbs:
   - create
   - delete
@@ -75,9 +55,9 @@ rules:
   - update
   - watch
 - apiGroups:
-  - sns.services.k8s.aws
+  - sfn.services.k8s.aws
   resources:
-  - topics/status
+  - statemachines/status
   verbs:
   - get
   - patch

--- a/services/sfn/config/rbac/kustomization.yaml
+++ b/services/sfn/config/rbac/kustomization.yaml
@@ -1,3 +1,5 @@
 resources:
-- role.yaml
 - cluster-role-binding.yaml
+- cluster-role-controller.yaml
+- role-reader.yaml
+- role-writer.yaml

--- a/services/sfn/config/rbac/role-reader.yaml
+++ b/services/sfn/config/rbac/role-reader.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: ack-sfn-reader
+  namespace: default
+rules:
+- apiGroups:
+  - sfn.services.k8s.aws
+  resources:
+  - activities
+  - statemachines
+  verbs:
+  - get
+  - list
+  - watch

--- a/services/sfn/config/rbac/role-writer.yaml
+++ b/services/sfn/config/rbac/role-writer.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: ack-sfn-writer
+  namespace: default
+rules:
+- apiGroups:
+  - sfn.services.k8s.aws
+  resources:
+  - activities
+  - statemachines
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - sfn.services.k8s.aws
+  resources:
+  - activities
+  - statemachines
+  verbs:
+  - get
+  - patch
+  - update

--- a/services/sns/config/rbac/cluster-role-binding.yaml
+++ b/services/sns/config/rbac/cluster-role-binding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ack-controller-rolebinding
+  name: ack-sns-controller-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: ack-controller
+  name: ack-sns-controller
 subjects:
 - kind: ServiceAccount
   name: default

--- a/services/sns/config/rbac/cluster-role-controller.yaml
+++ b/services/sns/config/rbac/cluster-role-controller.yaml
@@ -4,7 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: ack-controller
+  name: ack-sns-controller
 rules:
 - apiGroups:
   - ""
@@ -23,9 +23,9 @@ rules:
   - list
   - watch
 - apiGroups:
-  - sfn.services.k8s.aws
+  - sns.services.k8s.aws
   resources:
-  - activities
+  - platformapplications
   verbs:
   - create
   - delete
@@ -35,17 +35,17 @@ rules:
   - update
   - watch
 - apiGroups:
-  - sfn.services.k8s.aws
+  - sns.services.k8s.aws
   resources:
-  - activities/status
+  - platformapplications/status
   verbs:
   - get
   - patch
   - update
 - apiGroups:
-  - sfn.services.k8s.aws
+  - sns.services.k8s.aws
   resources:
-  - statemachines
+  - platformendpoints
   verbs:
   - create
   - delete
@@ -55,9 +55,29 @@ rules:
   - update
   - watch
 - apiGroups:
-  - sfn.services.k8s.aws
+  - sns.services.k8s.aws
   resources:
-  - statemachines/status
+  - platformendpoints/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - sns.services.k8s.aws
+  resources:
+  - topics
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - sns.services.k8s.aws
+  resources:
+  - topics/status
   verbs:
   - get
   - patch

--- a/services/sns/config/rbac/kustomization.yaml
+++ b/services/sns/config/rbac/kustomization.yaml
@@ -1,3 +1,5 @@
 resources:
-- role.yaml
 - cluster-role-binding.yaml
+- cluster-role-controller.yaml
+- role-reader.yaml
+- role-writer.yaml

--- a/services/sns/config/rbac/role-reader.yaml
+++ b/services/sns/config/rbac/role-reader.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: ack-sns-reader
+  namespace: default
+rules:
+- apiGroups:
+  - sns.services.k8s.aws
+  resources:
+  - platformapplications
+  - platformendpoints
+  - topics
+  verbs:
+  - get
+  - list
+  - watch

--- a/services/sns/config/rbac/role-writer.yaml
+++ b/services/sns/config/rbac/role-writer.yaml
@@ -1,0 +1,32 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: ack-sns-writer
+  namespace: default
+rules:
+- apiGroups:
+  - sns.services.k8s.aws
+  resources:
+  - platformapplications
+  - platformendpoints
+  - topics
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - sns.services.k8s.aws
+  resources:
+  - platformapplications
+  - platformendpoints
+  - topics
+  verbs:
+  - get
+  - patch
+  - update


### PR DESCRIPTION
Regenerates the RBAC Role and ClusterRole files for all dev preview
service controllers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
