### PR TITLE
Support for ListAllowedNodeTypeModifications

### DIFF
--- a/services/elasticache/apis/v1alpha1/replication_group.go
+++ b/services/elasticache/apis/v1alpha1/replication_group.go
@@ -79,6 +79,8 @@ type ReplicationGroupStatus struct {
 	MultiAZ                    *string                                `json:"multiAZ,omitempty"`
 	NodeGroups                 []*NodeGroup                           `json:"nodeGroups,omitempty"`
 	PendingModifiedValues      *ReplicationGroupPendingModifiedValues `json:"pendingModifiedValues,omitempty"`
+	ScaleDownModifications     []*string                              `json:"scaleDownModifications,omitempty"`
+	ScaleUpModifications       []*string                              `json:"scaleUpModifications,omitempty"`
 	SnapshottingClusterID      *string                                `json:"snapshottingClusterID,omitempty"`
 	Status                     *string                                `json:"status,omitempty"`
 }

--- a/services/elasticache/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/services/elasticache/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1989,6 +1989,28 @@ func (in *ReplicationGroupStatus) DeepCopyInto(out *ReplicationGroupStatus) {
 		*out = new(ReplicationGroupPendingModifiedValues)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ScaleDownModifications != nil {
+		in, out := &in.ScaleDownModifications, &out.ScaleDownModifications
+		*out = make([]*string, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(string)
+				**out = **in
+			}
+		}
+	}
+	if in.ScaleUpModifications != nil {
+		in, out := &in.ScaleUpModifications, &out.ScaleUpModifications
+		*out = make([]*string, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(string)
+				**out = **in
+			}
+		}
+	}
 	if in.SnapshottingClusterID != nil {
 		in, out := &in.SnapshottingClusterID, &out.SnapshottingClusterID
 		*out = new(string)

--- a/services/elasticache/config/crd/bases/elasticache.services.k8s.aws_replicationgroups.yaml
+++ b/services/elasticache/config/crd/bases/elasticache.services.k8s.aws_replicationgroups.yaml
@@ -294,6 +294,14 @@ spec:
                         type: object
                     type: object
                 type: object
+              scaleDownModifications:
+                items:
+                  type: string
+                type: array
+              scaleUpModifications:
+                items:
+                  type: string
+                type: array
               snapshottingClusterID:
                 type: string
               status:

--- a/services/elasticache/generator.yaml
+++ b/services/elasticache/generator.yaml
@@ -10,6 +10,11 @@ resources:
         - InvalidParameter
         - InvalidParameterValue
         - InvalidParameterCombination
+    status_fields:
+      - operation_id: ListAllowedNodeTypeModifications
+        member_name: ScaleUpModifications
+      - operation_id: ListAllowedNodeTypeModifications
+        member_name: ScaleDownModifications
   Snapshot:
     update_conditions_custom_method_name: CustomUpdateConditions
     exceptions:


### PR DESCRIPTION
Add allowed node modifications to the status of replication group.

`kubectl describe` will have the status if RG is in active or snapshotting status.

```
  Pending Modified Values:
  Scale Down Modifications:
    cache.t2.micro
    cache.t3.micro
  Scale Up Modifications:
    cache.m4.10xlarge
    cache.m4.2xlarge
    cache.m4.4xlarge
    cache.m4.large
    cache.m4.xlarge
    cache.m5.12xlarge
    cache.m5.24xlarge
    cache.m5.2xlarge
    cache.m5.4xlarge
    cache.m5.large
    cache.m5.xlarge
    cache.m6g.large
    cache.r4.2xlarge
    cache.r4.4xlarge
    cache.r4.8xlarge
    cache.r4.large
    cache.r4.xlarge
    cache.r5.12xlarge
    cache.r5.24xlarge
    cache.r5.2xlarge
    cache.r5.4xlarge
    cache.r5.large
    cache.r5.xlarge
    cache.r6g.large
    cache.t2.medium
    cache.t2.small
    cache.t3.medium
  Status:  available
Events:    <none>
```

Removed this field while modifying as it might not be relevant. Used https://github.com/aws/aws-controllers-k8s/pull/523 for adding the status field.

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
