### PR TITLE
dynamodb: add custom 404 exception codes for GlobalTable and Backup

### DIFF
--- a/services/dynamodb/generator.yaml
+++ b/services/dynamodb/generator.yaml
@@ -3,3 +3,11 @@ resources:
     exceptions:
       codes:
         404: ResourceNotFoundException
+  GlobalTable:
+    exceptions:
+      codes:
+        404: GlobalTableNotFoundException
+  Backup:
+    exceptions:
+      codes:
+        404: BackupNotFoundException

--- a/services/dynamodb/pkg/resource/backup/sdk.go
+++ b/services/dynamodb/pkg/resource/backup/sdk.go
@@ -59,7 +59,7 @@ func (rm *resourceManager) sdkFind(
 	_, respErr := rm.sdkapi.DescribeBackupWithContext(ctx, input)
 	rm.metrics.RecordAPICall("READ_ONE", "DescribeBackup", respErr)
 	if respErr != nil {
-		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "UNKNOWN" {
+		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "BackupNotFoundException" {
 			return nil, ackerr.NotFound
 		}
 		return nil, respErr

--- a/services/dynamodb/pkg/resource/global_table/sdk.go
+++ b/services/dynamodb/pkg/resource/global_table/sdk.go
@@ -59,7 +59,7 @@ func (rm *resourceManager) sdkFind(
 	resp, respErr := rm.sdkapi.DescribeGlobalTableWithContext(ctx, input)
 	rm.metrics.RecordAPICall("READ_ONE", "DescribeGlobalTable", respErr)
 	if respErr != nil {
-		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "UNKNOWN" {
+		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "GlobalTableNotFoundException" {
 			return nil, ackerr.NotFound
 		}
 		return nil, respErr


### PR DESCRIPTION
Description of changes: While generating [DynamoDB services for Crossplane](https://github.com/crossplane/provider-aws/pull/446), I have discovered that they need custom 404 exception codes similar to ECR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
