### PR TITLE
Terminal Condition stabilization

### DIFF
--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -207,13 +207,6 @@ func (r *reconciler) sync(
 			"diff", diffReporter.String(),
 			"arn", latest.Identifiers().ARN(),
 		)
-		// Before we update the backend AWS service resources, let's first update
-		// the latest status of CR which was retrieved by ReadOne call.
-		// Else, latest read status is lost in-case Update call fails with error.
-		err = r.patchResource(ctx, desired, latest)
-		if err != nil {
-			return err
-		}
 		latest, err = rm.Update(ctx, desired, latest, diffReporter)
 		if err != nil {
 			if latest != nil {

--- a/services/apigatewayv2/pkg/resource/api/manager.go
+++ b/services/apigatewayv2/pkg/resource/api/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/apigatewayv2/pkg/resource/api_mapping/manager.go
+++ b/services/apigatewayv2/pkg/resource/api_mapping/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/apigatewayv2/pkg/resource/authorizer/manager.go
+++ b/services/apigatewayv2/pkg/resource/authorizer/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/apigatewayv2/pkg/resource/deployment/manager.go
+++ b/services/apigatewayv2/pkg/resource/deployment/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/apigatewayv2/pkg/resource/domain_name/manager.go
+++ b/services/apigatewayv2/pkg/resource/domain_name/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/apigatewayv2/pkg/resource/integration/manager.go
+++ b/services/apigatewayv2/pkg/resource/integration/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/apigatewayv2/pkg/resource/integration_response/manager.go
+++ b/services/apigatewayv2/pkg/resource/integration_response/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/apigatewayv2/pkg/resource/model/manager.go
+++ b/services/apigatewayv2/pkg/resource/model/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/apigatewayv2/pkg/resource/route/manager.go
+++ b/services/apigatewayv2/pkg/resource/route/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/apigatewayv2/pkg/resource/route_response/manager.go
+++ b/services/apigatewayv2/pkg/resource/route_response/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/apigatewayv2/pkg/resource/stage/manager.go
+++ b/services/apigatewayv2/pkg/resource/stage/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/apigatewayv2/pkg/resource/vpc_link/manager.go
+++ b/services/apigatewayv2/pkg/resource/vpc_link/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/dynamodb/pkg/resource/backup/manager.go
+++ b/services/dynamodb/pkg/resource/backup/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/dynamodb/pkg/resource/global_table/manager.go
+++ b/services/dynamodb/pkg/resource/global_table/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/dynamodb/pkg/resource/table/manager.go
+++ b/services/dynamodb/pkg/resource/table/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/ecr/pkg/resource/repository/manager.go
+++ b/services/ecr/pkg/resource/repository/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/elasticache/pkg/resource/cache_parameter_group/custom_update_api.go
+++ b/services/elasticache/pkg/resource/cache_parameter_group/custom_update_api.go
@@ -96,7 +96,7 @@ func (rm *resourceManager) provideDelta(
 	for latestParameterName, latestParameterNameValue := range latestPametersMap {
 		desiredParameterNameValue, found := desiredPametersMap[latestParameterName]
 		if found && desiredParameterNameValue != nil &&
-			desiredParameterNameValue.ParameterValue != nil && *desiredParameterNameValue.ParameterValue != ""{
+			desiredParameterNameValue.ParameterValue != nil && *desiredParameterNameValue.ParameterValue != "" {
 			if *desiredParameterNameValue.ParameterValue != *latestParameterNameValue.ParameterValue {
 				// available in both desired, latest but values differ
 				modified := *desiredParameterNameValue

--- a/services/elasticache/pkg/resource/cache_parameter_group/manager.go
+++ b/services/elasticache/pkg/resource/cache_parameter_group/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/elasticache/pkg/resource/cache_subnet_group/manager.go
+++ b/services/elasticache/pkg/resource/cache_subnet_group/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/elasticache/pkg/resource/replication_group/manager.go
+++ b/services/elasticache/pkg/resource/replication_group/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/elasticache/pkg/resource/snapshot/manager.go
+++ b/services/elasticache/pkg/resource/snapshot/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/s3/pkg/resource/bucket/manager.go
+++ b/services/s3/pkg/resource/bucket/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/sagemaker/pkg/resource/model/manager.go
+++ b/services/sagemaker/pkg/resource/model/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/sfn/pkg/resource/activity/manager.go
+++ b/services/sfn/pkg/resource/activity/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/sfn/pkg/resource/state_machine/manager.go
+++ b/services/sfn/pkg/resource/state_machine/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/sns/pkg/resource/platform_application/manager.go
+++ b/services/sns/pkg/resource/platform_application/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/sns/pkg/resource/platform_endpoint/manager.go
+++ b/services/sns/pkg/resource/platform_endpoint/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/services/sns/pkg/resource/topic/manager.go
+++ b/services/sns/pkg/resource/topic/manager.go
@@ -192,7 +192,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&

--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -179,7 +179,7 @@ func (rm *resourceManager) onError(
 ) (acktypes.AWSResource, error) {
 	r1, updated := rm.updateConditions(r, err)
 	if !updated {
-		return nil, err
+		return r, err
 	}
 	for _, condition := range r1.Conditions() {
 		if condition.Type == ackv1alpha1.ConditionTypeTerminal &&


### PR DESCRIPTION
Issue #494 

Description of changes:
The changes fix the issue where Terminal condition fluctuates between a `false` and `true` value

Steps to reproduce:
The issue occurs when a custom resource was successfully reconciled and its terminal condition is false or not set.
Then if this resource is updated using yaml which would result in failure during modify call; then this issue surfaces.

Cause:
`rm.ReadOne()` for already created resource returns successfully; the code which invokes `patchResource()` before the `rm.Update()` call sets the terminal condition to `false` (because of successful retrieval of `latest` object not having any failure); this is followed by `rm.Update()` call which fails with terminal condition and results in setting it to `true`.

Fix:
- The call to `patchResource()` before the `rm.Update()` call is removed as it was not required considering that `patchResource` is invoked in case of update failure and latest is not nil. 
- Updated the code in manager `onError()` to ensure that latest object is returned in-case of error too.
  - Generated service controllers (due to updated manager template) using: 
```
SERVICE=apigatewayv2 && make build-controller && \
SERVICE=dynamodb && make build-controller && \
SERVICE=ecr && make build-controller && \
SERVICE=elasticache && make build-controller && \
SERVICE=s3 && make build-controller && \
SERVICE=sagemaker && make build-controller && \
SERVICE=sfn && make build-controller && \
SERVICE=sns && make build-controller;
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
