### PR TITLE
removed getopts strategy from delete-kind-cluster

### DIFF
--- a/scripts/delete-kind-cluster.sh
+++ b/scripts/delete-kind-cluster.sh
@@ -3,34 +3,33 @@ set -eo pipefail
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 
-USAGE=$(cat << 'EOM'
-  Usage: delete-cluster  [-c <CLUSTER_CONTEXT>] [-o]
-  Deletes a kind cluster and context dir
-  Example: delete-cluster -c build/tmp-cluster-1234
-          Required:
-            -c          Cluster context directory
-          Optional:
-            -o          Override path w/ your own kubectl and kind binaries
-EOM
-)
+USAGE="
+Usage:
+  $(basename "$0") <Cluster_context_directory>
 
-# Process our input arguments
-while getopts "c:o" opt; do
-  case ${opt} in
-    c ) # Cluster context directory
-        TMP_DIR=$OPTARG
-        CLUSTER_NAME=$(cat $TMP_DIR/clustername)
-      ;;
-    o ) # Override path with your own kubectl and kind binaries
-	      OVERRIDE_PATH=1
-        export PATH=$PATH:$TMP_DIR
-      ;;
-    \? )
-        echoerr "$USAGE" 1>&2
-        exit
-      ;;
-  esac
-done
+Deletes a kind cluster and context dir
+
+Example: delete-cluster build/tmp-cluster-1234
+
+<cluster_context_directory> Cluster context directory
+
+Environment variables:
+  OVERRIDE_PATH:            Override path w/ your own kubectl and kind binaries (<0|1>) 
+                            Default: 0
+"
+
+if [ $# -ne 1 ]; then
+    echo "Context directory is not defined" 1>&2
+    echo "${USAGE}"
+    exit 1
+fi
+
+TMP_DIR="$1"
+CLUSTER_NAME=$(cat $TMP_DIR/clustername)
+OVERRIDE_PATH=${OVERRIDE_PATH:-0}
+
+# Override path with your own kubectl and kind binaries
+[[ $OVERRIDE_PATH = 1 ]] && export PATH=$PATH:$TMP_DIR
 
 echo "🥑 Deleting k8s cluster using \"kind\""
 kind delete cluster --name "$CLUSTER_NAME"

--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -55,7 +55,7 @@ fi
 
 function clean_up {
     if [[ "$PRESERVE" == false ]]; then
-        "${SCRIPTS_DIR}"/delete-kind-cluster.sh -c "$TMP_DIR" || :
+        "${SCRIPTS_DIR}"/delete-kind-cluster.sh "$TMP_DIR" || :
         return
     fi
     echo "To resume test with the same cluster use: \"-c $TMP_DIR\""""


### PR DESCRIPTION
Efforts part of Issue #504
Refactoring stage: Argument variable values as env variables instead of getops strategy
Script: delete-kind-cluster.sh

Description of changes:
Replaced getopts strategy with a fixed number of arguments (cluster context path ) and env variable (override binary path, defaulted to 0). Fixed references to this script in kind-build-test.sh

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
