### PR TITLE
ElastiCache DescribeEvents support

### DIFF
--- a/pkg/generate/elasticache_test.go
+++ b/pkg/generate/elasticache_test.go
@@ -779,4 +779,35 @@ func TestElasticache_Additional_CacheParameterGroup_Status(t *testing.T) {
 
 	assert := assert.New(t)
 	assert.Contains(crd.StatusFields, "Parameters")
+	assert.Contains(crd.StatusFields, "Events")
+}
+
+func TestElasticache_Additional_ReplicationGroup_Status(t *testing.T) {
+	require := require.New(t)
+
+	g := testutil.NewGeneratorForService(t, "elasticache")
+	crds, err := g.GetCRDs()
+
+	require.Nil(err)
+
+	crd := getCRDByName("ReplicationGroup", crds)
+	require.NotNil(crd)
+
+	assert := assert.New(t)
+	assert.Contains(crd.StatusFields, "Events")
+}
+
+func TestElasticache_Additional_CacheSubnetGroup_Status(t *testing.T) {
+	require := require.New(t)
+
+	g := testutil.NewGeneratorForService(t, "elasticache")
+	crds, err := g.GetCRDs()
+
+	require.Nil(err)
+
+	crd := getCRDByName("CacheSubnetGroup", crds)
+	require.NotNil(crd)
+
+	assert := assert.New(t)
+	assert.Contains(crd.StatusFields, "Events")
 }

--- a/pkg/generate/testdata/models/apis/elasticache/0000-00-00/generator.yaml
+++ b/pkg/generate/testdata/models/apis/elasticache/0000-00-00/generator.yaml
@@ -1,4 +1,11 @@
 resources:
+  CacheSubnetGroup:
+    exceptions:
+      codes:
+        404: CacheSubnetGroupNotFoundFault
+    status_fields:
+      - operation_id: DescribeEvents
+        member_name: Events
   Snapshot:
     spec_fields:
       - operation_id: CopySnapshot
@@ -18,8 +25,14 @@ resources:
     status_fields:
       - operation_id: DescribeCacheParameters
         member_name: Parameters
+      - operation_id: DescribeEvents
+        member_name: Events
     update_operation:
       custom_method_name: customUpdateCacheParameterGroup
+  ReplicationGroup:
+    status_fields:
+      - operation_id: DescribeEvents
+        member_name: Events
 operations:
   ModifyReplicationGroup:
     override_values:

--- a/services/elasticache/apis/v1alpha1/cache_parameter_group.go
+++ b/services/elasticache/apis/v1alpha1/cache_parameter_group.go
@@ -42,6 +42,7 @@ type CacheParameterGroupStatus struct {
 	// the various terminal states of the CR and its backend AWS service API
 	// resource
 	Conditions []*ackv1alpha1.Condition `json:"conditions"`
+	Events     []*Event                 `json:"events,omitempty"`
 	IsGlobal   *bool                    `json:"isGlobal,omitempty"`
 	Parameters []*Parameter             `json:"parameters,omitempty"`
 }

--- a/services/elasticache/apis/v1alpha1/cache_subnet_group.go
+++ b/services/elasticache/apis/v1alpha1/cache_subnet_group.go
@@ -41,6 +41,7 @@ type CacheSubnetGroupStatus struct {
 	// the various terminal states of the CR and its backend AWS service API
 	// resource
 	Conditions []*ackv1alpha1.Condition `json:"conditions"`
+	Events     []*Event                 `json:"events,omitempty"`
 	Subnets    []*Subnet                `json:"subnets,omitempty"`
 	VPCID      *string                  `json:"vpcID,omitempty"`
 }

--- a/services/elasticache/apis/v1alpha1/replication_group.go
+++ b/services/elasticache/apis/v1alpha1/replication_group.go
@@ -74,6 +74,7 @@ type ReplicationGroupStatus struct {
 	ClusterEnabled             *bool                                  `json:"clusterEnabled,omitempty"`
 	ConfigurationEndpoint      *Endpoint                              `json:"configurationEndpoint,omitempty"`
 	Description                *string                                `json:"description,omitempty"`
+	Events                     []*Event                               `json:"events,omitempty"`
 	GlobalReplicationGroupInfo *GlobalReplicationGroupInfo            `json:"globalReplicationGroupInfo,omitempty"`
 	MemberClusters             []*string                              `json:"memberClusters,omitempty"`
 	MultiAZ                    *string                                `json:"multiAZ,omitempty"`

--- a/services/elasticache/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/services/elasticache/apis/v1alpha1/zz_generated.deepcopy.go
@@ -485,6 +485,17 @@ func (in *CacheParameterGroupStatus) DeepCopyInto(out *CacheParameterGroupStatus
 			}
 		}
 	}
+	if in.Events != nil {
+		in, out := &in.Events, &out.Events
+		*out = make([]*Event, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(Event)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
 	if in.IsGlobal != nil {
 		in, out := &in.IsGlobal, &out.IsGlobal
 		*out = new(bool)
@@ -748,6 +759,17 @@ func (in *CacheSubnetGroupStatus) DeepCopyInto(out *CacheSubnetGroupStatus) {
 			if (*in)[i] != nil {
 				in, out := &(*in)[i], &(*out)[i]
 				*out = new(corev1alpha1.Condition)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
+	if in.Events != nil {
+		in, out := &in.Events, &out.Events
+		*out = make([]*Event, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(Event)
 				(*in).DeepCopyInto(*out)
 			}
 		}
@@ -1962,6 +1984,17 @@ func (in *ReplicationGroupStatus) DeepCopyInto(out *ReplicationGroupStatus) {
 		in, out := &in.Description, &out.Description
 		*out = new(string)
 		**out = **in
+	}
+	if in.Events != nil {
+		in, out := &in.Events, &out.Events
+		*out = make([]*Event, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(Event)
+				(*in).DeepCopyInto(*out)
+			}
+		}
 	}
 	if in.GlobalReplicationGroupInfo != nil {
 		in, out := &in.GlobalReplicationGroupInfo, &out.GlobalReplicationGroupInfo

--- a/services/elasticache/config/crd/bases/elasticache.services.k8s.aws_cacheparametergroups.yaml
+++ b/services/elasticache/config/crd/bases/elasticache.services.k8s.aws_cacheparametergroups.yaml
@@ -116,6 +116,18 @@ spec:
                   - type
                   type: object
                 type: array
+              events:
+                items:
+                  properties:
+                    date:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    sourceIdentifier:
+                      type: string
+                  type: object
+                type: array
               isGlobal:
                 type: boolean
               parameters:

--- a/services/elasticache/config/crd/bases/elasticache.services.k8s.aws_cachesubnetgroups.yaml
+++ b/services/elasticache/config/crd/bases/elasticache.services.k8s.aws_cachesubnetgroups.yaml
@@ -108,6 +108,18 @@ spec:
                   - type
                   type: object
                 type: array
+              events:
+                items:
+                  properties:
+                    date:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    sourceIdentifier:
+                      type: string
+                  type: object
+                type: array
               subnets:
                 items:
                   properties:

--- a/services/elasticache/config/crd/bases/elasticache.services.k8s.aws_replicationgroups.yaml
+++ b/services/elasticache/config/crd/bases/elasticache.services.k8s.aws_replicationgroups.yaml
@@ -216,6 +216,18 @@ spec:
                 type: object
               description:
                 type: string
+              events:
+                items:
+                  properties:
+                    date:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    sourceIdentifier:
+                      type: string
+                  type: object
+                type: array
               globalReplicationGroupInfo:
                 properties:
                   globalReplicationGroupID:

--- a/services/elasticache/generator.yaml
+++ b/services/elasticache/generator.yaml
@@ -3,6 +3,9 @@ resources:
     exceptions:
       codes:
         404: CacheSubnetGroupNotFoundFault
+    status_fields:
+      - operation_id: DescribeEvents
+        member_name: Events
   ReplicationGroup:
     update_conditions_custom_method_name: CustomUpdateConditions
     exceptions:
@@ -15,6 +18,8 @@ resources:
         member_name: ScaleUpModifications
       - operation_id: ListAllowedNodeTypeModifications
         member_name: ScaleDownModifications
+      - operation_id: DescribeEvents
+        member_name: Events
   Snapshot:
     update_conditions_custom_method_name: CustomUpdateConditions
     exceptions:
@@ -42,9 +47,13 @@ resources:
     status_fields:
       - operation_id: DescribeCacheParameters
         member_name: Parameters
+      - operation_id: DescribeEvents
+        member_name: Events
     update_operation:
       custom_method_name: customUpdateCacheParameterGroup
 operations:
+  DescribeCacheSubnetGroups:
+    set_output_custom_method_name: CustomDescribeCacheSubnetGroupsSetOutput
   DescribeReplicationGroups:
     set_output_custom_method_name: CustomDescribeReplicationGroupsSetOutput
   CreateReplicationGroup:

--- a/services/elasticache/pkg/resource/cache_subnet_group/custom_set_output.go
+++ b/services/elasticache/pkg/resource/cache_subnet_group/custom_set_output.go
@@ -1,0 +1,92 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cache_subnet_group
+
+import (
+	"context"
+	svcapitypes "github.com/aws/aws-controllers-k8s/services/elasticache/apis/v1alpha1"
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// The number of minutes worth of events to retrieve.
+	// 14 days in minutes
+	eventsDuration = 20160
+)
+
+func (rm *resourceManager) CustomDescribeCacheSubnetGroupsSetOutput(
+	ctx context.Context,
+	r *resource,
+	resp *elasticache.DescribeCacheSubnetGroupsOutput,
+	ko *svcapitypes.CacheSubnetGroup,
+) (*svcapitypes.CacheSubnetGroup, error) {
+	if len(resp.CacheSubnetGroups) == 0 {
+		return ko, nil
+	}
+	elem := resp.CacheSubnetGroups[0]
+	err := rm.customSetOutputSupplementAPIs(ctx, r, elem, ko)
+	if err != nil {
+		return nil, err
+	}
+	return ko, nil
+}
+
+func (rm *resourceManager) customSetOutputSupplementAPIs(
+	ctx context.Context,
+	r *resource,
+	subnetGroup *elasticache.CacheSubnetGroup,
+	ko *svcapitypes.CacheSubnetGroup,
+) error {
+	events, err := rm.provideEvents(ctx, r.ko.Spec.CacheSubnetGroupName, 20)
+	if err != nil {
+		return err
+	}
+	ko.Status.Events = events
+	return nil
+}
+
+func (rm *resourceManager) provideEvents(
+	ctx context.Context,
+	subnetGroupName *string,
+	maxRecords int64,
+) ([]*svcapitypes.Event, error) {
+	input := &elasticache.DescribeEventsInput{}
+	input.SetSourceType("cache-subnet-group")
+	input.SetSourceIdentifier(*subnetGroupName)
+	input.SetMaxRecords(maxRecords)
+	input.SetDuration(eventsDuration)
+	resp, err := rm.sdkapi.DescribeEventsWithContext(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	events := []*svcapitypes.Event{}
+	if resp.Events != nil {
+		for _, respEvent := range resp.Events {
+			event := &svcapitypes.Event{}
+			if respEvent.Message != nil {
+				event.Message = respEvent.Message
+			}
+			if respEvent.Date != nil {
+				eventDate := metav1.NewTime(*respEvent.Date)
+				event.Date = &eventDate
+			}
+			// Not copying redundant source id (replication id)
+			// and source type (replication group)
+			// into each event object
+			events = append(events, event)
+		}
+	}
+	return events, nil
+}

--- a/services/elasticache/pkg/resource/cache_subnet_group/sdk.go
+++ b/services/elasticache/pkg/resource/cache_subnet_group/sdk.go
@@ -107,6 +107,12 @@ func (rm *resourceManager) sdkFind(
 
 	rm.setStatusDefaults(ko)
 
+	// custom set output from response
+	ko, err = rm.CustomDescribeCacheSubnetGroupsSetOutput(ctx, r, resp, ko)
+	if err != nil {
+		return nil, err
+	}
+
 	return &resource{ko}, nil
 }
 

--- a/services/elasticache/pkg/resource/replication_group/custom_set_output.go
+++ b/services/elasticache/pkg/resource/replication_group/custom_set_output.go
@@ -20,6 +20,13 @@ import (
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	svcsdk "github.com/aws/aws-sdk-go/service/elasticache"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// The number of minutes worth of events to retrieve.
+	// 14 days in minutes
+	eventsDuration = 20160
 )
 
 func (rm *resourceManager) CustomDescribeReplicationGroupsSetOutput(
@@ -33,6 +40,10 @@ func (rm *resourceManager) CustomDescribeReplicationGroupsSetOutput(
 	}
 	elem := resp.ReplicationGroups[0]
 	rm.customSetOutput(r, elem, ko)
+	err := rm.customSetOutputSupplementAPIs(ctx, r, elem, ko)
+	if err != nil {
+		return nil, err
+	}
 	return ko, nil
 }
 
@@ -122,4 +133,52 @@ func (rm *resourceManager) newListAllowedNodeTypeModificationsPayLoad(respRG *el
 	}
 
 	return res, nil
+}
+
+func (rm *resourceManager) customSetOutputSupplementAPIs(
+	ctx context.Context,
+	r *resource,
+	respRG *elasticache.ReplicationGroup,
+	ko *svcapitypes.ReplicationGroup,
+) error {
+	events, err := rm.provideEvents(ctx, r.ko.Spec.ReplicationGroupID, 20)
+	if err != nil {
+		return err
+	}
+	ko.Status.Events = events
+	return nil
+}
+
+func (rm *resourceManager) provideEvents(
+	ctx context.Context,
+	replicationGroupId *string,
+	maxRecords int64,
+) ([]*svcapitypes.Event, error) {
+	input := &elasticache.DescribeEventsInput{}
+	input.SetSourceType("replication-group")
+	input.SetSourceIdentifier(*replicationGroupId)
+	input.SetMaxRecords(maxRecords)
+	input.SetDuration(eventsDuration)
+	resp, err := rm.sdkapi.DescribeEventsWithContext(ctx, input)
+	if err != nil {
+		return nil, err
+	}
+	events := []*svcapitypes.Event{}
+	if resp.Events != nil {
+		for _, respEvent := range resp.Events {
+			event := &svcapitypes.Event{}
+			if respEvent.Message != nil {
+				event.Message = respEvent.Message
+			}
+			if respEvent.Date != nil {
+				eventDate := metav1.NewTime(*respEvent.Date)
+				event.Date = &eventDate
+			}
+			// Not copying redundant source id (replication id)
+			// and source type (replication group)
+			// into each event object
+			events = append(events, event)
+		}
+	}
+	return events, nil
 }


### PR DESCRIPTION
Issue #527 

Description of changes:
ElastiCache DescribeEvents support for:
- Replication Group,
- Cache Parameter Group,
- Cache Subnet Group

Example Events for replication group `kubectl` get call:
```
        "events": [
            {
                "date": "2020-11-25T06:42:57Z",
                "message": "Moved a total of 8192 slots out of 8192 slots from shard 0004 to shard 0001"
            },
            {
                "date": "2020-11-25T06:36:51Z",
                "message": "Migrating slots from node groups 0004 to 0001 to rebalance slots"
            },
            {
                "date": "2020-11-25T06:34:41Z",
                "message": "Modified replication group ack-test-rg-1 to add 1 new node groups - 0001"
            },
            {
                "date": "2020-11-25T06:25:00Z",
                "message": "Scaling out replication group ack-test-rg-1 from 1 node groups to 2 node groups"
            },
            {
                "date": "2020-11-25T06:24:08Z",
                "message": "Increase replica count completed for replication group ack-test-rg-1 on 2020-11-25T06:24:08.175Z"
            },
            {
                "date": "2020-11-25T06:17:31Z",
                "message": "Increase replica count started for replication group ack-test-rg-1 on 2020-11-25T06:17:31.744Z"
            }
        ],
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
