### PR TITLE
Config option to specify resource tags

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -30,6 +30,7 @@ const (
 	flagAWSAccountID         = "aws-account-id"
 	flagAWSRegion            = "aws-region"
 	flagLogLevel             = "log-level"
+	flagResourceTags         = "resource-tags"
 )
 
 // Config contains configuration otpions for ACK service controllers
@@ -41,6 +42,7 @@ type Config struct {
 	AccountID                string
 	Region                   string
 	LogLevel                 string
+	ResourceTags             []string
 }
 
 // BindFlags defines CLI/runtime configuration options
@@ -81,6 +83,11 @@ func (cfg *Config) BindFlags() {
 		&cfg.LogLevel, flagLogLevel,
 		"info",
 		"The log level. Default is info. We use logr interface which only supports info and debug level",
+	)
+	flag.StringSliceVar(
+		&cfg.ResourceTags, flagResourceTags,
+		[]string{},
+		"Configures the ACK service controller to always set key/value pairs tags on resources that it manages.",
 	)
 }
 

--- a/pkg/runtime/tags.go
+++ b/pkg/runtime/tags.go
@@ -1,0 +1,69 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package runtime
+
+import (
+	"strings"
+	"time"
+
+	ackconfig "github.com/aws/aws-controllers-k8s/pkg/config"
+	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
+)
+
+// GetDefaultTags provides Default tags (key value pairs) for given resource
+func GetDefaultTags(
+	config *ackconfig.Config,
+	metadata *acktypes.RuntimeMetaObject,
+) map[string]string {
+	if metadata == nil || config == nil || len(config.ResourceTags) == 0 {
+		return nil
+	}
+	var populatedTags = make(map[string]string)
+	for _, tagKeyVal := range config.ResourceTags {
+		keyVal := strings.Split(tagKeyVal, "=")
+		if keyVal == nil && len(keyVal) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(keyVal[0])
+		val := strings.TrimSpace(keyVal[1])
+		if key == "" || val == "" {
+			continue
+		}
+		populatedValue := expandTagValue(&val, metadata)
+		populatedTags[key] = *populatedValue
+	}
+	if len(populatedTags) == 0 {
+		return nil
+	}
+	return populatedTags
+}
+
+func expandTagValue(
+	value *string,
+	metadata *acktypes.RuntimeMetaObject,
+) *string {
+	if value == nil || metadata == nil {
+		return nil
+	}
+	var expandedValue string = ""
+	switch *value {
+	case "%UTCNOW%":
+		expandedValue = time.Now().UTC().String()
+	case "%KUBERNETES_NAMESPACE%":
+		expandedValue = (*metadata).GetNamespace()
+	default:
+		expandedValue = *value
+	}
+	return &expandedValue
+}

--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -19,6 +19,7 @@ AWS_ROLE_ARN=${AWS_ROLE_ARN:-""}
 ACK_ENABLE_DEVELOPMENT_LOGGING="true"
 ENABLE_PROMETHEUS=${ENABLE_PROMETHEUS:-"false"}
 ACK_LOG_LEVEL="debug"
+ACK_RESOURCE_TAGS='services.k8s.aws/managed=true, services.k8s.aws/created=%UTCNOW%, services.k8s.aws/namespace=%KUBERNETES_NAMESPACE%'
 DELETE_CLUSTER_ARGS=""
 K8S_VERSION=${K8S_VERSION:-"1.16"}
 PRESERVE=${PRESERVE:-"false"}
@@ -146,6 +147,7 @@ export AWS_REGION
 export AWS_ROLE_ARN
 export ACK_ENABLE_DEVELOPMENT_LOGGING
 export ENABLE_PROMETHEUS
+export ACK_RESOURCE_TAGS
 export ACK_LOG_LEVEL
 
 service_config_dir="$ROOT_DIR/services/$AWS_SERVICE/config"
@@ -190,6 +192,7 @@ kubectl -n ack-system set env deployment/ack-"$AWS_SERVICE"-controller \
     AWS_ACCOUNT_ID="$AWS_ACCOUNT_ID" \
     ACK_ENABLE_DEVELOPMENT_LOGGING="$ACK_ENABLE_DEVELOPMENT_LOGGING" \
     ACK_LOG_LEVEL="$ACK_LOG_LEVEL" \
+    ACK_RESOURCE_TAGS="$ACK_RESOURCE_TAGS" \
     AWS_REGION="$AWS_REGION" 1>/dev/null
 sleep 10
 echo "ok."

--- a/services/elasticache/config/controller/deployment.yaml
+++ b/services/elasticache/config/controller/deployment.yaml
@@ -34,6 +34,8 @@ spec:
         - "$(ACK_ENABLE_DEVELOPMENT_LOGGING)"
         - --log-level
         - "$(ACK_LOG_LEVEL)"
+        - --resource-tags
+        - "$(ACK_RESOURCE_TAGS)"
         image: controller:latest
         name: controller
         ports:

--- a/templates/config/controller/deployment.yaml.tpl
+++ b/templates/config/controller/deployment.yaml.tpl
@@ -34,6 +34,8 @@ spec:
         - "$(ACK_ENABLE_DEVELOPMENT_LOGGING)"
         - --log-level
         - "$(ACK_LOG_LEVEL)"
+        - --resource-tags
+        - "$(ACK_RESOURCE_TAGS)"
         image: controller:latest
         name: controller
         ports:

--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -45,6 +45,8 @@ spec:
         - "$(ACK_ENABLE_DEVELOPMENT_LOGGING)"
         - --log-level
         - "$(ACK_LOG_LEVEL)"
+        - --resource-tags
+        - "$(ACK_RESOURCE_TAGS)"
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         name: controller
         ports:
@@ -58,4 +60,6 @@ spec:
               fieldPath: metadata.namespace
         - name: AWS_REGION
           value: {{ .Values.aws.region }}
+        - name: ACK_RESOURCE_TAGS
+          value: {{ join "," .Values.resourceTags | quote }}
       terminationGracePeriodSeconds: 10

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -28,6 +28,12 @@ aws:
   # If specified, use the AWS region for AWS API calls
   region: ""
 
+resourceTags:
+  # Configures the ACK service controller to always set key/value pairs tags on resources that it manages.
+  - services.k8s.aws/managed=true
+  - services.k8s.aws/created=%UTCNOW%
+  - services.k8s.aws/namespace=%KUBERNETES_NAMESPACE%
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
Issue #532 

Description of changes:
- Added `resource-tags` option by referring to `ACK_RESOURCE_TAGS` environment variable. 
- Generated controllers using:
```
SERVICE=elasticache && make build-controller
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
