### PR TITLE
Adding update-api operation in apigatewayv2 e2e test.

### DIFF
--- a/test/e2e/apigatewayv2/api/e2e.sh
+++ b/test/e2e/apigatewayv2/api/e2e.sh
@@ -62,6 +62,7 @@ sleep 5
 apigwv2_create_lambda_authorizer "$authorizer_function_name" "$authorizer_role_name"
 
 apigwv2_create_http_api_and_validate "$api_name"
+apigwv2_update_http_api_and_validate "$api_name"
 apigwv2_create_integration_and_validate "$api_name" "$integration_name"
 apigwv2_create_authorizer_and_validate "$api_name" "$authorizer_name" "$authorizer_function_name"
 apigwv2_create_route_and_validate "$api_name" "$route_name" "$route_key" "$integration_name" "$authorizer_name"


### PR DESCRIPTION
Issue #539 :

Description of changes:

Adding update-api into apigatewayv2 e2e test

```
vijat@186590cff3cf aws-controllers-k8s % make build-ack-generate                                                                    
building ack-generate ... ok.
vijat@186590cff3cf aws-controllers-k8s % ./scripts/kind-build-test.sh -s apigatewayv2 -p -r arn:aws:iam::309117047740:role/Admin-k8s
checking AWS credentials ... ok.
creating kind cluster ack-test-e5508ed3-76898c79 ... ok.
[+] Building 209.7s (15/15) FINISHED                                                                                                       
 => [internal] load build definition from Dockerfile                                                                                  0.8s
 => => transferring dockerfile: 39B                                                                                                   0.1s
 => [internal] load .dockerignore                                                                                                     0.7s
 => => transferring context: 2B                                                                                                       0.0s
 => [internal] load metadata for docker.io/library/amazonlinux:2                                                                      1.1s
 => [internal] load metadata for docker.io/library/golang:1.14.1                                                                      0.0s
 => [internal] load build context                                                                                                     6.1s
 => => transferring context: 17.21MB                                                                                                  6.0s
 => CACHED [stage-1 1/3] FROM docker.io/library/amazonlinux:2@sha256:2c99363fc74d3a39f02365b964e73cceb2b2524c00e9977e16680156e2f79ee  0.0s
 => [builder 1/7] FROM docker.io/library/golang:1.14.1                                                                                0.0s
 => CACHED [builder 2/7] WORKDIR /github.com/aws/aws-controllers-k8s                                                                  0.0s
 => CACHED [builder 3/7] COPY go.mod go.mod                                                                                           0.0s
 => CACHED [builder 4/7] COPY go.sum go.sum                                                                                           0.0s
 => CACHED [builder 5/7] RUN  go mod download                                                                                         0.0s
 => [builder 6/7] COPY . /github.com/aws/aws-controllers-k8s/                                                                        17.7s
 => [builder 7/7] RUN GIT_VERSION=$(git describe --tags --dirty --always) &&     GIT_COMMIT=$(git rev-parse HEAD) &&     BUILD_DAT  180.1s
 => [stage-1 2/3] COPY --from=builder /github.com/aws/aws-controllers-k8s/bin/controller /github.com/aws/aws-controllers-k8s/LICENSE  0.4s
 => exporting to image                                                                                                                0.7s
 => => exporting layers                                                                                                               0.7s
 => => writing image sha256:595640238b993f9e9601fd61bba8e2ab19454d70320278b709649e26978bce4b                                          0.0s
 => => naming to docker.io/library/aws-controllers-k8s:apigatewayv2-v0.0.1-65-geb78885-dirty                                          0.0s
ok.
loading the images into the cluster ... ok.
loading CRD manifests for apigatewayv2 into the cluster ... ok.
loading RBAC manifests for apigatewayv2 into the cluster ... ok.
loading service controller Deployment for apigatewayv2 into the cluster ...ok.
generating AWS temporary credentials and adding to env vars map ... Unable to find image 'amazon/aws-cli:2.0.52' locally
2.0.52: Pulling from amazon/aws-cli
37373184fe69: Already exists
844beeb64872: Pulling fs layer
7777ff6d1f37: Pulling fs layer
e0e32ec92a4b: Pulling fs layer
c1dcf8eaa460: Pulling fs layer
c1dcf8eaa460: Waiting
e0e32ec92a4b: Verifying Checksum
e0e32ec92a4b: Download complete
c1dcf8eaa460: Verifying Checksum
c1dcf8eaa460: Download complete
844beeb64872: Verifying Checksum
844beeb64872: Download complete
7777ff6d1f37: Verifying Checksum
7777ff6d1f37: Download complete
844beeb64872: Pull complete
7777ff6d1f37: Pull complete
e0e32ec92a4b: Pull complete
c1dcf8eaa460: Pull complete
Digest: sha256:27f9634e4e31bf68b82929ef041d24dbe8d0a94b8d98489efa7104c180be5a55
Status: Downloaded newer image for amazon/aws-cli:2.0.52
ok.
======================================================================================================
To poke around your test cluster manually:
export KUBECONFIG=/Users/vijat/Documents/gocode/src/github.com/vijtrip2/aws-controllers-k8s/scripts/lib/../../build/tmp-ack-test-e5508ed3-76898c79/kubeconfig
kubectl get pods -A
======================================================================================================
testing Helm release for apigatewayv2 for release version v0.0.1-65-geb78885-dirty.
Building release artifacts for apigatewayv2-v0.0.1-65-geb78885-dirty
Generating custom resource definitions for apigatewayv2
Generating RBAC manifests for apigatewayv2
namespace/ack-system-test-helm created
installing the helm chart for ack-apigatewayv2-controller in namespace ack-system-test-helm ... ok.
uninstalling the helm chart for ack-apigatewayv2-controller in namespace ack-system-test-helm ... ok.
e2e took 217 second(s)
To resume test with the same cluster use: "-c /Users/vijat/Documents/gocode/src/github.com/vijtrip2/aws-controllers-k8s/scripts/lib/../../build/tmp-ack-test-e5508ed3-76898c79"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
