### PR TITLE
Bash error handling

### DIFF
--- a/scripts/build-controller-image.sh
+++ b/scripts/build-controller-image.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -E
+set -euxo pipefail
 
 DIR=$(cd "$(dirname "$0")"; pwd)
 SCRIPTS_DIR=$DIR

--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -3,7 +3,7 @@
 # A script that builds release artifacts for a single ACK service controller
 # for an AWS service API
 
-set -Eo pipefail
+set -euxo pipefail
 
 SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
 ROOT_DIR="$SCRIPTS_DIR/.."

--- a/scripts/build-controller.sh
+++ b/scripts/build-controller.sh
@@ -2,7 +2,7 @@
 
 # A script that builds a single ACK service controller for an AWS service API
 
-set -Eo pipefail
+set -euxo pipefail
 
 SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
 ROOT_DIR="$SCRIPTS_DIR/.."

--- a/scripts/delete-kind-cluster.sh
+++ b/scripts/delete-kind-cluster.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eo pipefail
+set -euxo pipefail
 
 SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
 

--- a/scripts/generate-crds.sh
+++ b/scripts/generate-crds.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-set -Euo pipefail
-trap 'on_error $LINENO' ERR
+set -euxo pipefail
+# trap 'on_error $LINENO' ERR
 
 echo "Generating CRDs"
 

--- a/scripts/helm-package-controller.sh
+++ b/scripts/helm-package-controller.sh
@@ -3,7 +3,7 @@
 # A script that creates a Helm chart package for a specific ACK service
 # controller
 
-set -Eo pipefail
+set -euxo pipefail
 
 SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
 ROOT_DIR="$SCRIPTS_DIR/.."

--- a/scripts/helm-publish-charts.sh
+++ b/scripts/helm-publish-charts.sh
@@ -5,7 +5,7 @@
 # the updated Helm packages and repository index to the gh-pages branch of the
 # upstream source repository.
 
-set -Eo pipefail
+set -euxo pipefail
 
 SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
 ROOT_DIR="$SCRIPTS_DIR/.."

--- a/scripts/install-controller-gen.sh
+++ b/scripts/install-controller-gen.sh
@@ -15,7 +15,7 @@
 #
 # See: https://github.com/kubernetes-sigs/controller-tools/issues/500
 
-set -Eo pipefail
+set -euxo pipefail
 
 SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
 ROOT_DIR="$SCRIPTS_DIR/.."

--- a/scripts/install-helm.sh
+++ b/scripts/install-helm.sh
@@ -9,7 +9,7 @@
 #
 # NOTE: uses `sudo mv` to relocate a downloaded binary to /usr/local/bin/helm
 
-set -Eo pipefail
+set -euxo pipefail
 
 SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
 ROOT_DIR="$SCRIPTS_DIR/.."

--- a/scripts/install-kind.sh
+++ b/scripts/install-kind.sh
@@ -9,7 +9,7 @@
 #
 # NOTE: uses `sudo mv` to relocate a downloaded binary to /usr/local/bin/kind
 
-set -Eo pipefail
+set -euxo pipefail
 
 SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
 ROOT_DIR="$SCRIPTS_DIR/.."

--- a/scripts/install-kubectl.sh
+++ b/scripts/install-kubectl.sh
@@ -6,7 +6,7 @@
 #
 # NOTE: uses `sudo mv` to relocate a downloaded binary to /usr/local/bin/kubectl
 
-set -Eo pipefail
+set -euxo pipefail
 
 SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
 ROOT_DIR="$SCRIPTS_DIR/.."

--- a/scripts/install-kustomize.sh
+++ b/scripts/install-kustomize.sh
@@ -6,7 +6,7 @@
 #
 # NOTE: uses `sudo mv` to relocate a downloaded binary to /usr/local/bin/kustomize
 
-set -Eo pipefail
+set -euxo pipefail
 
 SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
 ROOT_DIR="$SCRIPTS_DIR/.."

--- a/scripts/install-mockery.sh
+++ b/scripts/install-mockery.sh
@@ -4,7 +4,7 @@
 # for our interfaces to use in unit testing. This script installs mockery into
 # the bin/mockery path and really should just be used in testing scripts.
 
-set -Eo pipefail
+set -euxo pipefail
 
 SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
 ROOT_DIR="$SCRIPTS_DIR/.."

--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -4,7 +4,7 @@
 # Kubernetes cluster, installs the built ACK service controller into that
 # Kubernetes cluster and runs a set of tests
 
-set -Eo pipefail
+set -euxo pipefail
 
 SCRIPTS_DIR=$(cd "$(dirname "$0")" || exit 1; pwd)
 ROOT_DIR="$SCRIPTS_DIR/.."
@@ -53,13 +53,13 @@ if [ "z$AWS_ACCOUNT_ID" == "z" ]; then
     AWS_ACCOUNT_ID=$( aws_account_id )
 fi
 
-function clean_up {
-    if [[ "$PRESERVE" == false ]]; then
-        "${SCRIPTS_DIR}"/delete-kind-cluster.sh "$TMP_DIR" || :
-        return
-    fi
-    echo "To resume test with the same cluster use: \"-c $TMP_DIR\""""
-}
+# function clean_up {
+#     if [[ "$PRESERVE" == false ]]; then
+#         "${SCRIPTS_DIR}"/delete-kind-cluster.sh "$TMP_DIR" || :
+#         return
+#     fi
+#     echo "To resume test with the same cluster use: \"-c $TMP_DIR\""""
+# }
 
 
 USAGE="
@@ -155,7 +155,7 @@ echo "ok."
 
 export KUBECONFIG="${TMP_DIR}/kubeconfig"
 
-trap "clean_up" EXIT
+# trap "clean_up" EXIT
 
 export AWS_ACCOUNT_ID
 export AWS_REGION

--- a/scripts/lib/aws/sagemaker.sh
+++ b/scripts/lib/aws/sagemaker.sh
@@ -1,5 +1,6 @@
 
 #!/usr/bin/env bash
+set -euxo pipefail
 
 THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$THIS_DIR/../../.."
@@ -30,20 +31,20 @@ print_k8s_ack_controller_pod_logs() {
 }
 
 # Cleans up all k8s resources created during tests
-cleanup() {
+# cleanup() {
   # We want to run every command in this function, even if some fail.
-  set +e
-  delete_all_resources
-  if [[ ("$CLEANUP_EXECUTION_ROLE_ARN" = true) ]]; then
-    sagemaker_delete_execution_role $SAGEMAKER_EXECUTION_ROLE_NAME
-  fi
-  if [[ "$CLEANUP_DATA_BUCKET" = true ]]; then
-    sagemaker_delete_data_bucket $SAGEMAKER_DATA_BUCKET
-  fi
-  print_k8s_ack_controller_pod_logs
-}
+#   set +e
+#   delete_all_resources
+#   if [[ ("$CLEANUP_EXECUTION_ROLE_ARN" = true) ]]; then
+#     sagemaker_delete_execution_role $SAGEMAKER_EXECUTION_ROLE_NAME
+#   fi
+#   if [[ "$CLEANUP_DATA_BUCKET" = true ]]; then
+#     sagemaker_delete_data_bucket $SAGEMAKER_DATA_BUCKET
+#   fi
+#   print_k8s_ack_controller_pod_logs
+# }
 
-trap cleanup EXIT
+# trap cleanup EXIT
 
 # Cleans up all k8s resources created during tests
 # Parameter:

--- a/scripts/provision-kind-cluster.sh
+++ b/scripts/provision-kind-cluster.sh
@@ -3,7 +3,7 @@
 # A script that provisions a KinD Kubernetes cluster for local development and
 # testing
 
-set -Eo pipefail
+set -euxo pipefail
 
 SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
 ROOT_DIR="$SCRIPTS_DIR/.."

--- a/scripts/publish-controller-image.sh
+++ b/scripts/publish-controller-image.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -E
+set -euxo pipefail
 
 DIR=$(cd "$(dirname "$0")"; pwd)
 SCRIPTS_DIR=$DIR


### PR DESCRIPTION
Issue #, if available:
#504 
Description of changes:

1. Added safeguards to make error handling more strict. Included the option -x in hopes to make debugging easier. I can use set -Eo pipefail Instead if that works better.

2. There are three files with trap signals. [generate-crds.sh, kind-build-test.sh, sagemaker.sh]. I commented these out as well as the functions associated with them. Then added the set options without the -E option since there are no more trap ERR.

3. Lib and aws folders barely had any set options so any files without set options I left that way.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
