### PR TITLE
removed getopts strategy from publish-controller-image.sh

### DIFF
--- a/scripts/publish-controller-image.sh
+++ b/scripts/publish-controller-image.sh
@@ -4,9 +4,8 @@ set -E
 
 DIR=$(cd "$(dirname "$0")"; pwd)
 SCRIPTS_DIR=$DIR
-DEFAULT_DOCKER_REPOSITORY="amazon/aws-controllers-k8s"
+DEFAULT_DOCKER_REPOSITORY="aws-controllers-k8s"
 DOCKER_REPOSITORY=${DOCKER_REPOSITORY:-$DEFAULT_DOCKER_REPOSITORY}
-OPTIND=1
 VERSION=$(git describe --tags --always --dirty || echo "unknown")
 
 source $SCRIPTS_DIR/lib/common.sh
@@ -15,44 +14,32 @@ check_is_installed docker
 
 USAGE="
 Usage:
-  $(basename "$0") -s <AWS_SERVICE> -r <DOCKER_REPOSITORY> [-i <Docker image tag>]
+  $(basename "$0") <AWS_SERVICE> 
 
 Publishes the Docker image for an ACK service controller. By default, the
 repository will be $DEFAULT_DOCKER_REPOSITORY and the image tag for the
 specific ACK service controller will be ":\$SERVICE-\$VERSION".
 
-Example: $(basename "$0") -s ecr -r amazon/aws-controllers-k8s
+<AWS_SERVICE> AWS Service name (ecr, sns, sqs)
 
-Options:
-  -s          Provide AWS Service name (ecr, sns, sqs)
-  -i          Controller container image tag (default: ack-<service>-controller:$VERSION)
-  -r          Name for the Docker repository to push to (default: $DEFAULT_DOCKER_REPOSITORY)
+Example: 
+export DOCKER_REPOSITORY=aws-controllers-k8s
+$(basename "$0") ecr 
+
+Environment variables:
+  DOCKER_REPOSITORY:        Name for the Docker repository to push to 
+                            Default: $DEFAULT_DOCKER_REPOSITORY
+  AWS_SERVICE_DOCKER_IMG:   Controller container image tag 
+                            Default: aws-controllers-k8s:$AWS_SERVICE-$VERSION
 "
 
-# Process our input arguments
-while getopts "r:s:i:" opt; do
-  case ${opt} in
-    r ) # Docker repository name
-        DOCKER_REPOSITORY="${OPTARG}"
-      ;;
-    s ) # AWS Service name
-        AWS_SERVICE=$(echo "${OPTARG}" | tr '[:upper:]' '[:lower:]')
-      ;;
-    i ) # Controller image tag
-        AWS_SERVICE_DOCKER_IMG="${OPTARG}"
-      ;;
-    \? )
-        echo "${USAGE}" 1>&2
-        exit
-      ;;
-  esac
-done
-
-if [ -z "$AWS_SERVICE" ]; then
-  echo "AWS_SERVICE is not defined. Use flag -s <AWS_SERVICE> to build a container image of that service"
-  echo "(Example: $(basename "$0") -q -s ecr)"
-  exit  1
+if [ $# -ne 1 ]; then
+    echo "AWS_SERVICE is not defined. Script accepts one parameter, <AWS_SERVICE> to build that docker images of that service" 1>&2
+    echo "${USAGE}"
+    exit 1
 fi
+
+AWS_SERVICE=$(echo "$1" | tr '[:upper:]' '[:lower:]')
 
 DEFAULT_AWS_SERVICE_DOCKER_IMG_TAG="${AWS_SERVICE}-${VERSION}"
 : "${AWS_SERVICE_DOCKER_IMG_TAG:="$DOCKER_REPOSITORY:$DEFAULT_AWS_SERVICE_DOCKER_IMG_TAG"}"

--- a/scripts/publish-controller-image.sh
+++ b/scripts/publish-controller-image.sh
@@ -4,7 +4,7 @@ set -E
 
 DIR=$(cd "$(dirname "$0")"; pwd)
 SCRIPTS_DIR=$DIR
-DEFAULT_DOCKER_REPOSITORY="aws-controllers-k8s"
+DEFAULT_DOCKER_REPOSITORY="amazon/aws-controllers-k8s"
 DOCKER_REPOSITORY=${DOCKER_REPOSITORY:-$DEFAULT_DOCKER_REPOSITORY}
 VERSION=$(git describe --tags --always --dirty || echo "unknown")
 


### PR DESCRIPTION
Efforts part of Issue #504
Refactoring stage: Argument variable values as env variables instead of getopts strategy
Script: publish-controller-image.sh

Description of changes:
Replaced getopts strategy with a fixed number of arguments (aws service name ) and env variables.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
