### PR TITLE
Elasticache e2e tests: verification, more tests, cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,9 @@ publish-controller-image:  ## docker push a container image for SERVICE
 build-controller: build-ack-generate ## Generate controller code for SERVICE
 	@./scripts/build-controller.sh $(AWS_SERVICE)
 
+kind-test: export PRESERVE = true
 kind-test: ## Run functional tests for SERVICE with AWS_ROLE_ARN
-	@./scripts/kind-build-test.sh -s $(AWS_SERVICE) -p -r $(AWS_ROLE_ARN)
+	@./scripts/kind-build-test.sh $(AWS_SERVICE)
 
 delete-all-kind-clusters:	## Delete all local kind clusters
 	@kind get clusters | \

--- a/scripts/lib/testutil.sh
+++ b/scripts/lib/testutil.sh
@@ -71,3 +71,78 @@ assert_pod_not_restarted() {
         return 1
     fi
 }
+
+# k8s_wait_resource_synced checks the given resource for an ACK.ResourceSynced condition in its
+#   k8s status.conditions property. Times out if condition has not been met for a long time. This function
+#   is intended to be used after yaml application to await creation of a resource.
+# k8s_wait_resource_synced requires 2 arguments:
+#   k8s_resource_name: the name of the resource, e.g. "snapshots/test-snapshot"
+#   wait_periods: the number of 60-second periods to wait for the resource before timing out
+k8s_wait_resource_synced() {
+  if [[ $# -ne 2 ]]; then
+    echo "FATAL: Wrong number of arguments passed to ${FUNCNAME[0]}"
+    echo "Usage: ${FUNCNAME[0]} k8s_resource_name wait_periods"
+    exit 1
+  fi
+
+  local k8s_resource_name="$1"
+  local wait_periods="$2"
+
+  kubectl get "$k8s_resource_name" 1>/dev/null 2>&1
+  assert_equal "0" "$?" "Resource $k8s_resource_name doesn't exist in k8s cluster" || exit 1
+
+  local wait_failed="true"
+  for i in $(seq 1 "$wait_periods"); do
+    debug_msg "waiting for resource $k8s_resource_name to be synced ($i)"
+    sleep 60
+
+    # ensure we at least have .status.conditions
+    local conditions=$(kubectl get "$k8s_resource_name" -o json | jq -r -e ".status.conditions[]")
+    assert_equal "0" "$?" "Expected .status.conditions property to exist for $k8s_resource_name" || exit 1
+
+    # this condition should probably always exist, regardless of the value
+    local synced_cond=$(echo $conditions | jq -r -e 'select(.type == "ACK.ResourceSynced")')
+    assert_equal "0" "$?" "Expected ACK.ResourceSynced condition to exist for $k8s_resource_name" || exit 1
+
+    # check value of condition; continue if not yet set True
+    local cond_status=$(echo $synced_cond | jq -r -e ".status")
+    if [[ "$cond_status" == "True" ]]; then
+      wait_failed="false"
+      debug_msg "resource $k8s_resource_name is synced, continuing.."
+      break
+    fi
+  done
+
+  assert_equal "false" "$wait_failed" "Wait for resource $k8s_resource_name to be synced timed out" || exit 1
+}
+
+# k8s_check_resource_terminal_condition_true asserts that the terminal condition of the given resource
+#   exists, has status "True", and that the message associated with the terminal condition matches the
+#   one provided.
+# k8s_check_resource_terminal_condition_true requires 2 arguments:
+#   k8s_resource_name: the name of the resource, e.g. "snapshots/test-snapshot"
+#   expected_substring: a substring of the expected message associated with the terminal condition
+k8s_check_resource_terminal_condition_true() {
+  if [[ $# -ne 2 ]]; then
+    echo "FATAL: Wrong number of arguments passed to ${FUNCNAME[0]}"
+    echo "Usage: ${FUNCNAME[0]} replication_group_id expected_substring"
+    exit 1
+  fi
+  local k8s_resource_name="$1"
+  local expected_substring="$2"
+
+  local resource_json=$(kubectl get "$k8s_resource_name" -o json)
+  assert_equal "0" "$?" "Expected $k8s_resource_name to exist in k8s cluster" || exit 1
+
+  local terminal_cond=$(echo $resource_json | jq -r -e ".status.conditions[]" | jq -r -e 'select(.type == "ACK.Terminal")')
+  assert_equal "0" "$?" "Expected resource $k8s_resource_name to have a terminal condition" || exit 1
+
+  local status=$(echo $terminal_cond | jq -r ".status")
+  assert_equal "True" "$status" "expected status of terminal condition to be True for resource $k8s_resource_name" || exit 1
+
+  local cond_msg=$(echo $terminal_cond | jq -r ".message")
+  if [[ $cond_msg != *"$expected_substring"* ]]; then
+    echo "FAIL: resource $k8s_resource_name has terminal condition set True, but with message different than expected"
+    exit 1
+  fi
+}

--- a/test/e2e/elasticache/replication_group/creation.sh
+++ b/test/e2e/elasticache/replication_group/creation.sh
@@ -101,11 +101,11 @@ test_create_rg_single_shard_no_replicas() {
   replicas_per_node_group=0
   automatic_failover_enabled="false"
   multi_az_enabled="false"
-  output_msg=$(provide_replication_group_yaml | kubectl apply -f - 2>&1)
+  provide_replication_group_yaml | kubectl apply -f - 2>&1
   exit_if_rg_config_application_failed $? "$rg_id"
 
   # ensure resource successfully created and available
-  wait_and_assert_replication_group_available_status
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
 }
 
 # create RG with custom node group specification where ID isn't surrounded by quotes: negative test,
@@ -165,11 +165,11 @@ $yaml_base
           - us-east-1a
 EOF
 )
-  output_msg=$(echo "$rg_yaml" | kubectl apply -f - 2>&1)
+  echo "$rg_yaml" | kubectl apply -f - 2>&1
   exit_if_rg_config_application_failed $? "$rg_id"
 
   # ensure resource successfully created and available
-  wait_and_assert_replication_group_available_status
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
 }
 
 # create RG with custom param group
@@ -192,11 +192,11 @@ $yaml_base
     cacheParameterGroupName: pgtest
 EOF
 )
-  output_msg=$(echo "$rg_yaml" | kubectl apply -f - 2>&1)
+  echo "$rg_yaml" | kubectl apply -f - 2>&1
   exit_if_rg_config_application_failed $? "$rg_id"
 
   # ensure resource successfully created and available, check resource is as expected
-  wait_and_assert_replication_group_available_status
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
   aws_assert_rg_param_group "$rg_id" "pgtest"
 }
 

--- a/test/e2e/elasticache/replication_group/e2e.sh
+++ b/test/e2e/elasticache/replication_group/e2e.sh
@@ -54,7 +54,7 @@ ack_create_replication_group() {
 }
 
 ack_create_replication_group
-wait_and_assert_replication_group_available_status
+wait_and_assert_replication_group_synced_and_available "$rg_id"
 
 #################################################
 # modify replication group
@@ -67,7 +67,7 @@ ack_modify_replication_group() {
   ack_apply_replication_group_yaml
 }
 ack_modify_replication_group
-wait_and_assert_replication_group_available_status
+wait_and_assert_replication_group_synced_and_available "$rg_id"
 k8s_assert_replication_group_status_property "$rg_id" ".description" "$rg_description"
 
 #################################################
@@ -79,7 +79,7 @@ test_update_shards_count_increase() {
   num_node_groups="3" # increases from 2 to 3
   debug_msg "Testing modify replication group: $rg_id shards count to new value: $num_node_groups."
   ack_apply_replication_group_yaml
-  wait_and_assert_replication_group_available_status
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
   k8s_assert_replication_group_shard_count "$rg_id" "$num_node_groups"  # assert updated value
 }
 test_update_shards_count_increase
@@ -90,7 +90,7 @@ test_update_shards_count_decrease() {
   num_node_groups="2" # decreases from 3 to 2
   debug_msg "Testing modify replication group: $rg_id shards count to new value: $num_node_groups."
   ack_apply_replication_group_with_node_groups_yaml
-  wait_and_assert_replication_group_available_status
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
   k8s_assert_replication_group_shard_count "$rg_id" "$num_node_groups"  # assert updated value
 }
 test_update_shards_count_decrease
@@ -107,7 +107,7 @@ ack_modify_replication_group_replica_count() {
 test_update_replica_count() {
   k8s_assert_replication_group_replica_count "$rg_id" "$replicas_per_node_group"  # assert current value
   ack_modify_replication_group_replica_count "$1"
-  wait_and_assert_replication_group_available_status
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
   k8s_assert_replication_group_replica_count "$rg_id" "$replicas_per_node_group"  # assert updated value
 }
 ### increase replicas count

--- a/test/e2e/elasticache/replication_group/replication.sh
+++ b/test/e2e/elasticache/replication_group/replication.sh
@@ -25,21 +25,21 @@ test_modify_rg_negative_replicas() {
 
   # generate and apply yaml for replication group creation
   clear_rg_parameter_variables
-  rg_id="test-rg-modify-to-negative-replicas"
+  rg_id="test-rg-modify-negative-replicas"
   automatic_failover_enabled="false"
   num_node_groups="1"
   replicas_per_node_group="0"
   multi_az_enabled="false"
-  output_msg=$(provide_replication_group_yaml | kubectl apply -f - 2>&1)
+  provide_replication_group_yaml | kubectl apply -f - 2>&1
   exit_if_rg_config_application_failed $? "$rg_id"
 
   # ensure resource successfully created and available, check resource is as expected
-  wait_and_assert_replication_group_available_status
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
   k8s_assert_replication_group_replica_count "$rg_id" 0
 
   # update config and apply: attempt to change to negative replica count
   replicas_per_node_group="-1"
-  output_msg=$(provide_replication_group_yaml | kubectl apply -f - 2>&1)
+  provide_replication_group_yaml | kubectl apply -f - 2>&1
   exit_if_rg_config_application_failed $? "$rg_id"
 
   check_rg_terminal_condition_true "$rg_id" "New replica count must be between"
@@ -56,20 +56,20 @@ test_modify_rg_enable_auto_failover() {
   multi_az_enabled="false"
   num_node_groups=1
   replicas_per_node_group=1
-  output_msg=$(provide_replication_group_yaml | kubectl apply -f - 2>&1)
+  provide_replication_group_yaml | kubectl apply -f - 2>&1
   exit_if_rg_config_application_failed $? "$rg_id"
 
   # ensure resource successfully created and available, check property as expected
-  wait_and_assert_replication_group_available_status
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
   k8s_assert_replication_group_status_property "$rg_id" ".automaticFailover" "disabled"
 
   # update configuration and apply
   automatic_failover_enabled="true"
-  output_msg=$(provide_replication_group_yaml | kubectl apply -f - 2>&1)
+  provide_replication_group_yaml | kubectl apply -f - 2>&1
   exit_if_rg_config_application_failed $? "$rg_id"
 
   # wait until RG available again then check value updated
-  wait_and_assert_replication_group_available_status
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
   k8s_assert_replication_group_status_property "$rg_id" ".automaticFailover" "enabled"
 }
 
@@ -85,17 +85,17 @@ test_modify_rg_remove_replica_with_af_enabled() {
   num_node_groups="1"
   replicas_per_node_group="1"
   multi_az_enabled="false"
-  output_msg=$(provide_replication_group_yaml | kubectl apply -f - 2>&1)
+  provide_replication_group_yaml | kubectl apply -f - 2>&1
   exit_if_rg_config_application_failed $? "$rg_id"
 
   # ensure resource successfully created and available, check resource is as expected
-  wait_and_assert_replication_group_available_status
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
   k8s_assert_replication_group_replica_count "$rg_id" 1
   k8s_assert_replication_group_status_property "$rg_id" ".automaticFailover" "enabled"
 
   # update config and apply: attempt to remove replica while keeping auto failover enabled
   replicas_per_node_group="0"
-  output_msg=$(provide_replication_group_yaml | kubectl apply -f - 2>&1)
+  provide_replication_group_yaml | kubectl apply -f - 2>&1
   exit_if_rg_config_application_failed $? "$rg_id"
 
   check_rg_terminal_condition_true "$rg_id" "Must have at least 1 replica when cluster mode is disabled with auto failover enabled"
@@ -113,11 +113,11 @@ test_modify_rg_remove_replica_disable_af() {
   num_node_groups="1"
   replicas_per_node_group="1"
   multi_az_enabled="false"
-  output_msg=$(provide_replication_group_yaml | kubectl apply -f - 2>&1)
+  provide_replication_group_yaml | kubectl apply -f - 2>&1
   exit_if_rg_config_application_failed $? "$rg_id"
 
   # ensure resource successfully created and available, check resource is as expected
-  wait_and_assert_replication_group_available_status
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
   k8s_assert_replication_group_replica_count "$rg_id" 1
   k8s_assert_replication_group_status_property "$rg_id" ".automaticFailover" "enabled"
   k8s_assert_replication_group_total_node_count "$rg_id" 2
@@ -125,14 +125,167 @@ test_modify_rg_remove_replica_disable_af() {
   # update config and apply: remove replica while disabling auto failover
   replicas_per_node_group="0"
   automatic_failover_enabled="false"
-  output_msg=$(provide_replication_group_yaml | kubectl apply -f - 2>&1)
+  provide_replication_group_yaml | kubectl apply -f - 2>&1
   exit_if_rg_config_application_failed $? "$rg_id"
 
   # wait and assert new state
-  wait_and_assert_replication_group_available_status
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
   k8s_assert_replication_group_replica_count "$rg_id" 0
   k8s_assert_replication_group_status_property "$rg_id" ".automaticFailover" "disabled"
   k8s_assert_replication_group_total_node_count "$rg_id" 1
+}
+
+# create 1 shard/no replica RG, enable autofailover while adding replicas
+test_modify_rg_enable_af_add_replicas() {
+  debug_msg "executing ${FUNCNAME[0]}"
+
+  # generate and apply yaml for replication group creation
+  clear_rg_parameter_variables
+  rg_id="test-enable-af-add-replicas"
+  num_node_groups=1
+  replicas_per_node_group=0
+  automatic_failover_enabled="false"
+  multi_az_enabled="false"
+  provide_replication_group_yaml | kubectl apply -f - 2>&1
+  exit_if_rg_config_application_failed $? "$rg_id"
+
+  # ensure resource successfully created and available, check resource is as expected
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
+  k8s_assert_replication_group_shard_count "$rg_id" 1
+  k8s_assert_replication_group_replica_count "$rg_id" 0
+  k8s_assert_replication_group_status_property "$rg_id" ".automaticFailover" "disabled"
+  k8s_assert_replication_group_status_property "$rg_id" ".multiAZ" "disabled"
+  k8s_assert_replication_group_total_node_count "$rg_id" 1
+
+  # update config and apply: enable autofailover and add replicas to satisfy enabling condition
+  replicas_per_node_group=2
+  automatic_failover_enabled="true"
+  provide_replication_group_yaml | kubectl apply -f - 2>&1
+  exit_if_rg_config_application_failed $? "$rg_id"
+
+  # wait and assert new state
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
+  k8s_assert_replication_group_shard_count "$rg_id" 1
+  k8s_assert_replication_group_replica_count "$rg_id" 2
+  k8s_assert_replication_group_status_property "$rg_id" ".automaticFailover" "enabled"
+  k8s_assert_replication_group_status_property "$rg_id" ".multiAZ" "disabled"
+  k8s_assert_replication_group_total_node_count "$rg_id" 3
+}
+
+# create replication group with one shard and one replica with custom node group configuration. Increase
+#   replicas per node group and specify preferred AZ
+test_modify_rg_increase_replica_specify_az() {
+  debug_msg "executing ${FUNCNAME[0]}"
+
+  # generate and apply yaml for replication group creation
+  clear_rg_parameter_variables
+  rg_id="rg-inc-replica-specify-az"
+  num_node_groups=1
+  replicas_per_node_group=1
+  yaml_base="$(provide_replication_group_yaml)"
+  rg_yaml=$(cat <<EOF
+$yaml_base
+    nodeGroupConfiguration:
+      - nodeGroupID: "0010"
+        primaryAvailabilityZone: us-east-1a
+        replicaAvailabilityZones:
+          - us-east-1b
+EOF
+)
+  echo "$rg_yaml" | kubectl apply -f - 2>&1
+  exit_if_rg_config_application_failed $? "$rg_id"
+
+  # ensure resource successfully created and available, check resource is as expected
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
+  k8s_assert_replication_group_shard_count "$rg_id" 1
+  k8s_assert_replication_group_replica_count "$rg_id" 1
+  k8s_assert_replication_group_total_node_count "$rg_id" 2
+
+  # update config and apply: increase replica count, specify additional AZ
+  replicas_per_node_group=2
+  yaml_base="$(provide_replication_group_yaml)"
+  rg_yaml=$(cat <<EOF
+$yaml_base
+    nodeGroupConfiguration:
+      - nodeGroupID: "0010"
+        primaryAvailabilityZone: us-east-1a
+        replicaAvailabilityZones:
+          - us-east-1b
+          - us-east-1a
+EOF
+)
+  echo "$rg_yaml" | kubectl apply -f - 2>&1
+  exit_if_rg_config_application_failed $? "$rg_id"
+
+  # wait and assert resource state
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
+  k8s_assert_replication_group_shard_count "$rg_id" 1
+  k8s_assert_replication_group_replica_count "$rg_id" 2
+  k8s_assert_replication_group_total_node_count "$rg_id" 3
+}
+
+# create a cluster mode enabled RG, then scale up while adding replicas
+test_modify_rg_cme_scale_up_add_replicas() {
+  debug_msg "executing ${FUNCNAME[0]}"
+
+  # generate and apply yaml for replication group creation
+  clear_rg_parameter_variables
+  rg_id="rg-cme-scale-up-add-replicas"
+  cache_node_type="cache.t3.micro"
+  num_node_groups="2"
+  replicas_per_node_group="1"
+  yaml_base=$(provide_replication_group_yaml)
+  rg_yaml=$(cat <<EOF
+$yaml_base
+    nodeGroupConfiguration:
+      - nodeGroupID: "0010"
+        primaryAvailabilityZone: us-east-1a
+        replicaAvailabilityZones:
+        - us-east-1b
+      - nodeGroupID: "0020"
+        primaryAvailabilityZone: us-east-1b
+        replicaAvailabilityZones:
+        - us-east-1a
+EOF
+)
+  echo "$rg_yaml" | kubectl apply -f - 2>&1
+  exit_if_rg_config_application_failed $? "$rg_id"
+
+  # ensure resource successfully created and available, check resource is as expected
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
+  k8s_assert_replication_group_shard_count "$rg_id" 2
+  k8s_assert_replication_group_replica_count "$rg_id" 1
+  k8s_assert_replication_group_total_node_count "$rg_id" 4
+  aws_assert_replication_group_property "$rg_id" ".CacheNodeType" "cache.t3.micro"
+
+  # update config and apply: scale out and add replicas
+  replicas_per_node_group="2"
+  cache_node_type="cache.t3.small"
+  yaml_base=$(provide_replication_group_yaml "$rg_id")
+  rg_yaml=$(cat <<EOF
+$yaml_base
+    nodeGroupConfiguration:
+      - nodeGroupID: "0010"
+        primaryAvailabilityZone: us-east-1a
+        replicaAvailabilityZones:
+        - us-east-1b
+        - us-east-1a
+      - nodeGroupID: "0020"
+        primaryAvailabilityZone: us-east-1b
+        replicaAvailabilityZones:
+        - us-east-1a
+        - us-east-1b
+EOF
+)
+  echo "$rg_yaml" | kubectl apply -f - 2>&1
+  exit_if_rg_config_application_failed $? "$rg_id"
+
+  # wait and assert new resource state
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
+  k8s_assert_replication_group_shard_count "$rg_id" 2
+  k8s_assert_replication_group_replica_count "$rg_id" 2
+  k8s_assert_replication_group_total_node_count "$rg_id" 6
+  aws_assert_replication_group_property "$rg_id" ".CacheNodeType" "cache.t3.small"
 }
 
 # ensure node roles are correct after failover: create a cluster mode disabled RG with one replica and
@@ -145,11 +298,11 @@ test_rg_failover_roles() {
   rg_id="rg-failover-roles"
   num_node_groups=1
   replicas_per_node_group=1
-  output_msg=$(provide_replication_group_yaml | kubectl apply -f - 2>&1)
+  provide_replication_group_yaml | kubectl apply -f - 2>&1
   exit_if_rg_config_application_failed $? "$rg_id"
 
   # ensure second RG successfully created and available, assert initial node roles
-  wait_and_assert_replication_group_available_status
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
   local shard_json=$(aws_get_replication_group_json "$rg_id" | jq -r '.NodeGroups[0]')
   local node1_role=$(echo "$shard_json" | jq -r '.NodeGroupMembers[] | select(.CacheClusterId=="rg-failover-roles-001") | .CurrentRole')
   local node2_role=$(echo "$shard_json" | jq -r '.NodeGroupMembers[] | select(.CacheClusterId=="rg-failover-roles-002") | .CurrentRole')
@@ -189,10 +342,13 @@ test_rg_failover_roles() {
 }
 
 # run tests
-test_modify_rg_negative_replicas # failing, same terminal condition "toggling" issue
+test_modify_rg_negative_replicas
 test_modify_rg_enable_auto_failover
-test_modify_rg_remove_replica_with_af_enabled # failing due to same reason
-test_modify_rg_remove_replica_disable_af # failing due to available/modifying status and member cluster count check
+test_modify_rg_remove_replica_with_af_enabled
+test_modify_rg_remove_replica_disable_af # failing due to member cluster count check even when ResourceSynced is True
+test_modify_rg_enable_af_add_replicas # failing: "inverse" to deletion case as expected; nodes present in memberClusters but not the node group
+test_modify_rg_increase_replica_specify_az # failing: Terminal condition with "1 validation error found"
+test_modify_rg_cme_scale_up_add_replicas # failing: Terminal condition with "2 validation errors" (yaml issue?)
 test_rg_failover_roles
 
 k8s_perform_rg_test_cleanup

--- a/test/e2e/elasticache/replication_group/scaling.sh
+++ b/test/e2e/elasticache/replication_group/scaling.sh
@@ -29,18 +29,18 @@ test_modify_rg_cmd_scale_out() {
   num_node_groups="1"
   replicas_per_node_group="0"
   multi_az_enabled="false"
-  output_msg=$(provide_replication_group_yaml | kubectl apply -f - 2>&1)
+  provide_replication_group_yaml | kubectl apply -f - 2>&1
   exit_if_rg_config_application_failed $? "$rg_id"
 
   # ensure resource successfully created and available, check resource is as expected
-  wait_and_assert_replication_group_available_status
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
   k8s_assert_replication_group_shard_count "$rg_id" 1
   k8s_assert_replication_group_replica_count "$rg_id" 0
 
   # update config and apply: attempt to scale out
   # config application should actually succeed in this case, but leave RG with Terminal Condition set True
   num_node_groups=2
-  output_msg=$(provide_replication_group_yaml | kubectl apply -f - 2>&1)
+  provide_replication_group_yaml | kubectl apply -f - 2>&1
   exit_if_rg_config_application_failed $? "$rg_id"
 
   # ensure terminal condition exists, is set true, and has expected message
@@ -59,20 +59,20 @@ test_modify_rg_cmd_scale_up() {
   num_node_groups=1
   replicas_per_node_group=3
   multi_az_enabled="false"
-  output_msg=$(provide_replication_group_yaml | kubectl apply -f - 2>&1)
+  provide_replication_group_yaml | kubectl apply -f - 2>&1
   exit_if_rg_config_application_failed $? "$rg_id"
 
   # ensure resource successfully created and available, check resource is as expected
-  wait_and_assert_replication_group_available_status
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
   aws_assert_replication_group_property "$rg_id" ".CacheNodeType" "cache.t3.micro"
 
   # update config and apply: scale up to larger instance
   cache_node_type="cache.t3.small"
-  output_msg=$(provide_replication_group_yaml | kubectl apply -f - 2>&1)
+  provide_replication_group_yaml | kubectl apply -f - 2>&1
   exit_if_rg_config_application_failed $? "$rg_id"
 
   # wait and assert new state
-  wait_and_assert_replication_group_available_status
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
   aws_assert_replication_group_property "$rg_id" ".CacheNodeType" "cache.t3.small"
 }
 
@@ -99,11 +99,11 @@ $yaml_base
         - us-east-1a
 EOF
 )
-  output_msg=$(echo "$rg_yaml" | kubectl apply -f - 2>&1)
+  echo "$rg_yaml" | kubectl apply -f - 2>&1
   exit_if_rg_config_application_failed $? "$rg_id"
 
   # ensure resource successfully created and available, check resource is as expected
-  wait_and_assert_replication_group_available_status
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
   k8s_assert_replication_group_shard_count "$rg_id" 2
   k8s_assert_replication_group_replica_count "$rg_id" 1
   k8s_assert_replication_group_total_node_count "$rg_id" 4
@@ -132,11 +132,11 @@ $yaml_base
         - us-east-1a
 EOF
 )
-  output_msg=$(echo "$rg_yaml" | kubectl apply -f - 2>&1)
+  echo "$rg_yaml" | kubectl apply -f - 2>&1
   exit_if_rg_config_application_failed $? "$rg_id"
 
   # wait and assert new resource state
-  wait_and_assert_replication_group_available_status
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
   k8s_assert_replication_group_shard_count "$rg_id" 3
   k8s_assert_replication_group_replica_count "$rg_id" 2
   k8s_assert_replication_group_total_node_count "$rg_id" 9
@@ -171,11 +171,11 @@ $yaml_base
         replicaCount: 2
 EOF
 )
-  output_msg=$(echo "$rg_yaml" | kubectl apply -f - 2>&1)
+  echo "$rg_yaml" | kubectl apply -f - 2>&1
   exit_if_rg_config_application_failed $? "$rg_id"
 
   # ensure resource successfully created and available, check resource is as expected
-  wait_and_assert_replication_group_available_status
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
   k8s_assert_replication_group_shard_count "$rg_id" 2
   k8s_assert_replication_group_total_node_count "$rg_id" 5 #skip checking each node group for now
 
@@ -206,11 +206,11 @@ $yaml_base
         replicaCount: 1
 EOF
 )
-  output_msg=$(echo "$rg_yaml" | kubectl apply -f - 2>&1)
+  echo "$rg_yaml" | kubectl apply -f - 2>&1
   exit_if_rg_config_application_failed $? "$rg_id"
 
   # wait and assert new resource state
-  wait_and_assert_replication_group_available_status
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
   k8s_assert_replication_group_shard_count "$rg_id" 3
   k8s_assert_replication_group_total_node_count "$rg_id" 7
 }
@@ -238,11 +238,11 @@ $yaml_base
         - us-east-1b
 EOF
 )
-  output_msg=$(echo "$rg_yaml" | kubectl apply -f - 2>&1)
+  echo "$rg_yaml" | kubectl apply -f - 2>&1
   exit_if_rg_config_application_failed $? "$rg_id"
 
   # ensure resource successfully created and available, check resource is as expected
-  wait_and_assert_replication_group_available_status
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
   k8s_assert_replication_group_shard_count "$rg_id" 2
   k8s_assert_replication_group_replica_count "$rg_id" 1
   k8s_assert_replication_group_total_node_count "$rg_id" 4
@@ -267,18 +267,18 @@ $yaml_base
         - us-east-1b
 EOF
 )
-  output_msg=$(echo "$rg_yaml" | kubectl apply -f - 2>&1)
+  echo "$rg_yaml" | kubectl apply -f - 2>&1
   exit_if_rg_config_application_failed $? "$rg_id"
 
   # wait and assert resource state
-  wait_and_assert_replication_group_available_status
+  wait_and_assert_replication_group_synced_and_available "$rg_id"
   k8s_assert_replication_group_shard_count "$rg_id" 3
   k8s_assert_replication_group_replica_count "$rg_id" 1
   k8s_assert_replication_group_total_node_count "$rg_id" 6
 }
 
 # run tests
-test_modify_rg_cmd_scale_out # currently failing, terminal condition frequently toggles (is this desired behavior?)
+test_modify_rg_cmd_scale_out
 test_modify_rg_cmd_scale_up
 test_modify_rg_cme_scale_out_add_replica # failing, terminal condition shows "2 validation errors" after new config - issue with distribution of AZs in test case?
 test_modify_rg_cme_scale_out_uneven_shards


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/aws-controllers-k8s/issues/494

Related PRs:
https://github.com/aws/aws-controllers-k8s/pull/531
https://github.com/aws/aws-controllers-k8s/pull/530

Description of changes:

- Moved some generic resource testing functions to testutil.sh as requested in pull 528
- Verified terminal condition stabilization fix, issue 494/PR 531
- Changed the wait function (for replication groups) to wait on ResourceSynced condition rather than status.status property to properly test this
- Improved test output (added output for wait loop and no longer suppressing kubectl apply output), was previously hard see what was going on in each test
- Re-added some extra tests that were saved on a local branch
- Updated kind-test target in Makefile (old target was broken because getopts was removed in pull 547)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
