### PR TITLE
Rename Status and Spec Field

### DIFF
--- a/pkg/generate/config/config.go
+++ b/pkg/generate/config/config.go
@@ -151,10 +151,13 @@ type AdditionalFieldConfig struct {
 	// OperationID refers to the ID of the API Operation where we will
 	// determine the field's Go type.
 	OperationID string `json:"operation_id,omitempty"`
-	// MemberName refers to the name of the member of the
+	// SourceName refers to the name of the member of the
 	// Input shape in the Operation identified by OperationID that
 	// we will take as our additional spec/status field.
-	MemberName string `json:"member_name"`
+	SourceName string `json:"source_name"`
+	// TargetName refers to the name that will be used instead of
+	// SourceName in the status.
+	TargetName string `json:"target_name,omitempty"`
 }
 
 type PrefixConfig struct {

--- a/pkg/generate/elasticache_test.go
+++ b/pkg/generate/elasticache_test.go
@@ -811,3 +811,19 @@ func TestElasticache_Additional_CacheSubnetGroup_Status(t *testing.T) {
 	assert := assert.New(t)
 	assert.Contains(crd.StatusFields, "Events")
 }
+
+func TestElasticache_Additional_ReplicationGroup_Status_RenameField(t *testing.T) {
+	require := require.New(t)
+
+	g := testutil.NewGeneratorForService(t, "elasticache")
+	crds, err := g.GetCRDs()
+
+	require.Nil(err)
+
+	crd := getCRDByName("ReplicationGroup", crds)
+	require.NotNil(crd)
+
+	assert := assert.New(t)
+	assert.Contains(crd.StatusFields, "AllowedScaleUpModifications")
+	assert.Contains(crd.StatusFields, "AllowedScaleDownModifications")
+}

--- a/pkg/generate/generator.go
+++ b/pkg/generate/generator.go
@@ -127,9 +127,13 @@ func (g *Generator) GetCRDs() ([]*ackmodel.CRD, error) {
 		specFieldConfigs, ok := g.cfg.SpecFieldConfigs(crdName)
 		if ok {
 			for _, specField := range specFieldConfigs {
-				memberShapeRef, found := g.SDKAPI.GetMemberInputShapeRef(specField.OperationID, specField.MemberName)
+				memberShapeRef, found := g.SDKAPI.GetMemberInputShapeRef(specField.OperationID, specField.SourceName)
 				if found {
-					crd.AddSpecField(names.New(specField.MemberName), memberShapeRef)
+					memberName := names.New(specField.SourceName)
+					if specField.TargetName != "" {
+						memberName = names.New(specField.TargetName)
+					}
+					crd.AddSpecField(memberName, memberShapeRef)
 				}
 			}
 		}
@@ -172,9 +176,13 @@ func (g *Generator) GetCRDs() ([]*ackmodel.CRD, error) {
 		// Now add the additional Status fields that are required from other API operations.
 		if statusFieldConfigs, ok := g.cfg.StatusFieldConfigs(crdName); ok {
 			for _, statusField := range statusFieldConfigs {
-				memberShapeRef, found := g.SDKAPI.GetMemberOutputShapeRef(statusField.OperationID, statusField.MemberName)
+				memberShapeRef, found := g.SDKAPI.GetMemberOutputShapeRef(statusField.OperationID, statusField.SourceName)
 				if found {
-					crd.AddStatusField(names.New(statusField.MemberName), memberShapeRef)
+					memberName := names.New(statusField.SourceName)
+					if statusField.TargetName != "" {
+						memberName = names.New(statusField.TargetName)
+					}
+					crd.AddStatusField(memberName, memberShapeRef)
 				}
 			}
 		}

--- a/pkg/generate/testdata/models/apis/elasticache/0000-00-00/generator.yaml
+++ b/pkg/generate/testdata/models/apis/elasticache/0000-00-00/generator.yaml
@@ -5,11 +5,11 @@ resources:
         404: CacheSubnetGroupNotFoundFault
     status_fields:
       - operation_id: DescribeEvents
-        member_name: Events
+        source_name: Events
   Snapshot:
     spec_fields:
       - operation_id: CopySnapshot
-        member_name: SourceSnapshotName
+        source_name: SourceSnapshotName
   CacheParameterGroup:
     exceptions:
       terminal_codes:
@@ -21,18 +21,24 @@ resources:
         - InvalidParameterValue
     spec_fields:
       - operation_id: ModifyCacheParameterGroup
-        member_name: ParameterNameValues
+        source_name: ParameterNameValues
     status_fields:
       - operation_id: DescribeCacheParameters
-        member_name: Parameters
+        source_name: Parameters
       - operation_id: DescribeEvents
-        member_name: Events
+        source_name: Events
     update_operation:
       custom_method_name: customUpdateCacheParameterGroup
   ReplicationGroup:
     status_fields:
       - operation_id: DescribeEvents
-        member_name: Events
+        source_name: Events
+      - operation_id: ListAllowedNodeTypeModifications
+        source_name: ScaleUpModifications
+        target_name: AllowedScaleUpModifications
+      - operation_id: ListAllowedNodeTypeModifications
+        source_name: ScaleDownModifications
+        target_name: AllowedScaleDownModifications
 operations:
   ModifyReplicationGroup:
     override_values:

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -186,6 +186,44 @@ func (r *CRD) InputFieldRename(
 	)
 }
 
+// AdditionStatusFieldRename returns the renamed field for the additional Status field
+// that has been added.
+func (r *CRD) AdditionStatusFieldRename(
+	origFieldName string) (*string, bool) {
+	resGenConfig, found := r.genCfg.Resources[r.Names.Original]
+
+	if !found {
+		return nil, false
+	}
+
+	for _, statusField := range resGenConfig.StatusFields {
+		if statusField.TargetName == origFieldName {
+			return &statusField.TargetName, true
+		}
+	}
+
+	return nil, false
+}
+
+// AdditionSpecFieldRename returns the renamed field for the additional Spec field
+// that has been added.
+func (r *CRD) AdditionSpecFieldRename(
+	origFieldName string) (*string, bool) {
+	resGenConfig, found := r.genCfg.Resources[r.Names.Original]
+
+	if !found {
+		return nil, false
+	}
+
+	for _, specField := range resGenConfig.StatusFields {
+		if specField.TargetName == origFieldName {
+			return &specField.TargetName, true
+		}
+	}
+
+	return nil, false
+}
+
 func (r *CRD) cleanGoType(shape *awssdkmodel.Shape) (string, string, string) {
 	// There are shapes that are called things like DBProxyStatus that are
 	// fields in a DBProxy CRD... we need to ensure the type names don't
@@ -688,6 +726,21 @@ func (r *CRD) GoCodeSetInput(
 	for memberIndex, memberName := range inputShape.MemberNames() {
 		if r.UnpacksAttributesMap() && memberName == "Attributes" {
 			continue
+		}
+
+		// Rename additional Spec or Status fields that are added.
+		{
+			renamedSpecField, renamed := r.AdditionSpecFieldRename(memberName)
+
+			if renamed {
+				memberName = *renamedSpecField
+			}
+
+			renamedStatusField, renamed := r.AdditionStatusFieldRename(memberName)
+
+			if renamed {
+				memberName = *renamedStatusField
+			}
 		}
 
 		if override {

--- a/services/elasticache/apis/v1alpha1/replication_group.go
+++ b/services/elasticache/apis/v1alpha1/replication_group.go
@@ -67,23 +67,23 @@ type ReplicationGroupStatus struct {
 	// contains a collection of `ackv1alpha1.Condition` objects that describe
 	// the various terminal states of the CR and its backend AWS service API
 	// resource
-	Conditions                 []*ackv1alpha1.Condition               `json:"conditions"`
-	AuthTokenEnabled           *bool                                  `json:"authTokenEnabled,omitempty"`
-	AuthTokenLastModifiedDate  *metav1.Time                           `json:"authTokenLastModifiedDate,omitempty"`
-	AutomaticFailover          *string                                `json:"automaticFailover,omitempty"`
-	ClusterEnabled             *bool                                  `json:"clusterEnabled,omitempty"`
-	ConfigurationEndpoint      *Endpoint                              `json:"configurationEndpoint,omitempty"`
-	Description                *string                                `json:"description,omitempty"`
-	Events                     []*Event                               `json:"events,omitempty"`
-	GlobalReplicationGroupInfo *GlobalReplicationGroupInfo            `json:"globalReplicationGroupInfo,omitempty"`
-	MemberClusters             []*string                              `json:"memberClusters,omitempty"`
-	MultiAZ                    *string                                `json:"multiAZ,omitempty"`
-	NodeGroups                 []*NodeGroup                           `json:"nodeGroups,omitempty"`
-	PendingModifiedValues      *ReplicationGroupPendingModifiedValues `json:"pendingModifiedValues,omitempty"`
-	ScaleDownModifications     []*string                              `json:"scaleDownModifications,omitempty"`
-	ScaleUpModifications       []*string                              `json:"scaleUpModifications,omitempty"`
-	SnapshottingClusterID      *string                                `json:"snapshottingClusterID,omitempty"`
-	Status                     *string                                `json:"status,omitempty"`
+	Conditions                    []*ackv1alpha1.Condition               `json:"conditions"`
+	AllowedScaleDownModifications []*string                              `json:"allowedScaleDownModifications,omitempty"`
+	AllowedScaleUpModifications   []*string                              `json:"allowedScaleUpModifications,omitempty"`
+	AuthTokenEnabled              *bool                                  `json:"authTokenEnabled,omitempty"`
+	AuthTokenLastModifiedDate     *metav1.Time                           `json:"authTokenLastModifiedDate,omitempty"`
+	AutomaticFailover             *string                                `json:"automaticFailover,omitempty"`
+	ClusterEnabled                *bool                                  `json:"clusterEnabled,omitempty"`
+	ConfigurationEndpoint         *Endpoint                              `json:"configurationEndpoint,omitempty"`
+	Description                   *string                                `json:"description,omitempty"`
+	Events                        []*Event                               `json:"events,omitempty"`
+	GlobalReplicationGroupInfo    *GlobalReplicationGroupInfo            `json:"globalReplicationGroupInfo,omitempty"`
+	MemberClusters                []*string                              `json:"memberClusters,omitempty"`
+	MultiAZ                       *string                                `json:"multiAZ,omitempty"`
+	NodeGroups                    []*NodeGroup                           `json:"nodeGroups,omitempty"`
+	PendingModifiedValues         *ReplicationGroupPendingModifiedValues `json:"pendingModifiedValues,omitempty"`
+	SnapshottingClusterID         *string                                `json:"snapshottingClusterID,omitempty"`
+	Status                        *string                                `json:"status,omitempty"`
 }
 
 // ReplicationGroup is the Schema for the ReplicationGroups API

--- a/services/elasticache/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/services/elasticache/apis/v1alpha1/zz_generated.deepcopy.go
@@ -1956,6 +1956,28 @@ func (in *ReplicationGroupStatus) DeepCopyInto(out *ReplicationGroupStatus) {
 			}
 		}
 	}
+	if in.AllowedScaleDownModifications != nil {
+		in, out := &in.AllowedScaleDownModifications, &out.AllowedScaleDownModifications
+		*out = make([]*string, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(string)
+				**out = **in
+			}
+		}
+	}
+	if in.AllowedScaleUpModifications != nil {
+		in, out := &in.AllowedScaleUpModifications, &out.AllowedScaleUpModifications
+		*out = make([]*string, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(string)
+				**out = **in
+			}
+		}
+	}
 	if in.AuthTokenEnabled != nil {
 		in, out := &in.AuthTokenEnabled, &out.AuthTokenEnabled
 		*out = new(bool)
@@ -2032,28 +2054,6 @@ func (in *ReplicationGroupStatus) DeepCopyInto(out *ReplicationGroupStatus) {
 		in, out := &in.PendingModifiedValues, &out.PendingModifiedValues
 		*out = new(ReplicationGroupPendingModifiedValues)
 		(*in).DeepCopyInto(*out)
-	}
-	if in.ScaleDownModifications != nil {
-		in, out := &in.ScaleDownModifications, &out.ScaleDownModifications
-		*out = make([]*string, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(string)
-				**out = **in
-			}
-		}
-	}
-	if in.ScaleUpModifications != nil {
-		in, out := &in.ScaleUpModifications, &out.ScaleUpModifications
-		*out = make([]*string, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(string)
-				**out = **in
-			}
-		}
 	}
 	if in.SnapshottingClusterID != nil {
 		in, out := &in.SnapshottingClusterID, &out.SnapshottingClusterID

--- a/services/elasticache/config/crd/bases/elasticache.services.k8s.aws_replicationgroups.yaml
+++ b/services/elasticache/config/crd/bases/elasticache.services.k8s.aws_replicationgroups.yaml
@@ -164,6 +164,14 @@ spec:
                 required:
                 - ownerAccountID
                 type: object
+              allowedScaleDownModifications:
+                items:
+                  type: string
+                type: array
+              allowedScaleUpModifications:
+                items:
+                  type: string
+                type: array
               authTokenEnabled:
                 type: boolean
               authTokenLastModifiedDate:
@@ -306,14 +314,6 @@ spec:
                         type: object
                     type: object
                 type: object
-              scaleDownModifications:
-                items:
-                  type: string
-                type: array
-              scaleUpModifications:
-                items:
-                  type: string
-                type: array
               snapshottingClusterID:
                 type: string
               status:

--- a/services/elasticache/generator.yaml
+++ b/services/elasticache/generator.yaml
@@ -10,7 +10,7 @@ resources:
         - InvalidSubnet
     status_fields:
       - operation_id: DescribeEvents
-        member_name: Events
+        source_name: Events
   ReplicationGroup:
     update_conditions_custom_method_name: CustomUpdateConditions
     exceptions:
@@ -32,11 +32,13 @@ resources:
         - InvalidKMSKeyFault
     status_fields:
       - operation_id: ListAllowedNodeTypeModifications
-        member_name: ScaleUpModifications
+        source_name: ScaleUpModifications
+        target_name: AllowedScaleUpModifications
       - operation_id: ListAllowedNodeTypeModifications
-        member_name: ScaleDownModifications
+        source_name: ScaleDownModifications
+        target_name: AllowedScaleDownModifications
       - operation_id: DescribeEvents
-        member_name: Events
+        source_name: Events
   Snapshot:
     update_conditions_custom_method_name: CustomUpdateConditions
     exceptions:
@@ -51,7 +53,7 @@ resources:
         - SnapshotFeatureNotSupportedFault
     spec_fields:
         - operation_id: CopySnapshot
-          member_name: SourceSnapshotName
+          source_name: SourceSnapshotName
     update_operation:
       custom_method_name: customUpdateSnapshot
   CacheParameterGroup:
@@ -65,12 +67,12 @@ resources:
         - InvalidParameterValue
     spec_fields:
       - operation_id: ModifyCacheParameterGroup
-        member_name: ParameterNameValues
+        source_name: ParameterNameValues
     status_fields:
       - operation_id: DescribeCacheParameters
-        member_name: Parameters
+        source_name: Parameters
       - operation_id: DescribeEvents
-        member_name: Events
+        source_name: Events
     update_operation:
       custom_method_name: customUpdateCacheParameterGroup
 operations:

--- a/services/elasticache/pkg/resource/replication_group/custom_set_output.go
+++ b/services/elasticache/pkg/resource/replication_group/custom_set_output.go
@@ -113,13 +113,13 @@ func (rm *resourceManager) customSetOutput(
 			rm.metrics.RecordAPICall("READ_MANY", "ListAllowedNodeTypeModifications", apiErr)
 			// Overwrite the values for ScaleUp and ScaleDown
 			if apiErr == nil {
-				ko.Status.ScaleDownModifications = resp.ScaleDownModifications
-				ko.Status.ScaleUpModifications = resp.ScaleUpModifications
+				ko.Status.AllowedScaleDownModifications = resp.ScaleDownModifications
+				ko.Status.AllowedScaleUpModifications = resp.ScaleUpModifications
 			}
 		}
 	} else {
-		ko.Status.ScaleDownModifications = nil
-		ko.Status.ScaleUpModifications = nil
+		ko.Status.AllowedScaleDownModifications = nil
+		ko.Status.AllowedScaleUpModifications = nil
 	}
 }
 


### PR DESCRIPTION
Added ability to rename the additional Status and Spec field.

For ElastiCache, updated status from ScaleUpModifications to AllowedScaleUpModifications.

```
 Allowed Scale Up Modifications:
    cache.m4.10xlarge
    cache.m4.2xlarge
    cache.m4.4xlarge
    cache.m4.large
    cache.m4.xlarge
    cache.m5.12xlarge
    cache.m5.24xlarge
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
