### PR TITLE
rm getopts strategy from provision-kind-cluster.sh

### DIFF
--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -104,7 +104,8 @@ if [ -z "$TMP_DIR" ]; then
     CLUSTER_NAME_BASE=$(uuidgen | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
     CLUSTER_NAME="ack-test-$CLUSTER_NAME_BASE"-"${TEST_ID}"
     TMP_DIR=$ROOT_DIR/build/tmp-$CLUSTER_NAME
-    $SCRIPTS_DIR/provision-kind-cluster.sh "${CLUSTER_NAME}" -v "${K8S_VERSION}"
+    export K8S_VERSION
+    $SCRIPTS_DIR/provision-kind-cluster.sh "${CLUSTER_NAME}"
 fi
 export PATH=$TMP_DIR:$PATH
 

--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -104,8 +104,7 @@ if [ -z "$TMP_DIR" ]; then
     CLUSTER_NAME_BASE=$(uuidgen | cut -d'-' -f1 | tr '[:upper:]' '[:lower:]')
     CLUSTER_NAME="ack-test-$CLUSTER_NAME_BASE"-"${TEST_ID}"
     TMP_DIR=$ROOT_DIR/build/tmp-$CLUSTER_NAME
-    export K8S_VERSION
-    $SCRIPTS_DIR/provision-kind-cluster.sh "${CLUSTER_NAME}"
+    K8S_VERSION="$K8S_VERSION" $SCRIPTS_DIR/provision-kind-cluster.sh "${CLUSTER_NAME}"
 fi
 export PATH=$TMP_DIR:$PATH
 

--- a/scripts/provision-kind-cluster.sh
+++ b/scripts/provision-kind-cluster.sh
@@ -29,7 +29,7 @@ Usage:
 
 Provisions a KinD cluster for local development and testing.
 
-Example: export K8S_VERSION=1.18; $(basename "$0") my-test
+Example: $(basename "$0") my-test
 
 Environment variables:
   K8S_VERSION               Kubernetes Version [1.14, 1.15, 1.16, 1.17, and 1.18]           

--- a/scripts/provision-kind-cluster.sh
+++ b/scripts/provision-kind-cluster.sh
@@ -15,7 +15,6 @@ check_is_installed wget
 check_is_installed docker
 check_is_installed kind "You can install kind with the helper scripts/install-kind.sh"
 
-OVERRIDE_PATH=0
 KIND_CONFIG_FILE="$SCRIPTS_DIR/kind-two-node-cluster.yaml"
 
 K8_1_18="kindest/node:v1.18.4@sha256:9ddbe5ba7dad96e83aec914feae9105ac1cffeb6ebd0d5aa42e820defe840fd4"
@@ -24,18 +23,17 @@ K8_1_16="kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac
 K8_1_15="kindest/node:v1.15.11@sha256:6cc31f3533deb138792db2c7d1ffc36f7456a06f1db5556ad3b6927641016f50"
 K8_1_14="kindest/node:v1.14.10@sha256:6cd43ff41ae9f02bb46c8f455d5323819aec858b99534a290517ebc181b443c6"
 
-K8_VERSION="$K8_1_16"
-
 USAGE="
 Usage:
-  $(basename "$0") CLUSTER_NAME [-v K8S_VERSION]
+  $(basename "$0") CLUSTER_NAME
 
 Provisions a KinD cluster for local development and testing.
 
-Example: $(basename "$0") my-test -v 1.16
+Example: export K8S_VERSION=1.18; $(basename "$0") my-test
 
-      Optional:
-        -v          K8s version to use in this test
+Environment variables:
+  K8S_VERSION               Kubernetes Version [1.14, 1.15, 1.16, 1.17, and 1.18]           
+                            Default: 1.16
 "
 
 cluster_name="$1"
@@ -45,26 +43,21 @@ if [[ -z "$cluster_name" ]]; then
     exit 1
 fi
 
-shift
+# Process K8_VERSION env var
 
-# Process our input arguments
-while getopts "b:i:v:k:" opt; do
-  case ${opt} in
-    v ) # K8s version to provision
-        OPTARG="K8_$(echo "${OPTARG}" | sed 's/\./\_/g')"
-        if [ ! -z ${OPTARG+x} ]; then
-            K8_VERSION=${!OPTARG}
-        else
-            echo "K8s version not supported" 1>&2
-            exit 2
-        fi
-      ;;
-    \? )
-        echo "${USAGE}" 1>&2
-        exit
-      ;;
-  esac
-done
+if [ ! -z ${K8_VERSION} ]; then
+    K8_VER="K8_$(echo "${K8_VERSION}" | sed 's/\./\_/g')"
+    K8_VERSION=${!K8_VER}
+    
+    # Check if version is supported:
+    if [ -z $K8_VERSION ]; then
+        echo "Version set: $K8_VER"
+        echo "K8s version not supported" 1>&2
+        exit 2
+    fi
+else
+    K8_VERSION=${K8_1_16}
+fi
 
 TMP_DIR=$ROOT_DIR/build/tmp-$cluster_name
 mkdir -p "${TMP_DIR}"


### PR DESCRIPTION
Efforts part of Issue #504
Refactoring stage: Argument variable values as env variables instead of getopts strategy
Script: provision-kind-cluster.sh

Description of changes:
- Replaced getopts strategy with a fixed number of arguments and env variables.
- Removed unused variable OVERRIDE_PATH.
- Fixed reference to this script from kind-build-test.sh.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
