### PR TITLE
fix e2e execution in GH workflow

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -37,6 +37,6 @@ jobs:
         run: |
           export AWS_ROLE_ARN=$(aws ssm get-parameter --name ACK_ROLE_ARN | jq -r '.Parameter.Value')
           export AWS_ROLE_ARN_ALT=$(aws ssm get-parameter --name ACK_ROLE_ARN_ALT | jq -r '.Parameter.Value')
-          ./scripts/kind-build-test.sh -s $SERVICE -r $AWS_ROLE_ARN
+          ./scripts/kind-build-test.sh $SERVICE $AWS_ROLE_ARN
         env:
           SERVICE: ${{ matrix.service }}


### PR DESCRIPTION
When we merged the fixes to kind-build-test.sh we forgot to update the
execution in the workflow to remove the CLI args and replace with
params.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
