### PR TITLE
Update terminal conditions for SDK Find

### DIFF
--- a/services/elasticache/pkg/resource/cache_parameter_group/manager.go
+++ b/services/elasticache/pkg/resource/cache_parameter_group/manager.go
@@ -85,7 +85,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }

--- a/services/elasticache/pkg/resource/cache_subnet_group/manager.go
+++ b/services/elasticache/pkg/resource/cache_subnet_group/manager.go
@@ -85,7 +85,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }

--- a/services/elasticache/pkg/resource/replication_group/manager.go
+++ b/services/elasticache/pkg/resource/replication_group/manager.go
@@ -85,7 +85,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }

--- a/services/elasticache/pkg/resource/snapshot/manager.go
+++ b/services/elasticache/pkg/resource/snapshot/manager.go
@@ -85,7 +85,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }

--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -72,7 +72,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }


### PR DESCRIPTION
InvalidParameterCombination exception can be thrown for Elasticache snapshot find. This results in endless exceptions and no status change in `kubectl get or describe`

After the change terminal condition is set.

```
"conditions": [
            {
                "message": "Cannot specify both ReplicationGroupId and CacheClusterId",
                "status": "True",
                "type": "ACK.Terminal"
            }
        ]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
