### PR TITLE
Generate printer columns for service controller CRDs

### DIFF
--- a/pkg/generate/config/field.go
+++ b/pkg/generate/config/field.go
@@ -37,6 +37,10 @@ type FieldConfig struct {
 	// IsReadOnly indicates the field's value can not be set by a Kubernetes
 	// user; in other words, the field should go in the CR's Status struct
 	IsReadOnly bool `json:"is_read_only"`
+	// IsPrintable determines whether the field should be included in the
+	// AdditionalPrinterColumns list to be included in the `kubectl get`
+	// response.
+	IsPrintable bool `json:"is_printable"`
 	// ContainsOwnerAccountID indicates the field contains the AWS Account ID
 	// that owns the resource. This is a special field that we direct to
 	// storage in the common `Status.ACKResourceMetadata.OwnerAccountID` field.

--- a/pkg/generate/config/field.go
+++ b/pkg/generate/config/field.go
@@ -40,7 +40,7 @@ type FieldConfig struct {
 	// IsPrintable determines whether the field should be included in the
 	// AdditionalPrinterColumns list to be included in the `kubectl get`
 	// response.
-	IsPrintable bool `json:"is_printable"`
+	IsPrintable bool `json:"is_printable,omitempty"`
 	// ContainsOwnerAccountID indicates the field contains the AWS Account ID
 	// that owns the resource. This is a special field that we direct to
 	// storage in the common `Status.ACKResourceMetadata.OwnerAccountID` field.

--- a/pkg/generate/generator.go
+++ b/pkg/generate/generator.go
@@ -143,7 +143,7 @@ func (g *Generator) GetCRDs() ([]*ackmodel.CRD, error) {
 				memberNames := names.New(targetFieldName)
 				field := crd.AddSpecField(memberNames, memberShapeRef)
 
-				if specField.PrintableColumn {
+				if fieldConfig.IsPrintable {
 					crd.AddSpecPrintableColumn(field)
 				}
 			} else {
@@ -210,7 +210,7 @@ func (g *Generator) GetCRDs() ([]*ackmodel.CRD, error) {
 				memberNames := names.New(targetFieldName)
 				field := crd.AddStatusField(memberNames, memberShapeRef)
 
-				if statusField.PrintableColumn {
+				if fieldConfig.IsPrintable {
 					crd.AddStatusPrintableColumn(field)
 				}
 			} else {

--- a/pkg/generate/generator.go
+++ b/pkg/generate/generator.go
@@ -141,7 +141,11 @@ func (g *Generator) GetCRDs() ([]*ackmodel.CRD, error) {
 			)
 			if found {
 				memberNames := names.New(targetFieldName)
-				crd.AddSpecField(memberNames, memberShapeRef)
+				field := crd.AddSpecField(memberNames, memberShapeRef)
+
+				if specField.PrintableColumn {
+					crd.AddSpecPrintableColumn(field)
+				}
 			} else {
 				// This is a compile-time failure, just bomb out...
 				msg := fmt.Sprintf(
@@ -204,7 +208,11 @@ func (g *Generator) GetCRDs() ([]*ackmodel.CRD, error) {
 			)
 			if found {
 				memberNames := names.New(targetFieldName)
-				crd.AddStatusField(memberNames, memberShapeRef)
+				field := crd.AddStatusField(memberNames, memberShapeRef)
+
+				if statusField.PrintableColumn {
+					crd.AddStatusPrintableColumn(field)
+				}
 			} else {
 				// This is a compile-time failure, just bomb out...
 				msg := fmt.Sprintf(

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -57,6 +57,14 @@ func (ops CRDOps) IterOps() []*awssdkmodel.Operation {
 	return res
 }
 
+// CRDPrinterColumn represents a single field in the CRD's Spec or Status objects
+type CRDPrinterColumn struct {
+	CRD      *CRD
+	Name     string
+	Type     string
+	JSONPath string
+}
+
 // CRDField represents a single field in the CRD's Spec or Status objects
 type CRDField struct {
 	CRD               *CRD
@@ -112,6 +120,10 @@ type CRD struct {
 	Kind   string
 	Plural string
 	Ops    CRDOps
+	// AdditionalPrinterColumns is an array of CRDPrinterColumn objects
+	// representing the printer column settings for the CRD
+	// AdditionalPrinterColumns field.
+	AdditionalPrinterColumns []*CRDPrinterColumn
 	// SpecFields is a map, keyed by the **original SDK member name** of
 	// CRDField objects representing those fields in the CRD's Spec struct
 	// field.
@@ -235,9 +247,10 @@ func (r *CRD) cleanGoType(shape *awssdkmodel.Shape) (string, string, string) {
 func (r *CRD) AddSpecField(
 	memberNames names.Names,
 	shapeRef *awssdkmodel.ShapeRef,
-) {
+) *CRDField {
 	crdField := newCRDField(r, memberNames, shapeRef, nil)
 	r.SpecFields[memberNames.Original] = crdField
+	return crdField
 }
 
 // AddStatusField adds a new CRDField of a given name and shape into the Status
@@ -245,9 +258,10 @@ func (r *CRD) AddSpecField(
 func (r *CRD) AddStatusField(
 	memberNames names.Names,
 	shapeRef *awssdkmodel.ShapeRef,
-) {
+) *CRDField {
 	crdField := newCRDField(r, memberNames, shapeRef, nil)
 	r.StatusFields[memberNames.Original] = crdField
+	return crdField
 }
 
 // AddTypeImport adds an entry in the CRD's TypeImports map for an import line
@@ -270,6 +284,79 @@ func (r *CRD) SpecFieldNames() []string {
 	}
 	sort.Strings(res)
 	return res
+}
+
+// AddPrintableColumn adds an entry to the list of additional printer columns
+// using the given path and field types.
+func (r *CRD) AddPrintableColumn(
+	field *CRDField,
+	jsonPath string,
+) *CRDPrinterColumn {
+	fieldColumnType := field.GoTypeElem
+
+	// Printable columns must be primitives supported by the OpenAPI list of data
+	// types as defined by
+	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types
+	acceptableColumnMaps := map[string]string{
+		"string":  "string",
+		"boolean": "boolean",
+		"int":     "integer",
+		"int8":    "integer",
+		"int16":   "integer",
+		"int32":   "integer",
+		"int64":   "integer",
+		"uint":    "integer",
+		"uint8":   "integer",
+		"uint16":  "integer",
+		"uint32":  "integer",
+		"uint64":  "integer",
+		"uintptr": "integer",
+		"float32": "number",
+		"float64": "number",
+	}
+	printColumnType, exists := acceptableColumnMaps[fieldColumnType]
+
+	if !exists {
+		msg := fmt.Sprintf(
+			"GENERATION FAILURE! Unable to generate a printer column for the field %s that has type %s.",
+			field.Names.Camel, fieldColumnType,
+		)
+		panic(msg)
+		return nil
+	}
+
+	column := &CRDPrinterColumn{
+		CRD:      r,
+		Name:     field.Names.Camel,
+		Type:     printColumnType,
+		JSONPath: jsonPath,
+	}
+	r.AdditionalPrinterColumns = append(r.AdditionalPrinterColumns, column)
+	return column
+}
+
+// AddSpecPrintableColumn adds an entry to the list of additional printer columns
+// using the path of the given spec field.
+func (r *CRD) AddSpecPrintableColumn(
+	field *CRDField,
+) *CRDPrinterColumn {
+	return r.AddPrintableColumn(
+		field,
+		//TODO(nithomso): Ideally we'd use `r.genCfg.PrefixConfig.SpecField` but it uses uppercase
+		fmt.Sprintf("%s.%s", ".spec", field.Names.CamelLower),
+	)
+}
+
+// AddStatusPrintableColumn adds an entry to the list of additional printer columns
+// using the path of the given status field.
+func (r *CRD) AddStatusPrintableColumn(
+	field *CRDField,
+) *CRDPrinterColumn {
+	return r.AddPrintableColumn(
+		field,
+		//TODO(nithomso): Ideally we'd use `r.genCfg.PrefixConfig.StatusField` but it uses uppercase
+		fmt.Sprintf("%s.%s", ".status", field.Names.CamelLower),
+	)
 }
 
 // UnpacksAttributesMap returns true if the underlying API has
@@ -2431,14 +2518,15 @@ func NewCRD(
 	kind := crdNames.Camel
 	plural := pluralize.Plural(kind)
 	return &CRD{
-		sdkAPI:       sdkAPI,
-		genCfg:       genCfg,
-		Names:        crdNames,
-		Kind:         kind,
-		Plural:       plural,
-		Ops:          crdOps,
-		SpecFields:   map[string]*CRDField{},
-		StatusFields: map[string]*CRDField{},
+		sdkAPI:                   sdkAPI,
+		genCfg:                   genCfg,
+		Names:                    crdNames,
+		Kind:                     kind,
+		Plural:                   plural,
+		Ops:                      crdOps,
+		AdditionalPrinterColumns: make([]*CRDPrinterColumn, 0),
+		SpecFields:               map[string]*CRDField{},
+		StatusFields:             map[string]*CRDField{},
 	}
 }
 

--- a/pkg/model/crd.go
+++ b/pkg/model/crd.go
@@ -297,6 +297,7 @@ func (r *CRD) AddPrintableColumn(
 	// Printable columns must be primitives supported by the OpenAPI list of data
 	// types as defined by
 	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types
+	// This maps Go type to OpenAPI type.
 	acceptableColumnMaps := map[string]string{
 		"string":  "string",
 		"boolean": "boolean",

--- a/services/sagemaker/generator.yaml
+++ b/services/sagemaker/generator.yaml
@@ -1,20 +1,4 @@
 resources:
-  TrainingJob:
-    exceptions:
-      codes:
-        404: ValidationException
-    status_fields:
-    - operation_id: DescribeTrainingJob
-      source_name: TrainingJobStatus
-      printable_column: true
-    - operation_id: DescribeTrainingJob
-      source_name: SecondaryStatus
-      printable_column: true
-    - operation_id: DescribeTrainingJob
-      source_name: FailureReason
-      printable_column: true
-    - operation_id: DescribeTrainingJob
-      source_name: DebugRuleEvaluationStatuses
   Model:
     exceptions:
       errors:

--- a/services/sagemaker/generator.yaml
+++ b/services/sagemaker/generator.yaml
@@ -1,4 +1,20 @@
 resources:
+  TrainingJob:
+    exceptions:
+      codes:
+        404: ValidationException
+    status_fields:
+    - operation_id: DescribeTrainingJob
+      source_name: TrainingJobStatus
+      printable_column: true
+    - operation_id: DescribeTrainingJob
+      source_name: SecondaryStatus
+      printable_column: true
+    - operation_id: DescribeTrainingJob
+      source_name: FailureReason
+      printable_column: true
+    - operation_id: DescribeTrainingJob
+      source_name: DebugRuleEvaluationStatuses
   Model:
     exceptions:
       errors:

--- a/templates/apis/crd.go.tpl
+++ b/templates/apis/crd.go.tpl
@@ -41,6 +41,9 @@ type {{ .CRD.Kind }}Status struct {
 // {{ .CRD.Kind }} is the Schema for the {{ .CRD.Plural }} API
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+{{- range $column := .CRD.AdditionalPrinterColumns }}
+// +kubebuilder:printcolumn:name="{{$column.Name}}",type={{$column.Type}},JSONPath=`{{$column.JSONPath}}`
+{{- end }}
 type {{ .CRD.Kind }} struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Issue #, if available: #561 

Description of changes:
Adds support for "AdditionalPrinterColumns" (generated by `controller-gen`).

Both status and spec fields in the `generator.yaml` file now have an additional `printable_column` boolean. If enabled, the generator will add the target field as a printable column annotation.

Please give me feedback on how best to map the golang field types to OpenAPI data types - this may already be elsewhere in the code that I was unable to find.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
