### PR TITLE
option to setup prometheus during kind-test

### DIFF
--- a/kind-setup/prometheus/prometheus-setup.yaml
+++ b/kind-setup/prometheus/prometheus-setup.yaml
@@ -1,0 +1,97 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: ack-system
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 15s
+    scrape_configs:
+      - job_name: 'service-endpoints'
+        kubernetes_sd_configs:
+          - role: endpoints
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-cluster-role
+rules:
+  - apiGroups: [""]
+    resources:
+      - nodes
+      - services
+      - endpoints
+      - pods
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources:
+      - configmaps
+    verbs: ["get"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-service-account
+  namespace: ack-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-cluster-role
+subjects:
+  - kind: ServiceAccount
+    name: prometheus-service-account
+    namespace: ack-system
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-deployment
+  namespace: ack-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+  template:
+    metadata:
+      labels:
+        app: prometheus
+    spec:
+      containers:
+        - name: prometheus-cont
+          image: prom/prometheus
+          ports:
+            - containerPort: 9090
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/prometheus/prometheus.yml
+              subPath: prometheus.yml
+      volumes:
+        - name: config-volume
+          configMap:
+            name: prometheus-config
+      serviceAccountName: prometheus-service-account
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: prometheus-service
+  namespace: ack-system
+spec:
+  selector:
+    app: prometheus
+  ports:
+    - name: prometheusmetricsport
+      nodePort: 30900
+      protocol: TCP
+      port: 9090
+      targetPort: 9090
+  type: NodePort

--- a/pkg/generate/ack/controller.go
+++ b/pkg/generate/ack/controller.go
@@ -26,6 +26,7 @@ import (
 var (
 	controllerConfigTemplatePaths = []string{
 		"config/controller/deployment.yaml.tpl",
+		"config/controller/service.yaml.tpl",
 		"config/controller/kustomization.yaml.tpl",
 		"config/default/kustomization.yaml.tpl",
 		"config/rbac/cluster-role-binding.yaml.tpl",

--- a/scripts/kind-two-node-cluster.yaml
+++ b/scripts/kind-two-node-cluster.yaml
@@ -9,3 +9,8 @@ nodes:
         metadata:
           name: config
   - role: worker
+    extraPortMappings: # Host machine to Prometheus service reachability
+      - containerPort: 30900
+        hostPort: 9090
+        listenAddress: "0.0.0.0" # Optional, defaults to "0.0.0.0"
+        protocol: tcp # Optional, defaults to tcp

--- a/services/elasticache/config/controller/deployment.yaml
+++ b/services/elasticache/config/controller/deployment.yaml
@@ -36,6 +36,8 @@ spec:
         - "$(ACK_LOG_LEVEL)"
         image: controller:latest
         name: controller
+        ports:
+          - containerPort: 8080
         resources:
           limits:
             cpu: 100m

--- a/services/elasticache/config/controller/kustomization.yaml
+++ b/services/elasticache/config/controller/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - deployment.yaml
+- service.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:

--- a/services/elasticache/config/controller/service.yaml
+++ b/services/elasticache/config/controller/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ack-elasticache-metrics-service
+  namespace: ack-system
+spec:
+  selector:
+    control-plane: controller
+  ports:
+    - name: metricsport
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  type: NodePort

--- a/templates/config/controller/deployment.yaml.tpl
+++ b/templates/config/controller/deployment.yaml.tpl
@@ -36,6 +36,8 @@ spec:
         - "$(ACK_LOG_LEVEL)"
         image: controller:latest
         name: controller
+        ports:
+          - containerPort: 8080
         resources:
           limits:
             cpu: 100m

--- a/templates/config/controller/kustomization.yaml.tpl
+++ b/templates/config/controller/kustomization.yaml.tpl
@@ -1,5 +1,6 @@
 resources:
 - deployment.yaml
+- service.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:

--- a/templates/config/controller/service.yaml.tpl
+++ b/templates/config/controller/service.yaml.tpl
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ack-{{ .ServiceIDClean }}-metrics-service
+  namespace: ack-system
+spec:
+  selector:
+    control-plane: controller
+  ports:
+    - name: metricsport
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  type: NodePort

--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -47,6 +47,8 @@ spec:
         - "$(ACK_LOG_LEVEL)"
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         name: controller
+        ports:
+          - containerPort: {{ .Values.deployment.containerPort }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
         env:

--- a/templates/helm/values.yaml.tpl
+++ b/templates/helm/values.yaml.tpl
@@ -14,6 +14,7 @@ fullnameOverride: ""
 deployment:
   annotations: {}
   labels: {}
+  containerPort: 8080
 
 resources:
   requests:


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Adds container ports in deployment files for metrics discovery
* Option to setup prometheus during kind-test (default false):

Use with `make kind-test`:
```
ENABLE_PROMETHEUS=true make kind-test
```
Upon setup, the prometheus URL (http://localhost:9090) can be accessed on host machine.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
