### PR TITLE
pass selinux labels to docker mount in daws

### DIFF
--- a/scripts/lib/aws.sh
+++ b/scripts/lib/aws.sh
@@ -23,7 +23,7 @@ DEFAULT_AWS_CLI_VERSION="2.0.52"
 daws() {
     aws_cli_img_version=${ACK_AWS_CLI_IMAGE_VERSION:-$DEFAULT_AWS_CLI_VERSION}
     aws_cli_img="amazon/aws-cli:$aws_cli_img_version"
-    docker run --rm -v ~/.aws:/root/.aws  -v $(pwd):/aws "$aws_cli_img" "$@"
+    docker run --rm -v ~/.aws:/root/.aws:z  -v $(pwd):/aws "$aws_cli_img" "$@"
 }
 
 # aws_check_credentials() calls the STS::GetCallerIdentity API call and


### PR DESCRIPTION
pass the `z` flag to the docker volume for the AWS credentials when
launching aws-cli Docker image in `daws` script utility.

On Fedora/RHEL systems, this is necessary otherwise the aws-cli in the
Docker image won't be able to read the .aws credentials directory
properly.

ref: https://github.com/aws/aws-cli/issues/5811
ref: https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
