### PR TITLE
Fixes for Snapshot failures

### DIFF
--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -156,15 +156,15 @@ func (r *reconciler) sync(
 
 	latest, err := rm.ReadOne(ctx, desired)
 	if err != nil {
-		if latest != nil {
-			// this indicates, that even though ReadOne failed
-			// there is some changes available in the latest.RuntimeObject()
-			// (example: ko.Status.Conditions) which have been
-			// updated in the resource
-			// Thus, patchResource() call should be made here
-			_ = r.patchResource(ctx, desired, latest)
-		}
 		if err != ackerr.NotFound {
+			if latest != nil {
+				// this indicates, that even though ReadOne failed
+				// there is some changes available in the latest.RuntimeObject()
+				// (example: ko.Status.Conditions) which have been
+				// updated in the resource
+				// Thus, patchResource() call should be made here
+				_ = r.patchResource(ctx, desired, latest)
+			}
 			return err
 		}
 		if isAdopted {

--- a/services/elasticache/pkg/resource/snapshot/custom_update_api.go
+++ b/services/elasticache/pkg/resource/snapshot/custom_update_api.go
@@ -25,5 +25,5 @@ func (rm *resourceManager) customUpdateSnapshot(
 	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
-	return desired, nil
+	return latest, nil
 }


### PR DESCRIPTION
Fixes for Snapshot failures:
```
1. Fix snapshot crud failures:
   Cause: update did not save the sync status condition
   Fix: update() needed to return latest retrieved.
2. Fix endless reconciler loop:
   Cause: ReadOne->onError() sets terminal condition to false using patchResource,
     followed by error returned from Create() leads to
     setting terminal condition to true using patchResource;
     causing reconciler loop.
   Fix: ensure patchResource is invoked once in the reconciler::sync()
3 Snapshots e2e tests fix - updated scenarios where create snapshot expects either Replication Group or Cache Cluster Id and fails if other is supplied.
```

Testing done:
```
1. Snapshot e2e tests passed.
2. apigatewayv2 e2e tests passed.
```

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
