### PR TITLE
update release and publish scripts for ECR

### DIFF
--- a/docs/contents/dev-docs/release.md
+++ b/docs/contents/dev-docs/release.md
@@ -32,9 +32,9 @@ release version for the controller along with the AWS service. For example,
 assume a release semver tag of `v0.1.0` that includes service controllers for
 S3 and SNS. There would be two Docker images built for this release, one each
 containing the ACK service controllers for S3 and SNS. The Docker images would
-have the following image tags: `s3-controller-v0.1.0` and
-`sns-controller-v0.1.0`. Note that the full image name would be
-`amazon/aws-controllers-k8s:s3-v0.1.0`
+have the following image tags: `s3-v0.1.0` and `sns-v0.1.0`. Note
+that the full image name would be
+`public.ecr.aws/aws-controllers-k8s/controller:s3-v0.1.0`
 
 The Helm chart artifact can be used to install the ACK service controller as a
 Kubernetes Deployment; the Deployment's Pod image will refer to the exact
@@ -86,19 +86,100 @@ git commit -a -m "release artifacts for release $RELEASE_VERSION"
 
 5. Get your pull request reviewed and merged.
 
-6. Upon merging the pull request, a Github Action should trigger that does the
-   following:
+6. Upon merging the pull request
 
 ```bash
 git tag -a $RELEASE_VERSION $( git rev-parse HEAD )
 git push upstream main --tags
 ```
 
+!!! todo
+    A Github Action should execute the above
+
 which will end up associating a Git tag (and therefore a Github release) with
 the SHA1 commit ID of the source code for the controllers and the release
 artifacts you built for that release version.
 
-The same Github Action should run the `scripts/publish-controller-images.sh`
-script to build the Docker images for the service controllers included in the
-release and push the images to the `amazon/aws-controllers-k8s` image
-repository.
+7. Publish the controller images
+
+First, ensure you are logged in to the ECR public repository:
+
+```bash
+aws --profile ecrpush ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin public.ecr.aws
+Login Succeeded
+```
+
+!!! note
+    Above, I have a set of AWS CLI credentials in a profile called "ecrpush"
+    that I use for pushing to the ACK public ECR repository. You will need
+    something similar.
+
+Now publish all the controller images to the ECR public repository for
+controller images:
+
+```bash
+export DOCKER_REPOSITORY=public.ecr.aws/aws-controllers-k8s/controller
+for SERVICE in s3 sns; 
+    do ./scripts/publish-controller-image.sh $SERVICE
+done
+```
+
+!!! todo
+
+    The same Github Action should run the
+    `scripts/publish-controller-images.sh` script to build the Docker images
+    for the service controllers included in the release and push the images to
+    the `public.ecr.aws/aws-controllers-k8s/controller` image repository.
+
+8. Publish the Helm Charts
+
+First, ensure you are logged in to the ECR public repository for Helm:
+
+```bash
+aws --profile ecrpush ecr-public get-login-password --region us-east-1 | HELM_EXPERIMENTAL_OCI=1 helm registry login -u AWS --password-stdin public.ecr.aws
+Login succeeded
+```
+
+!!! note
+    Above, I have a set of AWS CLI credentials in a profile called "ecrpush"
+    that I use for pushing to the ACK public ECR repository. You will need
+    something similar.
+
+Now publish all the controller images to the ECR public repository for
+controller images using the `scripts/helm-publish-charts.sh` script:
+
+```bash
+RELEASE_VERSION=v0.0.1 ./scripts/helm-publish-charts.sh 
+Generating Helm chart package for apigatewayv2@v0.0.1 ... ref:     public.ecr.aws/aws-controllers-k8s/chart:apigatewayv2-v0.0.1
+digest:  0e24159c9afb840677ba64e63c19a65a6de2dcc87e80df95b3daf0cdb5c54de6
+size:    6.4 KiB
+name:    ack-apigatewayv2-controller
+version: v0.0.1
+apigatewayv2-v0.0.1: saved
+ok.
+The push refers to repository [public.ecr.aws/aws-controllers-k8s/chart]
+ref:     public.ecr.aws/aws-controllers-k8s/chart:apigatewayv2-v0.0.1
+digest:  0e24159c9afb840677ba64e63c19a65a6de2dcc87e80df95b3daf0cdb5c54de6
+size:    6.4 KiB
+name:    ack-apigatewayv2-controller
+version: v0.0.1
+apigatewayv2-v0.0.1: pushed to remote (1 layer, 6.4 KiB total)
+<snip>
+Generating Helm chart package for sns@v0.0.1 ... ref:     public.ecr.aws/aws-controllers-k8s/chart:sns-v0.0.1
+digest:  d5c1a79f85f8c320210c3418e7175da5398fba4e5644cd49f107c19db9e1e6d1
+size:    4.0 KiB
+name:    ack-sns-controller
+version: v0.0.1
+sns-v0.0.1: saved
+ok.
+The push refers to repository [public.ecr.aws/aws-controllers-k8s/chart]
+ref:     public.ecr.aws/aws-controllers-k8s/chart:sns-v0.0.1
+digest:  d5c1a79f85f8c320210c3418e7175da5398fba4e5644cd49f107c19db9e1e6d1
+size:    4.0 KiB
+name:    ack-sns-controller
+version: v0.0.1
+sns-v0.0.1: pushed to remote (1 layer, 4.0 KiB total)
+```
+
+All services that have had a Helm chart generated from step #2 will have a
+corresponding Helm chart pushed to the ECR public repository.

--- a/docs/contents/user-docs/install.md
+++ b/docs/contents/user-docs/install.md
@@ -10,47 +10,102 @@ In the following we walk you through installing an ACK service controller.
     for a particular AWS API.
 
 Each ACK service controller is packaged into a separate container image,
-published on the [`amazon/aws-controllers-k8s` DockerHub repository][0].
+published on a [public ECR repository][controller-repo].
 
-[0]: https://hub.docker.com/r/amazon/aws-controllers-k8s
+[controller-repo]: https://gallery.ecr.aws/aws-controllers-k8s/controller
 
 Individual ACK service controllers are tagged with `$SERVICE-$VERSION` Docker
 image tags, allowing you to download/test specific ACK service controllers. For
 example, if you wanted to test the `v0.1.0` release image of the ACK service
-controller for S3, you would pull the `amazon/aws-controllers-k8s:s3-v0.1.0`
-image.
+controller for S3, you would pull the
+`public.ecr.aws/aws-controllers-k8s/controller:s3-v0.1.0` image.
+
+!!! note "No 'latest' tag"
+    It is [not good practice][no-latest-tag] to rely on a `:latest` default
+    image tag. There are actually no images tagged with a `:latest` tag in our
+    image repositories. You should always specify a `$SERVICE-$VERSION` tag
+    when referencing an ACK service controller image.
+
+[no-latest-tag]: https://vsupalov.com/docker-latest-tag/
 
 ## Helm (recommended)
 
 The recommended way to install an ACK service controller for Kubernetes is to
-use Helm 3. Please ensure you have installed Helm 3 to your local environment
-before running these steps.
+use Helm 3. Please ensure you have [installed Helm 3][install-helm] to your
+local environment before running these steps.
 
-Before installing an ACK service controller, ensure you have added the
-AWS Controllers for Kubernetes Helm repository:
+[install-helm]: https://helm.sh/docs/intro/install/
 
+Each ACK service controller has a separate Helm chart that installs—as a
+Kubernetes `Deployment`—the ACK service controller, necessary custom resource
+definitions (CRDs), Kubernetes RBAC manifests, and other supporting artifacts.
+
+To view the Helm charts available for installation, check the ECR public
+repository for the [ACK Helm charts][charts-repo]. Click on the "Image tags"
+tab and take a note of the Helm chart tag for the service controller and
+version you wish to install.
+
+[charts-repo]: https://gallery.ecr.aws/aws-controllers-k8s/chart
+
+Before installing a Helm chart, you must first make the Helm chart available on
+the deployment host. To do so, use the `helm chart pull` and `helm chart
+export` commands:
+
+```bash
+export HELM_EXPERIMENTAL_OCI=1
+export SERVICE=s3
+export RELEASE_VERSION=v0.0.1
+export CHART_EXPORT_PATH=/tmp/chart
+export CHART_REPO=public.ecr.aws/aws-controllers-k8s/chart
+export CHART_REF=$CHART_REPO:$SERVICE-$RELEASE_VERSION
+
+mkdir -p $CHART_EXPORT_PATH
+
+helm chart pull $CHART_REF
+helm chart export $CHART_REF --destination $CHART_EXPORT_PATH
 ```
-helm repo add ack https://aws.github.io/aws-controllers-k8s/charts
-```
 
-Likewise, each ACK service controller has a separate Helm chart that
-installs—as a Kubernetes `Deployment`—the ACK service controller, necessary
-custom resource definitions (CRDs), Kubernetes RBAC manifests, and other
-supporting artifacts.
-
-You may install a particular ACK service controller using the `helm install`
+You then install a particular ACK service controller using the `helm install`
 CLI command:
 
+```bash
+export ACK_K8S_NAMESPACE=ack-system
+
+kubectl create namespace $ACK_K8S_NAMESPACE
+
+helm install --namespace $ACK_K8S_NAMESPACE ack-$SERVICE-controller \
+    $CHART_EXPORT_PATH/ack-$SERVICE-controller
 ```
-helm install [--namespace $KUBERNETES_NAMESPACE] ack-$SERVICE-controller ack/ack-$SERVICE-controller
+
+You will see the Helm chart installed:
+
+```
+$ helm install --namespace $ACK_K8S_NAMESPACE ack-$SERVICE-controller $CHART_EXPORT_PATH/ack-$SERVICE-controller
+NAME: ack-s3-controller
+LAST DEPLOYED: Thu Dec 17 13:09:17 2020
+NAMESPACE: ack-system
+STATUS: deployed
+REVISION: 1
+TEST SUITE: None
 ```
 
-for example, if you wanted to install the latest ACK service controller for S3
-into the "ack-system" Kubernetes namespace, you would execute:
+You may then verify the Helm chart was installed using the `helm list` command:
 
+```bash
+helm list --namespace $ACK_K8S_NAMESPACE -o yaml
+```
 
-```sh
-helm install --namespace ack-system ack-s3-controller ack/ack-s3-controller
+you should see your newly-deployed Helm chart release:
+
+```
+$ helm list --namespace $ACK_K8S_NAMESPACE -o yaml
+- app_version: v0.0.1
+  chart: ack-s3-controller-v0.0.1
+  name: ack-s3-controller
+  namespace: ack-system
+  revision: "1"
+  status: deployed
+  updated: 2020-12-17 13:09:17.309002201 -0500 EST
 ```
 
 ## Static Kubernetes manifests
@@ -64,19 +119,4 @@ release from the [list of releases][1] for AWS Controllers for Kubernetes.
 
 [1]: https://github.com/aws/aws-controllers-k8s/releases
 
-You will see a list of Assets for the release. One of those Assets will be
-named `services/$SERVICE/all-resources.yaml`. For example, for the ACK service
-controller for S3, there will be an Asset named
-`services/s3/all-resources.yaml` attached to the release. Click on the link to
-download the YAML file. This YAML file may be fed to `kubectl apply -f`
-directly to install the service controller, any CRDs that it manages, and all
-necessary Kubernetes RBAC manifests.
-
-For example:
-
-```sh
-kubectl apply -f https://github.com/aws/aws-controllers-k8s/releases/download/v0.0.1/services/s3/all-resources.yaml
-```
-
-Once you've installed one or more ACK service controllers, make sure to
-[configure permissions](../authorization#configure-permissions), next.
+TODO(jaypipes)

--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -9,6 +9,7 @@ SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
 ROOT_DIR="$SCRIPTS_DIR/.."
 BIN_DIR="$ROOT_DIR/bin"
 TEMPLATES_DIR="$ROOT_DIR/templates"
+DEFAULT_IMAGE_REPOSITORY="public.ecr.aws/aws-controllers-k8s/controller"
 
 source "$SCRIPTS_DIR/lib/common.sh"
 source "$SCRIPTS_DIR/lib/k8s.sh"
@@ -28,7 +29,7 @@ fi
 : "${ACK_GENERATE_API_VERSION:="v1alpha1"}"
 : "${ACK_GENERATE_CONFIG_PATH:=""}"
 : "${ACK_GENERATE_OUTPUT_PATH:=""}"
-: "${ACK_GENERATE_IMAGE_REPOSITORY:="amazon/aws-controllers-k8s"}"
+: "${ACK_GENERATE_IMAGE_REPOSITORY:=$DEFAULT_IMAGE_REPOSITORY}"
 
 USAGE="
 Usage:
@@ -57,7 +58,7 @@ Environment variables:
                                         Default: services/{SERVICE}
   ACK_GENERATE_IMAGE_REPOSITORY:        Specify a Docker image repository to use
                                         for release artifacts
-                                        Default: amazon/aws-controllers-k8s
+                                        Default: $DEFAULT_IMAGE_REPOSITORY
   ACK_GENERATE_SERVICE_ACCOUNT_NAME:    Name of the Kubernetes Service Account and
                                         Cluster Role to use in Helm chart.
                                         Default: $ACK_GENERATE_SERVICE_ACCOUNT_NAME

--- a/scripts/helm-publish-charts.sh
+++ b/scripts/helm-publish-charts.sh
@@ -9,19 +9,15 @@ set -Eo pipefail
 
 SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
 ROOT_DIR="$SCRIPTS_DIR/.."
-BUILD_DIR="$ROOT_DIR/build"
 SERVICES_DIR="$ROOT_DIR/services"
-DEFAULT_HELM_REPO_URL="https://aws.github.io/aws-controllers-k8s/charts"
-DEFAULT_GH_USER_EMAIL="eks-bot@users.noreply.github.com"
-DEFAULT_GH_USER_EMAIL="eks-bot"
-DEFAULT_GIT_REPOSITORY="https://eks-bot:${GITHUB_TOKEN}@github.com/aws/aws-controllers-k8s.git"
-VERSION=$(git describe --tags --always --dirty || echo "unknown")
+DEFAULT_HELM_REGISTRY="public.ecr.aws/aws-controllers-k8s"
+DEFAULT_HELM_REPO="chart"
+DEFAULT_RELEASE_VERSION=$(git describe --tags --always --dirty || echo "unknown")
 
-: "${HELM_REPO_URL:=$DEFAULT_HELM_REPO_URL}"
-: "${GH_USER_NAME:=$DEFAULT_GH_USER_NAME}"
-: "${GH_USER_EMAIL:=$DEFAULT_GH_USER_EMAIL}"
-: "${GIT_REPOSITORY:=$DEFAULT_GIT_REPOSITORY}"
-: "${GIT_COMMIT:="false"}"
+
+: "${RELEASE_VERSION:=$DEFAULT_RELEASE_VERSION}"
+: "${HELM_REGISTRY:=$DEFAULT_HELM_REGISTRY}"
+: "${HELM_REPO:=$DEFAULT_HELM_REPO}"
 
 source "$SCRIPTS_DIR/lib/common.sh"
 
@@ -32,58 +28,22 @@ Usage:
   $(basename "$0")
 
 Environment variables:
-  HELM_REPO_URL:            The URL for the Helm repository.
-                            Default: $DEFAULT_HELM_REPO_URL
-  GH_USER_NAME:             The name of the Github user to use when Git
-                            commit'ing.
-                            Default: $DEFAULT_GH_USER_NAME
-  GH_USER_EMAIL:            The email of the Github user to use when Git
-                            commit'ing.
-                            Default: $DEFAULT_GH_USER_EMAIL
-  GIT_REPOSITORY:           The Git repository URL to commit to.
-                            Default: $DEFAULT_GIT_REPOSITORY
-  GIT_COMMIT:               If false (default), only build the packages and
-                            index. If true, also creates a Git commit and
-                            pushes that commit to an upstream Git repository.
-                            Default: false
+  RELEASE_VERSION:          The semver release version to use.
+                            Default: $DEFAULT_RELEASE_VERSION
+  HELM_REGISTRY:            The name of the Helm registry.
+                            Default: $DEFAULT_HELM_REGISTRY
+  HELM_REPO:                The name of the Helm repository.
+                            Default: $DEFAULT_HELM_REPO
 "
 
-CHARTS_DIR=$ROOT_DIR/charts
-
-if [[ $GIT_COMMIT = "false" ]]; then
-    # On a dry run, we stash the charts in the git-ignored build/ directory.
-    # For non-dry-run, we use the $ROOT_DIR/charts directory, which in the
-    # gh-pages branch of the aws/aws-controllers-k8s upstream source repository
-    # contains the chart packages and index.yaml file.
-    CHARTS_DIR=$BUILD_DIR/charts
-fi
-
-mkdir -p $CHARTS_DIR
-
-export PACKAGE_OUTPUT_PATH="$BUILD_DIR/release/$VERSION"
+export HELM_EXPERIMENTAL_OCI=1
 
 for SERVICE_DIR in $SERVICES_DIR/*; do
     SERVICE=$( basename $SERVICE_DIR)
     if [[ -d "$SERVICES_DIR/$SERVICE/helm" ]]; then
-        echo -n "Generating Helm chart package for $SERVICE ... "
-        $SCRIPTS_DIR/helm-package-controller.sh $SERVICE 1>/dev/null || exit 1
+        echo -n "Generating Helm chart package for $SERVICE@$RELEASE_VERSION ... "
+        helm chart save $SERVICES_DIR/$SERVICE/helm/ $HELM_REGISTRY/$HELM_REPO:$SERVICE-$RELEASE_VERSION
         echo "ok."
+        helm chart push $HELM_REGISTRY/$HELM_REPO:$SERVICE-$RELEASE_VERSION
     fi
 done
-
-# We need to place the packages into the Helm repository's root directory.
-mv -f $PACKAGE_OUTPUT_PATH/*.tgz $CHARTS_DIR
-
-echo -n "Building index for Helm repo ... "
-helm repo index $CHARTS_DIR --url $HELM_REPO_URL 1>/dev/null || exit 1
-echo "ok."
-
-if [[ $GIT_COMMIT = "true" ]]; then
-    git config user.name $GH_USER_NAME
-    git config user.email $GH_USER_EMAIL
-    git remote set-url upstream $GIT_REPOSITORY
-    git checkout gh-pages
-    git add .
-    git commit -m "Publish ACK service controller charts for $VERSION"
-    git push upstream gh-pages
-fi

--- a/services/apigatewayv2/helm/values.yaml
+++ b/services/apigatewayv2/helm/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: amazon/aws-controllers-k8s
+  repository: public.ecr.aws/aws-controllers-k8s/controller
   tag: apigatewayv2-v0.0.1
   pullPolicy: IfNotPresent
   pullSecrets: []

--- a/services/dynamodb/helm/values.yaml
+++ b/services/dynamodb/helm/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: amazon/aws-controllers-k8s
+  repository: public.ecr.aws/aws-controllers-k8s/controller
   tag: dynamodb-v0.0.1
   pullPolicy: IfNotPresent
   pullSecrets: []

--- a/services/ecr/helm/values.yaml
+++ b/services/ecr/helm/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: amazon/aws-controllers-k8s
+  repository: public.ecr.aws/aws-controllers-k8s/controller
   tag: ecr-v0.0.1
   pullPolicy: IfNotPresent
   pullSecrets: []

--- a/services/elasticache/helm/values.yaml
+++ b/services/elasticache/helm/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: amazon/aws-controllers-k8s
+  repository: public.ecr.aws/aws-controllers-k8s/controller
   tag: elasticache-v0.0.1
   pullPolicy: IfNotPresent
   pullSecrets: []

--- a/services/s3/helm/values.yaml
+++ b/services/s3/helm/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: amazon/aws-controllers-k8s
+  repository: public.ecr.aws/aws-controllers-k8s/controller
   tag: s3-v0.0.1
   pullPolicy: IfNotPresent
   pullSecrets: []

--- a/services/sfn/helm/values.yaml
+++ b/services/sfn/helm/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: amazon/aws-controllers-k8s
+  repository: public.ecr.aws/aws-controllers-k8s/controller
   tag: sfn-v0.0.1
   pullPolicy: IfNotPresent
   pullSecrets: []

--- a/services/sns/helm/values.yaml
+++ b/services/sns/helm/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: amazon/aws-controllers-k8s
+  repository: public.ecr.aws/aws-controllers-k8s/controller
   tag: sns-v0.0.1
   pullPolicy: IfNotPresent
   pullSecrets: []


### PR DESCRIPTION
Modifies our release docs and publish scripts to use our new ECR public
registry (public.ecr.aws/aws-controllers-k8s) for storing Docker images
for the controllers and Helm charts.

Note that the public alias "public.ecr.aws/aws-controllers-k8s" is still
not resolving from the generated alias of "public.ecr.aws/m5q3e4b2" but
that should be done shortly by the ECR team.

Issue #366

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
