### PR TITLE
Update crossplane-runtime import paths to match latest release

### DIFF
--- a/templates/crossplane/apis/crd.go.tpl
+++ b/templates/crossplane/apis/crd.go.tpl
@@ -11,7 +11,7 @@ import (
 {{ end }}
 
 {{- end }}
-	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -34,7 +34,7 @@ type {{ .CRD.Kind }}Parameters struct {
 
 // {{ .CRD.Kind }}Spec defines the desired state of {{ .CRD.Kind }}
 type {{ .CRD.Kind }}Spec struct {
-	runtimev1alpha1.ResourceSpec `json:",inline"`
+	xpv1.ResourceSpec `json:",inline"`
 	ForProvider {{ .CRD.Kind }}Parameters `json:"forProvider"`
 }
 
@@ -50,7 +50,7 @@ type {{ .CRD.Kind }}Observation struct {
 
 // {{ .CRD.Kind }}Status defines the observed state of {{ .CRD.Kind }}.
 type {{ .CRD.Kind }}Status struct {
-	runtimev1alpha1.ResourceStatus `json:",inline"`
+	xpv1.ResourceStatus `json:",inline"`
 	AtProvider {{ .CRD.Kind }}Observation `json:"atProvider"`
 }
 

--- a/templates/crossplane/pkg/controller.go.tpl
+++ b/templates/crossplane/pkg/controller.go.tpl
@@ -21,7 +21,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	cpresource "github.com/crossplane/crossplane-runtime/pkg/resource"
-	runtimev1alpha1 "github.com/crossplane/crossplane-runtime/apis/core/v1alpha1"
+	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 
 	svcapitypes "github.com/crossplane/provider-aws/apis/{{ .ServiceIDClean }}/{{ .APIVersion}}"
 	awsclient "github.com/crossplane/provider-aws/pkg/clients"
@@ -104,7 +104,7 @@ func (e *external) Create(ctx context.Context, mg cpresource.Managed) (managed.E
 	if !ok {
 		return managed.ExternalCreation{}, errors.New(errUnexpectedObject)
 	}
-	cr.Status.SetConditions(runtimev1alpha1.Creating())
+	cr.Status.SetConditions(xpv1.Creating())
 	if err := e.preCreate(ctx, cr); err != nil {
 		return managed.ExternalCreation{}, errors.Wrap(err, "pre-create failed")
 	}
@@ -133,7 +133,7 @@ func (e *external) Delete(ctx context.Context, mg cpresource.Managed) error {
 	if !ok {
 		return errors.New(errUnexpectedObject)
 	}
-	cr.Status.SetConditions(runtimev1alpha1.Deleting())
+	cr.Status.SetConditions(xpv1.Deleting())
 	{{- if .CRD.Ops.Delete }}
   input := Generate{{ .CRD.Ops.Delete.InputRef.Shape.ShapeName }}(cr)
   _, err := e.client.{{ .CRD.Ops.Delete.Name }}WithContext(ctx, input)


### PR DESCRIPTION
Description of changes: There is a breaking change in [latest crossplane-runtime](https://github.com/crossplane/crossplane-runtime/releases/tag/v0.12.0) that necessitates changes of these import paths.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
