### PR TITLE
Fix replication group tests failures

### DIFF
--- a/scripts/lib/aws/elasticache.sh
+++ b/scripts/lib/aws/elasticache.sh
@@ -570,7 +570,7 @@ wait_and_assert_replication_group_synced_and_available() {
 
   # wait for resourced to be synced (or time out), then assert availability in aws and k8s
   sleep 5
-  k8s_wait_resource_synced "replicationgroups/$rg_id" 60
+  k8s_wait_resource_synced "replicationgroups/$rg_id" 60 "$service_name"
   aws_assert_replication_group_status "$rg_id" "available"
   k8s_assert_replication_group_status_property "$rg_id" ".status" "available"
 }

--- a/scripts/lib/aws/elasticache.sh
+++ b/scripts/lib/aws/elasticache.sh
@@ -179,6 +179,45 @@ spec:
 EOF
 }
 
+# provide_replication_group_yaml puts replication group yaml to standard output
+# it uses following environment variables:
+#     rg_id, rg_description,
+#     automatic_failover_enabled, cache_node_type,
+#     num_node_groups, multi_az_enabled
+# if environment variables are not found, then following defaults are used
+#     $test_default_replication_group
+#     $test_default_replication_group_desc
+#     $test_default_replication_group_automatic_failover_enabled
+#     $test_default_replication_group_cache_node_type
+#     $test_default_replication_group_num_node_groups
+#     $test_default_replication_group_multi_az_enabled
+provide_replication_group_yaml_for_replica_config() {
+  local rg_id="${rg_id:-$test_default_replication_group}"
+  local rg_name="$rg_id"
+  local rg_description="${rg_description:-$test_default_replication_group_desc}"
+  local automatic_failover_enabled="${automatic_failover_enabled:-$test_default_replication_group_automatic_failover_enabled}"
+  local cache_node_type="${cache_node_type:=$test_default_replication_group_cache_node_type}"
+  local num_node_groups="${num_node_groups:-$test_default_replication_group_num_node_groups}"
+  local multi_az_enabled="${multi_az_enabled:-$test_default_replication_group_multi_az_enabled}"
+  # do not specify replicasPerNodeGroup in spec here
+  # the node group configuration in tests would specify
+  # fine grained details
+  cat <<EOF
+apiVersion: elasticache.services.k8s.aws/v1alpha1
+kind: ReplicationGroup
+metadata:
+  name: $rg_name
+spec:
+    engine: redis
+    replicationGroupID: $rg_id
+    replicationGroupDescription: $rg_description
+    automaticFailoverEnabled: $automatic_failover_enabled
+    cacheNodeType: $cache_node_type
+    numNodeGroups: $num_node_groups
+    multiAZEnabled: $multi_az_enabled
+EOF
+}
+
 # provide_replication_group_yaml_basic is similar to provide_replication_group_yaml, except only specifies
 #   a name, description, and engine. This is meant for use cases where certain properties which are usually included
 #   need to be excluded from the yaml (e.g. numNodeGroups not specified because replicaCount will be specified).

--- a/scripts/lib/testutil.sh
+++ b/scripts/lib/testutil.sh
@@ -75,24 +75,34 @@ assert_pod_not_restarted() {
 # k8s_wait_resource_synced checks the given resource for an ACK.ResourceSynced condition in its
 #   k8s status.conditions property. Times out if condition has not been met for a long time. This function
 #   is intended to be used after yaml application to await creation of a resource.
-# k8s_wait_resource_synced requires 2 arguments:
+# k8s_wait_resource_synced requires 3 arguments:
 #   k8s_resource_name: the name of the resource, e.g. "snapshots/test-snapshot"
 #   wait_periods: the number of 60-second periods to wait for the resource before timing out
+#   service_name: the aws service name. It is used to determine the controller deployment, in case credentials need
+#                 to be rotated during the wait.
 k8s_wait_resource_synced() {
-  if [[ $# -ne 2 ]]; then
+  if [[ $# -ne 3 ]]; then
     echo "FATAL: Wrong number of arguments passed to ${FUNCNAME[0]}"
-    echo "Usage: ${FUNCNAME[0]} k8s_resource_name wait_periods"
+    echo "Usage: ${FUNCNAME[0]} k8s_resource_name wait_periods service_name"
     exit 1
   fi
 
   local k8s_resource_name="$1"
   local wait_periods="$2"
+  local service_name="$3"
 
   kubectl get "$k8s_resource_name" 1>/dev/null 2>&1
   assert_equal "0" "$?" "Resource $k8s_resource_name doesn't exist in k8s cluster" || exit 1
 
   local wait_failed="true"
   for i in $(seq 1 "$wait_periods"); do
+    # Test role credentials expire after 15 minutes (Refer: aws.sh::aws_generate_temp_creds)
+    # Ensure that credentials are reloaded at the beginning and after every 15 minutes.
+    # else the controller fails to get the latest details from aws service api
+    # and the test fails on sync status.
+    if [[ "$((i % 15))" == "0" || "$i" == "1" ]]; then
+      k8s_controller_reload_credentials "$service_name"
+    fi
     debug_msg "waiting for resource $k8s_resource_name to be synced ($i)"
     sleep 60
 

--- a/scripts/lib/testutil.sh
+++ b/scripts/lib/testutil.sh
@@ -97,10 +97,10 @@ k8s_wait_resource_synced() {
   local wait_failed="true"
   for i in $(seq 1 "$wait_periods"); do
     # Test role credentials expire after 15 minutes (Refer: aws.sh::aws_generate_temp_creds)
-    # Ensure that credentials are reloaded at the beginning and after every 15 minutes.
+    # Ensure that credentials are reloaded after first iteration and after every 15 minutes.
     # else the controller fails to get the latest details from aws service api
     # and the test fails on sync status.
-    if [[ "$((i % 15))" == "0" || "$i" == "1" ]]; then
+    if [[ "$((i % 15))" == "0" || "$i" == "2" ]]; then
       k8s_controller_reload_credentials "$service_name"
     fi
     debug_msg "waiting for resource $k8s_resource_name to be synced ($i)"

--- a/services/elasticache/generator.yaml
+++ b/services/elasticache/generator.yaml
@@ -9,6 +9,9 @@ resources:
         - CacheSubnetQuotaExceededFault
         - SubnetInUse
         - InvalidSubnet
+        - InvalidParameter
+        - InvalidParameterValue
+        - InvalidParameterCombination
     fields:
       Events:
         is_read_only: true
@@ -125,3 +128,5 @@ ignore:
     - DescribeSnapshotsInput.CacheClusterId
     - DescribeSnapshotsInput.ReplicationGroupId
     - DescribeSnapshotsInput.SnapshotSource
+    - ModifyReplicationGroupInput.SecurityGroupIds
+    - ModifyReplicationGroupInput.EngineVersion

--- a/services/elasticache/pkg/resource/cache_parameter_group/custom_api.go
+++ b/services/elasticache/pkg/resource/cache_parameter_group/custom_api.go
@@ -92,6 +92,7 @@ func (rm *resourceManager) provideEvents(
 	resp, err := rm.sdkapi.DescribeEventsWithContext(ctx, input)
 	rm.metrics.RecordAPICall("READ_MANY", "DescribeEvents-CacheParameterGroup", err)
 	if err != nil {
+		rm.log.V(1).Info("Error during DescribeEvents-CacheParameterGroup", "error", err)
 		return nil, err
 	}
 	events := []*svcapitypes.Event{}
@@ -133,6 +134,7 @@ func (rm *resourceManager) describeCacheParameters(
 			if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "CacheParameterGroupNotFound" {
 				return nil, ackerr.NotFound
 			}
+			rm.log.V(1).Info("Error during DescribeCacheParameters", "error", respErr)
 			return nil, respErr
 		}
 
@@ -198,6 +200,7 @@ func (rm *resourceManager) resetAllParameters(
 	_, err := rm.sdkapi.ResetCacheParameterGroupWithContext(ctx, input)
 	rm.metrics.RecordAPICall("UPDATE", "ResetCacheParameterGroup-ResetAllParameters", err)
 	if err != nil {
+		rm.log.V(1).Info("Error during ResetCacheParameterGroup-ResetAllParameters", "error", err)
 		return false, err
 	}
 	return true, nil
@@ -228,6 +231,7 @@ func (rm *resourceManager) resetParameters(
 	_, err := rm.sdkapi.ResetCacheParameterGroupWithContext(ctx, input)
 	rm.metrics.RecordAPICall("UPDATE", "ResetCacheParameterGroup", err)
 	if err != nil {
+		rm.log.V(1).Info("Error during ResetCacheParameterGroup", "error", err)
 		return false, err
 	}
 	return true, nil
@@ -288,6 +292,7 @@ func (rm *resourceManager) modifyCacheParameterGroup(
 	_, err := rm.sdkapi.ModifyCacheParameterGroupWithContext(ctx, input)
 	rm.metrics.RecordAPICall("UPDATE", "ModifyCacheParameterGroup", err)
 	if err != nil {
+		rm.log.V(1).Info("Error during ModifyCacheParameterGroup", "error", err)
 		return false, err
 	}
 	return true, nil

--- a/services/elasticache/pkg/resource/cache_subnet_group/custom_set_output.go
+++ b/services/elasticache/pkg/resource/cache_subnet_group/custom_set_output.go
@@ -70,6 +70,7 @@ func (rm *resourceManager) provideEvents(
 	resp, err := rm.sdkapi.DescribeEventsWithContext(ctx, input)
 	rm.metrics.RecordAPICall("READ_MANY", "DescribeEvents-CacheSubnetGroup", err)
 	if err != nil {
+		rm.log.V(1).Info("Error during DescribeEvents-CacheSubnetGroup", "error", err)
 		return nil, err
 	}
 	events := []*svcapitypes.Event{}

--- a/services/elasticache/pkg/resource/cache_subnet_group/sdk.go
+++ b/services/elasticache/pkg/resource/cache_subnet_group/sdk.go
@@ -392,7 +392,10 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 	case "CacheSubnetGroupQuotaExceeded",
 		"CacheSubnetQuotaExceededFault",
 		"SubnetInUse",
-		"InvalidSubnet":
+		"InvalidSubnet",
+		"InvalidParameter",
+		"InvalidParameterValue",
+		"InvalidParameterCombination":
 		return true
 	default:
 		return false

--- a/services/elasticache/pkg/resource/replication_group/sdk.go
+++ b/services/elasticache/pkg/resource/replication_group/sdk.go
@@ -841,9 +841,6 @@ func (rm *resourceManager) newUpdateRequestPayload(
 		}
 		res.SetCacheSecurityGroupNames(f7)
 	}
-	if r.ko.Spec.EngineVersion != nil {
-		res.SetEngineVersion(*r.ko.Spec.EngineVersion)
-	}
 	if r.ko.Spec.MultiAZEnabled != nil {
 		res.SetMultiAZEnabled(*r.ko.Spec.MultiAZEnabled)
 	}
@@ -861,15 +858,6 @@ func (rm *resourceManager) newUpdateRequestPayload(
 	}
 	if r.ko.Spec.ReplicationGroupID != nil {
 		res.SetReplicationGroupId(*r.ko.Spec.ReplicationGroupID)
-	}
-	if r.ko.Spec.SecurityGroupIDs != nil {
-		f17 := []*string{}
-		for _, f17iter := range r.ko.Spec.SecurityGroupIDs {
-			var f17elem string
-			f17elem = *f17iter
-			f17 = append(f17, &f17elem)
-		}
-		res.SetSecurityGroupIds(f17)
 	}
 	if r.ko.Spec.SnapshotRetentionLimit != nil {
 		res.SetSnapshotRetentionLimit(*r.ko.Spec.SnapshotRetentionLimit)

--- a/test/e2e/elasticache/replication_group/creation.sh
+++ b/test/e2e/elasticache/replication_group/creation.sh
@@ -12,7 +12,7 @@ source "$SCRIPTS_DIR/lib/testutil.sh"
 source "$SCRIPTS_DIR/lib/aws/elasticache.sh"
 
 check_is_installed jq "Please install jq before running this script."
-
+AWS_REGION=${AWS_REGION:-"us-west-2"}
 test_name="$( filenoext "${BASH_SOURCE[0]}" )"
 ack_ctrl_pod_id=$( controller_pod_id )
 debug_msg "executing test group: $service_name/$test_name------------------------------"
@@ -131,7 +131,7 @@ test_create_rg_specify_node_group_no_quotes() {
 $yaml_base
     nodeGroupConfiguration:
       - nodeGroupID: 1020
-        primaryAvailabilityZone: us-east-1a
+        primaryAvailabilityZone: ${AWS_REGION}a
 EOF
 )
   output_msg=$(echo "$rg_yaml" | kubectl apply -f - 2>&1)
@@ -165,10 +165,10 @@ test_create_rg_custom_node_config() {
 $yaml_base
     nodeGroupConfiguration:
       - nodeGroupID: "0010"
-        primaryAvailabilityZone: us-east-1a
+        primaryAvailabilityZone: ${AWS_REGION}a
         replicaAvailabilityZones:
-          - us-east-1b
-          - us-east-1a
+          - ${AWS_REGION}b
+          - ${AWS_REGION}a
 EOF
 )
   echo "$rg_yaml" | kubectl apply -f - 2>&1

--- a/test/e2e/elasticache/replication_group/misc.sh
+++ b/test/e2e/elasticache/replication_group/misc.sh
@@ -22,7 +22,6 @@ debug_msg "selected AWS region: $AWS_REGION"
 test_create_rg_specify_sg() {
 
   # create security group in default VPC to use
-  k8s_controller_reload_credentials "elasticache"
   local vpc_json=$(daws ec2 describe-vpcs | jq -r '.Vpcs[] | select( .IsDefault == true )')
   local default_vpc_id=$(echo "$vpc_json" | jq -r '.VpcId')
   daws ec2 create-security-group --group-name "test-sg-default" --description "sg for automated elasticache ACK test" --vpc-id "$default_vpc_id" 1>/dev/null 2>&1

--- a/test/e2e/elasticache/replication_group/scaling.sh
+++ b/test/e2e/elasticache/replication_group/scaling.sh
@@ -12,6 +12,7 @@ source "$SCRIPTS_DIR/lib/testutil.sh"
 source "$SCRIPTS_DIR/lib/aws/elasticache.sh"
 
 check_is_installed jq "Please install jq before running this script."
+AWS_REGION=${AWS_REGION:-"us-west-2"}
 
 test_name="$( filenoext "${BASH_SOURCE[0]}" )"
 ack_ctrl_pod_id=$( controller_pod_id )
@@ -84,19 +85,20 @@ test_modify_rg_cme_scale_out_add_replica() {
   clear_rg_parameter_variables
   rg_id="rg-cme-scale-out-add-replica"
   num_node_groups="2"
-  replicas_per_node_group="1"
-  yaml_base="$(provide_replication_group_yaml)"
+  yaml_base="$(provide_replication_group_yaml_for_replica_config)"
   rg_yaml=$(cat <<EOF
 $yaml_base
     nodeGroupConfiguration:
       - nodeGroupID: "0010"
-        primaryAvailabilityZone: us-east-1a
+        primaryAvailabilityZone: ${AWS_REGION}a
         replicaAvailabilityZones:
-        - us-east-1b
+        - ${AWS_REGION}b
+        replicaCount: 1
       - nodeGroupID: "0020"
-        primaryAvailabilityZone: us-east-1b
+        primaryAvailabilityZone: ${AWS_REGION}b
         replicaAvailabilityZones:
-        - us-east-1a
+        - ${AWS_REGION}a
+        replicaCount: 1
 EOF
 )
   echo "$rg_yaml" | kubectl apply -f - 2>&1
@@ -110,26 +112,28 @@ EOF
 
   # update config and apply: scale out and add replicas
   num_node_groups="3"
-  replicas_per_node_group="2"
-  yaml_base="$(provide_replication_group_yaml)"
+  yaml_base="$(provide_replication_group_yaml_for_replica_config)"
   rg_yaml=$(cat <<EOF
 $yaml_base
     nodeGroupConfiguration:
       - nodeGroupID: "0010"
-        primaryAvailabilityZone: us-east-1a
+        primaryAvailabilityZone: ${AWS_REGION}a
         replicaAvailabilityZones:
-        - us-east-1b
-        - us-east-1a
+        - ${AWS_REGION}b
+        - ${AWS_REGION}a
+        replicaCount: 2
       - nodeGroupID: "0020"
-        primaryAvailabilityZone: us-east-1b
+        primaryAvailabilityZone: ${AWS_REGION}b
         replicaAvailabilityZones:
-        - us-east-1a
-        - us-east-1b
+        - ${AWS_REGION}a
+        - ${AWS_REGION}b
+        replicaCount: 2
       - nodeGroupID: "0030"
-        primaryAvailabilityZone: us-east-1a
+        primaryAvailabilityZone: ${AWS_REGION}a
         replicaAvailabilityZones:
-        - us-east-1b
-        - us-east-1a
+        - ${AWS_REGION}b
+        - ${AWS_REGION}a
+        replicaCount: 2
 EOF
 )
   echo "$rg_yaml" | kubectl apply -f - 2>&1
@@ -159,15 +163,15 @@ $yaml_base
     multiAZEnabled: true
     nodeGroupConfiguration:
       - nodeGroupID: "0010"
-        primaryAvailabilityZone: us-east-1a
+        primaryAvailabilityZone: ${AWS_REGION}a
         replicaAvailabilityZones:
-        - us-east-1b
+        - ${AWS_REGION}b
         replicaCount: 1
       - nodeGroupID: "0020"
-        primaryAvailabilityZone: us-east-1b
+        primaryAvailabilityZone: ${AWS_REGION}b
         replicaAvailabilityZones:
-        - us-east-1a
-        - us-east-1c
+        - ${AWS_REGION}a
+        - ${AWS_REGION}c
         replicaCount: 2
 EOF
 )
@@ -189,20 +193,20 @@ $yaml_base
     multiAZEnabled: true
     nodeGroupConfiguration:
       - nodeGroupID: "0010"
-        primaryAvailabilityZone: us-east-1a
+        primaryAvailabilityZone: ${AWS_REGION}a
         replicaAvailabilityZones:
-        - us-east-1b
+        - ${AWS_REGION}b
         replicaCount: 1
       - nodeGroupID: "0020"
-        primaryAvailabilityZone: us-east-1b
+        primaryAvailabilityZone: ${AWS_REGION}b
         replicaAvailabilityZones:
-        - us-east-1a
-        - us-east-1c
+        - ${AWS_REGION}a
+        - ${AWS_REGION}c
         replicaCount: 2
       - nodeGroupID: "0030"
-        primaryAvailabilityZone: us-east-1a
+        primaryAvailabilityZone: ${AWS_REGION}a
         replicaAvailabilityZones:
-        - us-east-1b
+        - ${AWS_REGION}b
         replicaCount: 1
 EOF
 )
@@ -223,19 +227,20 @@ test_modify_rg_cme_scale_out_basic() {
   clear_rg_parameter_variables
   rg_id="rg-cme-scale-out-basic"
   num_node_groups="2"
-  replicas_per_node_group="1"
-  yaml_base="$(provide_replication_group_yaml)"
+  yaml_base="$(provide_replication_group_yaml_for_replica_config)"
   rg_yaml=$(cat <<EOF
 $yaml_base
     nodeGroupConfiguration:
       - nodeGroupID: "0010"
-        primaryAvailabilityZone: us-east-1a
+        primaryAvailabilityZone: ${AWS_REGION}a
         replicaAvailabilityZones:
-        - us-east-1b
+        - ${AWS_REGION}b
+        replicaCount: 1
       - nodeGroupID: "0020"
-        primaryAvailabilityZone: us-east-1a
+        primaryAvailabilityZone: ${AWS_REGION}a
         replicaAvailabilityZones:
-        - us-east-1b
+        - ${AWS_REGION}b
+        replicaCount: 1
 EOF
 )
   echo "$rg_yaml" | kubectl apply -f - 2>&1
@@ -249,22 +254,25 @@ EOF
 
    # update config and apply: scale out
   num_node_groups="3"
-  yaml_base="$(provide_replication_group_yaml)"
+  yaml_base="$(provide_replication_group_yaml_for_replica_config)"
   rg_yaml=$(cat <<EOF
 $yaml_base
     nodeGroupConfiguration:
       - nodeGroupID: "0010"
-        primaryAvailabilityZone: us-east-1a
+        primaryAvailabilityZone: ${AWS_REGION}a
         replicaAvailabilityZones:
-        - us-east-1b
+        - ${AWS_REGION}b
+        replicaCount: 1
       - nodeGroupID: "0020"
-        primaryAvailabilityZone: us-east-1a
+        primaryAvailabilityZone: ${AWS_REGION}a
         replicaAvailabilityZones:
-        - us-east-1b
+        - ${AWS_REGION}b
+        replicaCount: 1
       - nodeGroupID: "0030"
-        primaryAvailabilityZone: us-east-1a
+        primaryAvailabilityZone: ${AWS_REGION}a
         replicaAvailabilityZones:
-        - us-east-1b
+        - ${AWS_REGION}b
+        replicaCount: 1
 EOF
 )
   echo "$rg_yaml" | kubectl apply -f - 2>&1

--- a/test/e2e/elasticache/snapshot/e2e.sh
+++ b/test/e2e/elasticache/snapshot/e2e.sh
@@ -59,7 +59,7 @@ spec:
 EOF)
   echo "$snapshot_yaml" | kubectl apply -f -
   assert_equal "0" "$?" "Expected application of $snapshot_name to succeed" || exit 1
-  k8s_wait_resource_synced "snapshots/$snapshot_name" 5
+  k8s_wait_resource_synced "snapshots/$snapshot_name" 5 "$service_name"
 
   # create second snapshot from first to trigger copy-snapshot API
   local snapshot_yaml=$(cat <<EOF
@@ -73,7 +73,7 @@ spec:
 EOF)
   echo "$snapshot_yaml" | kubectl apply -f -
   assert_equal "0" "$?" "Expected application of $copied_snapshot_name to succeed" || exit 1
-  k8s_wait_resource_synced "snapshots/$copied_snapshot_name" 10
+  k8s_wait_resource_synced "snapshots/$copied_snapshot_name" 10 "$service_name"
 
   # test deletion
   kubectl delete snapshots/"$snapshot_name"
@@ -142,7 +142,7 @@ spec:
 EOF)
   echo "$snapshot_yaml" | kubectl apply -f -
   assert_equal "0" "$?" "Expected application of $snapshot_name to succeed" || exit 1
-  k8s_wait_resource_synced "snapshots/$snapshot_name" 10
+  k8s_wait_resource_synced "snapshots/$snapshot_name" 10 "$service_name"
 
   # delete snapshot for case 2 if creation succeeded
   kubectl delete snapshots/"$snapshot_name"
@@ -185,7 +185,7 @@ spec:
 EOF)
   echo "$snapshot_yaml" | kubectl apply -f -
   assert_equal "0" "$?" "Expected application of $snapshot_name to succeed" || exit 1
-  k8s_wait_resource_synced "snapshots/$snapshot_name" 10
+  k8s_wait_resource_synced "snapshots/$snapshot_name" 10 "$service_name"
 
   # delete snapshot for case 1 if creation succeeded
   kubectl delete snapshots/"$snapshot_name"
@@ -261,7 +261,7 @@ spec:
 EOF)
   echo "$snapshot_yaml" | kubectl apply -f -
   assert_equal "0" "$?" "Expected application of $snapshot_name to succeed" || exit 1
-  k8s_wait_resource_synced "snapshots/$snapshot_name" 10
+  k8s_wait_resource_synced "snapshots/$snapshot_name" 10 "$service_name"
 
   # delete snapshot for case 1 if creation succeeded
   kubectl delete snapshots/"$snapshot_name"


### PR DESCRIPTION
Issue #, if available:

Description of changes:

- Fix credential expire issue during elasticache tests failures. This caused the controller to fail to get the latest details from service API and the test would timeout waiting for latest updates.
- Fixes for replication group tests failures by
    - Include security group Ids and engine versions properties
      in modify replication group API call
      only if there is change in their values
    - Updated sync condition logic to: 
       a/ check all cache clusters' available status from node groups and 
       b/ check if the cacheclusters count from node groups match the count from member clusters
    - Added logs messages to help debugging
    - Updated replication group tests that were failing due to invalid input yaml
- Added cache subnet group terminal codes in generator config
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
