### PR TITLE
pass Config object to resource manager

### DIFF
--- a/mocks/pkg/types/aws_resource_manager_factory.go
+++ b/mocks/pkg/types/aws_resource_manager_factory.go
@@ -3,8 +3,11 @@
 package mocks
 
 import (
-	metrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
+	config "github.com/aws/aws-controllers-k8s/pkg/config"
 	logr "github.com/go-logr/logr"
+
+	metrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
+
 	mock "github.com/stretchr/testify/mock"
 
 	session "github.com/aws/aws-sdk-go/aws/session"
@@ -19,13 +22,13 @@ type AWSResourceManagerFactory struct {
 	mock.Mock
 }
 
-// ManagerFor provides a mock function with given fields: _a0, _a1, _a2, _a3, _a4, _a5
-func (_m *AWSResourceManagerFactory) ManagerFor(_a0 logr.Logger, _a1 *metrics.Metrics, _a2 types.AWSResourceReconciler, _a3 *session.Session, _a4 v1alpha1.AWSAccountID, _a5 v1alpha1.AWSRegion) (types.AWSResourceManager, error) {
-	ret := _m.Called(_a0, _a1, _a2, _a3, _a4, _a5)
+// ManagerFor provides a mock function with given fields: _a0, _a1, _a2, _a3, _a4, _a5, _a6
+func (_m *AWSResourceManagerFactory) ManagerFor(_a0 config.Config, _a1 logr.Logger, _a2 *metrics.Metrics, _a3 types.AWSResourceReconciler, _a4 *session.Session, _a5 v1alpha1.AWSAccountID, _a6 v1alpha1.AWSRegion) (types.AWSResourceManager, error) {
+	ret := _m.Called(_a0, _a1, _a2, _a3, _a4, _a5, _a6)
 
 	var r0 types.AWSResourceManager
-	if rf, ok := ret.Get(0).(func(logr.Logger, *metrics.Metrics, types.AWSResourceReconciler, *session.Session, v1alpha1.AWSAccountID, v1alpha1.AWSRegion) types.AWSResourceManager); ok {
-		r0 = rf(_a0, _a1, _a2, _a3, _a4, _a5)
+	if rf, ok := ret.Get(0).(func(config.Config, logr.Logger, *metrics.Metrics, types.AWSResourceReconciler, *session.Session, v1alpha1.AWSAccountID, v1alpha1.AWSRegion) types.AWSResourceManager); ok {
+		r0 = rf(_a0, _a1, _a2, _a3, _a4, _a5, _a6)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(types.AWSResourceManager)
@@ -33,8 +36,8 @@ func (_m *AWSResourceManagerFactory) ManagerFor(_a0 logr.Logger, _a1 *metrics.Me
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(logr.Logger, *metrics.Metrics, types.AWSResourceReconciler, *session.Session, v1alpha1.AWSAccountID, v1alpha1.AWSRegion) error); ok {
-		r1 = rf(_a0, _a1, _a2, _a3, _a4, _a5)
+	if rf, ok := ret.Get(1).(func(config.Config, logr.Logger, *metrics.Metrics, types.AWSResourceReconciler, *session.Session, v1alpha1.AWSAccountID, v1alpha1.AWSRegion) error); ok {
+		r1 = rf(_a0, _a1, _a2, _a3, _a4, _a5, _a6)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package runtime
+package config
 
 import (
 	"errors"
@@ -32,6 +32,7 @@ const (
 	flagLogLevel             = "log-level"
 )
 
+// Config contains configuration otpions for ACK service controllers
 type Config struct {
 	BindPort                 int
 	MetricsAddr              string
@@ -42,6 +43,7 @@ type Config struct {
 	LogLevel                 string
 }
 
+// BindFlags defines CLI/runtime configuration options
 func (cfg *Config) BindFlags() {
 	flag.IntVar(
 		&cfg.BindPort, flagBindPort,
@@ -82,6 +84,7 @@ func (cfg *Config) BindFlags() {
 	)
 }
 
+// SetupLogger initializes the logger used in the service controller
 func (cfg *Config) SetupLogger() {
 	var lvl zapcore.LevelEnabler
 
@@ -99,6 +102,7 @@ func (cfg *Config) SetupLogger() {
 	ctrlrt.SetLogger(zap.New(zap.UseFlagOptions(&zapOptions)))
 }
 
+// Validate ensures the options are valid
 func (cfg *Config) Validate() error {
 	if cfg.AccountID == "" {
 		return errors.New("unable to start service controller as account ID is nil. Please pass --aws-account-id flag")

--- a/pkg/runtime/reconciler.go
+++ b/pkg/runtime/reconciler.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	"github.com/aws/aws-controllers-k8s/pkg/requeue"
@@ -46,7 +47,7 @@ type reconciler struct {
 	rmf     acktypes.AWSResourceManagerFactory
 	rd      acktypes.AWSResourceDescriptor
 	log     logr.Logger
-	cfg     Config
+	cfg     ackcfg.Config
 	cache   ackrtcache.Caches
 	metrics *ackmetrics.Metrics
 }
@@ -123,7 +124,9 @@ func (r *reconciler) reconcile(req ctrlrt.Request) error {
 		"region", region,
 	)
 
-	rm, err := r.rmf.ManagerFor(r.log, r.metrics, r, sess, acctID, region)
+	rm, err := r.rmf.ManagerFor(
+		r.cfg, r.log, r.metrics, r, sess, acctID, region,
+	)
 	if err != nil {
 		return err
 	}
@@ -444,7 +447,7 @@ func (r *reconciler) getRegion(
 func NewReconciler(
 	rmf acktypes.AWSResourceManagerFactory,
 	log logr.Logger,
-	cfg Config,
+	cfg ackcfg.Config,
 	metrics *ackmetrics.Metrics,
 ) acktypes.AWSResourceReconciler {
 	return &reconciler{

--- a/pkg/runtime/service_controller.go
+++ b/pkg/runtime/service_controller.go
@@ -20,6 +20,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	ctrlrt "sigs.k8s.io/controller-runtime"
 
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 )
@@ -100,7 +101,7 @@ func (c *ServiceController) WithResourceManagerFactories(
 // BindControllerManager takes a `controller-runtime.Manager`, creates all the
 // AWSResourceReconcilers needed for the service and binds all of the
 // reconcilers within the service controller with that manager
-func (c *ServiceController) BindControllerManager(mgr ctrlrt.Manager, cfg Config) error {
+func (c *ServiceController) BindControllerManager(mgr ctrlrt.Manager, cfg ackcfg.Config) error {
 	c.metaLock.Lock()
 	defer c.metaLock.Unlock()
 	for _, rmf := range c.rmFactories {

--- a/pkg/runtime/service_controller_test.go
+++ b/pkg/runtime/service_controller_test.go
@@ -34,6 +34,7 @@ import (
 	k8sscheme "sigs.k8s.io/controller-runtime/pkg/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
 
 	mocks "github.com/aws/aws-controllers-k8s/mocks/pkg/types"
@@ -116,7 +117,7 @@ func TestServiceController(t *testing.T) {
 	require.Empty(recons)
 
 	mgr := &fakeManager{}
-	cfg := ackrt.Config{}
+	cfg := ackcfg.Config{}
 	err := sc.BindControllerManager(mgr, cfg)
 	require.Nil(err)
 

--- a/pkg/types/aws_resource_manager.go
+++ b/pkg/types/aws_resource_manager.go
@@ -21,6 +21,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 )
 
@@ -73,6 +74,7 @@ type AWSResourceManagerFactory interface {
 	// ManagerFor returns an AWSResourceManager that manages AWS resources on
 	// behalf of a particular AWS account and in a specific AWS region
 	ManagerFor(
+		ackcfg.Config, // passed by-value to avoid mutation by consumers
 		logr.Logger,
 		*ackmetrics.Metrics,
 		AWSResourceReconciler,

--- a/services/apigatewayv2/cmd/controller/main.go
+++ b/services/apigatewayv2/cmd/controller/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"os"
 
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
 	flag "github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -55,7 +56,7 @@ func init() {
 }
 
 func main() {
-	var ackCfg ackrt.Config
+	var ackCfg ackcfg.Config
 	ackCfg.BindFlags()
 	flag.Parse()
 	ackCfg.SetupLogger()

--- a/services/apigatewayv2/pkg/resource/api/manager.go
+++ b/services/apigatewayv2/pkg/resource/api/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -85,7 +89,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/apigatewayv2/pkg/resource/api/manager_factory.go
+++ b/services/apigatewayv2/pkg/resource/api/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/api_mapping/manager.go
+++ b/services/apigatewayv2/pkg/resource/api_mapping/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -85,7 +89,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/apigatewayv2/pkg/resource/api_mapping/manager_factory.go
+++ b/services/apigatewayv2/pkg/resource/api_mapping/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/authorizer/manager.go
+++ b/services/apigatewayv2/pkg/resource/authorizer/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -85,7 +89,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/apigatewayv2/pkg/resource/authorizer/manager_factory.go
+++ b/services/apigatewayv2/pkg/resource/authorizer/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/deployment/manager.go
+++ b/services/apigatewayv2/pkg/resource/deployment/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -85,7 +89,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/apigatewayv2/pkg/resource/deployment/manager_factory.go
+++ b/services/apigatewayv2/pkg/resource/deployment/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/domain_name/manager.go
+++ b/services/apigatewayv2/pkg/resource/domain_name/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -85,7 +89,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/apigatewayv2/pkg/resource/domain_name/manager_factory.go
+++ b/services/apigatewayv2/pkg/resource/domain_name/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/integration/manager.go
+++ b/services/apigatewayv2/pkg/resource/integration/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -85,7 +89,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/apigatewayv2/pkg/resource/integration/manager_factory.go
+++ b/services/apigatewayv2/pkg/resource/integration/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/integration_response/manager.go
+++ b/services/apigatewayv2/pkg/resource/integration_response/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -85,7 +89,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/apigatewayv2/pkg/resource/integration_response/manager_factory.go
+++ b/services/apigatewayv2/pkg/resource/integration_response/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/model/manager.go
+++ b/services/apigatewayv2/pkg/resource/model/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -85,7 +89,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/apigatewayv2/pkg/resource/model/manager_factory.go
+++ b/services/apigatewayv2/pkg/resource/model/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/route/manager.go
+++ b/services/apigatewayv2/pkg/resource/route/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -85,7 +89,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/apigatewayv2/pkg/resource/route/manager_factory.go
+++ b/services/apigatewayv2/pkg/resource/route/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/route_response/manager.go
+++ b/services/apigatewayv2/pkg/resource/route_response/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -85,7 +89,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/apigatewayv2/pkg/resource/route_response/manager_factory.go
+++ b/services/apigatewayv2/pkg/resource/route_response/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/stage/manager.go
+++ b/services/apigatewayv2/pkg/resource/stage/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -85,7 +89,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/apigatewayv2/pkg/resource/stage/manager_factory.go
+++ b/services/apigatewayv2/pkg/resource/stage/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/apigatewayv2/pkg/resource/vpc_link/manager.go
+++ b/services/apigatewayv2/pkg/resource/vpc_link/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -85,7 +89,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/apigatewayv2/pkg/resource/vpc_link/manager_factory.go
+++ b/services/apigatewayv2/pkg/resource/vpc_link/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/dynamodb/cmd/controller/main.go
+++ b/services/dynamodb/cmd/controller/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"os"
 
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
 	flag "github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -46,7 +47,7 @@ func init() {
 }
 
 func main() {
-	var ackCfg ackrt.Config
+	var ackCfg ackcfg.Config
 	ackCfg.BindFlags()
 	flag.Parse()
 	ackCfg.SetupLogger()

--- a/services/dynamodb/pkg/resource/backup/manager.go
+++ b/services/dynamodb/pkg/resource/backup/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -85,7 +89,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/dynamodb/pkg/resource/backup/manager_factory.go
+++ b/services/dynamodb/pkg/resource/backup/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/dynamodb/pkg/resource/global_table/manager.go
+++ b/services/dynamodb/pkg/resource/global_table/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -85,7 +89,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/dynamodb/pkg/resource/global_table/manager_factory.go
+++ b/services/dynamodb/pkg/resource/global_table/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/dynamodb/pkg/resource/table/manager.go
+++ b/services/dynamodb/pkg/resource/table/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -85,7 +89,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/dynamodb/pkg/resource/table/manager_factory.go
+++ b/services/dynamodb/pkg/resource/table/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/ecr/cmd/controller/main.go
+++ b/services/ecr/cmd/controller/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"os"
 
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
 	flag "github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -44,7 +45,7 @@ func init() {
 }
 
 func main() {
-	var ackCfg ackrt.Config
+	var ackCfg ackcfg.Config
 	ackCfg.BindFlags()
 	flag.Parse()
 	ackCfg.SetupLogger()

--- a/services/ecr/pkg/resource/repository/manager.go
+++ b/services/ecr/pkg/resource/repository/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -85,7 +89,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/ecr/pkg/resource/repository/manager_factory.go
+++ b/services/ecr/pkg/resource/repository/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/elasticache/cmd/controller/main.go
+++ b/services/elasticache/cmd/controller/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"os"
 
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
 	flag "github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -47,7 +48,7 @@ func init() {
 }
 
 func main() {
-	var ackCfg ackrt.Config
+	var ackCfg ackcfg.Config
 	ackCfg.BindFlags()
 	flag.Parse()
 	ackCfg.SetupLogger()

--- a/services/elasticache/pkg/resource/cache_parameter_group/manager.go
+++ b/services/elasticache/pkg/resource/cache_parameter_group/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/elasticache/pkg/resource/cache_parameter_group/manager_factory.go
+++ b/services/elasticache/pkg/resource/cache_parameter_group/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/elasticache/pkg/resource/cache_subnet_group/manager.go
+++ b/services/elasticache/pkg/resource/cache_subnet_group/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/elasticache/pkg/resource/cache_subnet_group/manager_factory.go
+++ b/services/elasticache/pkg/resource/cache_subnet_group/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/elasticache/pkg/resource/replication_group/manager.go
+++ b/services/elasticache/pkg/resource/replication_group/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/elasticache/pkg/resource/replication_group/manager_factory.go
+++ b/services/elasticache/pkg/resource/replication_group/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/elasticache/pkg/resource/snapshot/manager.go
+++ b/services/elasticache/pkg/resource/snapshot/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/elasticache/pkg/resource/snapshot/manager_factory.go
+++ b/services/elasticache/pkg/resource/snapshot/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/s3/cmd/controller/main.go
+++ b/services/s3/cmd/controller/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"os"
 
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
 	flag "github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -44,7 +45,7 @@ func init() {
 }
 
 func main() {
-	var ackCfg ackrt.Config
+	var ackCfg ackcfg.Config
 	ackCfg.BindFlags()
 	flag.Parse()
 	ackCfg.SetupLogger()

--- a/services/s3/pkg/resource/bucket/manager.go
+++ b/services/s3/pkg/resource/bucket/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -85,7 +89,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/s3/pkg/resource/bucket/manager_factory.go
+++ b/services/s3/pkg/resource/bucket/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/sagemaker/cmd/controller/main.go
+++ b/services/sagemaker/cmd/controller/main.go
@@ -18,11 +18,13 @@ package main
 import (
 	"os"
 
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
 	flag "github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrlrt "sigs.k8s.io/controller-runtime"
+	ctrlrtmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	svctypes "github.com/aws/aws-controllers-k8s/services/sagemaker/apis/v1alpha1"
 	svcresource "github.com/aws/aws-controllers-k8s/services/sagemaker/pkg/resource"
@@ -43,7 +45,7 @@ func init() {
 }
 
 func main() {
-	var ackCfg ackrt.Config
+	var ackCfg ackcfg.Config
 	ackCfg.BindFlags()
 	flag.Parse()
 	ackCfg.SetupLogger()
@@ -83,6 +85,8 @@ func main() {
 		ctrlrt.Log,
 	).WithResourceManagerFactories(
 		svcresource.GetManagerFactories(),
+	).WithPrometheusRegistry(
+		ctrlrtmetrics.Registry,
 	)
 	if err = sc.BindControllerManager(mgr, ackCfg); err != nil {
 		setupLog.Error(

--- a/services/sagemaker/pkg/resource/model/manager.go
+++ b/services/sagemaker/pkg/resource/model/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -85,7 +89,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/sagemaker/pkg/resource/model/manager_factory.go
+++ b/services/sagemaker/pkg/resource/model/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/sfn/cmd/controller/main.go
+++ b/services/sfn/cmd/controller/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"os"
 
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
 	flag "github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -45,7 +46,7 @@ func init() {
 }
 
 func main() {
-	var ackCfg ackrt.Config
+	var ackCfg ackcfg.Config
 	ackCfg.BindFlags()
 	flag.Parse()
 	ackCfg.SetupLogger()

--- a/services/sfn/pkg/resource/activity/manager.go
+++ b/services/sfn/pkg/resource/activity/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -85,7 +89,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/sfn/pkg/resource/activity/manager_factory.go
+++ b/services/sfn/pkg/resource/activity/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/sfn/pkg/resource/state_machine/manager.go
+++ b/services/sfn/pkg/resource/state_machine/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -85,7 +89,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/sfn/pkg/resource/state_machine/manager_factory.go
+++ b/services/sfn/pkg/resource/state_machine/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/sns/cmd/controller/main.go
+++ b/services/sns/cmd/controller/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"os"
 
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
 	flag "github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -46,7 +47,7 @@ func init() {
 }
 
 func main() {
-	var ackCfg ackrt.Config
+	var ackCfg ackcfg.Config
 	ackCfg.BindFlags()
 	flag.Parse()
 	ackCfg.SetupLogger()

--- a/services/sns/pkg/resource/platform_application/manager.go
+++ b/services/sns/pkg/resource/platform_application/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -85,7 +89,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/sns/pkg/resource/platform_application/manager_factory.go
+++ b/services/sns/pkg/resource/platform_application/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/sns/pkg/resource/platform_endpoint/manager.go
+++ b/services/sns/pkg/resource/platform_endpoint/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -85,7 +89,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/sns/pkg/resource/platform_endpoint/manager_factory.go
+++ b/services/sns/pkg/resource/platform_endpoint/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/services/sns/pkg/resource/topic/manager.go
+++ b/services/sns/pkg/resource/topic/manager.go
@@ -23,6 +23,7 @@ import (
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -40,6 +41,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -85,7 +89,7 @@ func (rm *resourceManager) ReadOne(
 	}
 	observed, err := rm.sdkFind(ctx, r)
 	if err != nil {
-		return nil, err
+		return rm.onError(r, err)
 	}
 	return rm.onSuccess(observed)
 }
@@ -166,6 +170,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -174,6 +179,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg:          cfg,
 		log:          log,
 		metrics:      metrics,
 		rr:           rr,

--- a/services/sns/pkg/resource/topic/manager_factory.go
+++ b/services/sns/pkg/resource/topic/manager_factory.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -45,6 +46,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -64,7 +66,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}

--- a/templates/cmd/controller/main.go.tpl
+++ b/templates/cmd/controller/main.go.tpl
@@ -5,6 +5,7 @@ package main
 import (
 	"os"
 
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackrt "github.com/aws/aws-controllers-k8s/pkg/runtime"
 	flag "github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,7 +33,7 @@ func init() {
 }
 
 func main() {
-	var ackCfg ackrt.Config
+	var ackCfg ackcfg.Config
 	ackCfg.BindFlags()
 	flag.Parse()
 	ackCfg.SetupLogger()

--- a/templates/pkg/resource/manager.go.tpl
+++ b/templates/pkg/resource/manager.go.tpl
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
@@ -27,6 +28,9 @@ import (
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
 type resourceManager struct {
+	// cfg is a copy of the ackcfg.Config object passed on start of the service
+	// controller
+	cfg ackcfg.Config
 	// log refers to the logr.Logger object handling logging for the service
 	// controller
 	log logr.Logger
@@ -153,6 +157,7 @@ func (rm *resourceManager) ARNFromName(name string) string {
 // newResourceManager returns a new struct implementing
 // acktypes.AWSResourceManager
 func newResourceManager(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -161,6 +166,7 @@ func newResourceManager(
 	region ackv1alpha1.AWSRegion,
 ) (*resourceManager, error) {
 	return &resourceManager{
+		cfg: cfg,
 		log: log,
 		metrics: metrics,
 		rr: rr,

--- a/templates/pkg/resource/manager_factory.go.tpl
+++ b/templates/pkg/resource/manager_factory.go.tpl
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
+	ackcfg "github.com/aws/aws-controllers-k8s/pkg/config"
 	ackmetrics "github.com/aws/aws-controllers-k8s/pkg/metrics"
 	acktypes "github.com/aws/aws-controllers-k8s/pkg/types"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -32,6 +33,7 @@ func (f *resourceManagerFactory) ResourceDescriptor() acktypes.AWSResourceDescri
 // ManagerFor returns a resource manager object that can manage resources for a
 // supplied AWS account
 func (f *resourceManagerFactory) ManagerFor(
+	cfg ackcfg.Config,
 	log logr.Logger,
 	metrics *ackmetrics.Metrics,
 	rr acktypes.AWSResourceReconciler,
@@ -51,7 +53,7 @@ func (f *resourceManagerFactory) ManagerFor(
 	f.Lock()
 	defer f.Unlock()
 
-	rm, err := newResourceManager(log, metrics, rr, sess, id, region)
+	rm, err := newResourceManager(cfg, log, metrics, rr, sess, id, region)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This patch modifies the `AWSResourceManagerFactory` interface's
`ManagerFor` method to accept a copy of a (now-separate package)
`pkg/config:Config` object and construct the resource manager with this
configuration object. This will allow custom resource manager code to
query the configuration object as needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
