### PR TITLE
specify outPath without .tpl extension for release

### DIFF
--- a/pkg/generate/ack/release.go
+++ b/pkg/generate/ack/release.go
@@ -73,7 +73,8 @@ func Release(
 		serviceAccountName,
 	}
 	for _, path := range releaseTemplatePaths {
-		if err := ts.Add(path, path, releaseVars); err != nil {
+		outPath := strings.TrimSuffix(path, ".tpl")
+		if err := ts.Add(outPath, path, releaseVars); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
The TemplateSet for ACK's release artifacts was improperly including the
`.tpl` extension in the outputPath. This patch simply corrects that
outputPath to remove the `.tpl` suffix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
