### PR TITLE
Implementing ImportApi & ReimportApi for apigatewayv2.

### DIFF
--- a/pkg/generate/apigwv2_test.go
+++ b/pkg/generate/apigwv2_test.go
@@ -50,6 +50,34 @@ func TestAPIGatewayV2_GetTypeDefs(t *testing.T) {
 	assert.Equal("API_SDK", tdef.Names.Camel)
 }
 
+func TestAPIGatewayV2_Api(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	g := testutil.NewGeneratorForService(t, "apigatewayv2")
+
+	crds, err := g.GetCRDs()
+	require.Nil(err)
+
+	crd := getCRDByName("Api", crds)
+	require.NotNil(crd)
+
+	assert.Equal("API", crd.Names.Camel)
+	assert.Equal("api", crd.Names.CamelLower)
+	assert.Equal("api", crd.Names.Snake)
+
+	assert.NotNil(crd.SpecFields["Name"])
+	assert.NotNil(crd.SpecFields["ProtocolType"])
+	// Body, Basepath and FailOnWarnings fields from ImportApi operation should get added to APISpec
+	assert.NotNil(crd.SpecFields["Body"])
+	assert.NotNil(crd.SpecFields["Basepath"])
+	assert.NotNil(crd.SpecFields["FailOnWarnings"])
+
+	// The required property should get overriden for Name and ProtocolType fields.
+	assert.False(crd.SpecFields["Name"].IsRequired())
+	assert.False(crd.SpecFields["ProtocolType"].IsRequired())
+}
+
 func TestAPIGatewayV2_Route(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)

--- a/pkg/generate/config/field.go
+++ b/pkg/generate/config/field.go
@@ -115,7 +115,7 @@ type FieldConfig struct {
 	// IsPrintable determines whether the field should be included in the
 	// AdditionalPrinterColumns list to be included in the `kubectl get`
 	// response.
-	IsPrintable bool `json:"is_printable,omitempty"`
+	IsPrintable bool `json:"is_printable"`
 	// ContainsOwnerAccountID indicates the field contains the AWS Account ID
 	// that owns the resource. This is a special field that we direct to
 	// storage in the common `Status.ACKResourceMetadata.OwnerAccountID` field.
@@ -123,4 +123,7 @@ type FieldConfig struct {
 	// From instructs the code generator that the value of the field should
 	// be retrieved from the specified operation and member path
 	From *SourceFieldConfig `json:"from,omitempty"`
+	// Required indicates whether this field is a required member or not.
+	// This field is used to configure '+kubebuilder:validation:Required' on API object's members.
+	IsRequired *bool `json:"is_required,omitempty"`
 }

--- a/pkg/generate/testdata/models/apis/apigatewayv2/0000-00-00/generator.yaml
+++ b/pkg/generate/testdata/models/apis/apigatewayv2/0000-00-00/generator.yaml
@@ -1,0 +1,24 @@
+resources:
+  Api:
+    fields:
+      Body:
+        from:
+          operation: ImportApi
+          path: Body
+      Basepath:
+        from:
+          operation: ImportApi
+          path: Basepath
+      FailOnWarnings:
+        from:
+          operation: ImportApi
+          path: FailOnWarnings
+      Name:
+        is_required: false
+      ProtocolType:
+        is_required: false
+    update_operation:
+      custom_method_name: customUpdateApi
+operations:
+  CreateApi:
+    custom_implementation: customCreateApi

--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -191,4 +191,6 @@ echo "==========================================================================
 export KUBECONFIG
 
 $TEST_RELEASE_DIR/test-helm.sh "$AWS_SERVICE" "$VERSION"
-$TEST_E2E_DIR/build-run-test-dockerfile.sh $AWS_SERVICE
+#$TEST_E2E_DIR/build-run-test-dockerfile.sh $AWS_SERVICE
+# switching to old e2e runs temporarily until docker test runs are successful.
+$TEST_E2E_DIR/run-tests.sh $AWS_SERVICE

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # setting the -x option if debugging is true
-if [[ "${DEBUG}" = "true" ]]; then
+if [[ "${DEBUG:-"false"}" = "true" ]]; then
     set -x
 fi
 

--- a/services/apigatewayv2/apis/v1alpha1/api.go
+++ b/services/apigatewayv2/apis/v1alpha1/api.go
@@ -22,21 +22,22 @@ import (
 
 // APISpec defines the desired state of API
 type APISpec struct {
-	APIKeySelectionExpression *string `json:"apiKeySelectionExpression,omitempty"`
-	CorsConfiguration         *Cors   `json:"corsConfiguration,omitempty"`
-	CredentialsARN            *string `json:"credentialsARN,omitempty"`
-	Description               *string `json:"description,omitempty"`
-	DisableExecuteAPIEndpoint *bool   `json:"disableExecuteAPIEndpoint,omitempty"`
-	DisableSchemaValidation   *bool   `json:"disableSchemaValidation,omitempty"`
-	// +kubebuilder:validation:Required
-	Name *string `json:"name"`
-	// +kubebuilder:validation:Required
-	ProtocolType             *string            `json:"protocolType"`
-	RouteKey                 *string            `json:"routeKey,omitempty"`
-	RouteSelectionExpression *string            `json:"routeSelectionExpression,omitempty"`
-	Tags                     map[string]*string `json:"tags,omitempty"`
-	Target                   *string            `json:"target,omitempty"`
-	Version                  *string            `json:"version,omitempty"`
+	APIKeySelectionExpression *string            `json:"apiKeySelectionExpression,omitempty"`
+	Basepath                  *string            `json:"basepath,omitempty"`
+	Body                      *string            `json:"body,omitempty"`
+	CorsConfiguration         *Cors              `json:"corsConfiguration,omitempty"`
+	CredentialsARN            *string            `json:"credentialsARN,omitempty"`
+	Description               *string            `json:"description,omitempty"`
+	DisableExecuteAPIEndpoint *bool              `json:"disableExecuteAPIEndpoint,omitempty"`
+	DisableSchemaValidation   *bool              `json:"disableSchemaValidation,omitempty"`
+	FailOnWarnings            *bool              `json:"failOnWarnings,omitempty"`
+	Name                      *string            `json:"name,omitempty"`
+	ProtocolType              *string            `json:"protocolType,omitempty"`
+	RouteKey                  *string            `json:"routeKey,omitempty"`
+	RouteSelectionExpression  *string            `json:"routeSelectionExpression,omitempty"`
+	Tags                      map[string]*string `json:"tags,omitempty"`
+	Target                    *string            `json:"target,omitempty"`
+	Version                   *string            `json:"version,omitempty"`
 }
 
 // APIStatus defines the observed state of API

--- a/services/apigatewayv2/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/services/apigatewayv2/apis/v1alpha1/zz_generated.deepcopy.go
@@ -256,6 +256,16 @@ func (in *APISpec) DeepCopyInto(out *APISpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Basepath != nil {
+		in, out := &in.Basepath, &out.Basepath
+		*out = new(string)
+		**out = **in
+	}
+	if in.Body != nil {
+		in, out := &in.Body, &out.Body
+		*out = new(string)
+		**out = **in
+	}
 	if in.CorsConfiguration != nil {
 		in, out := &in.CorsConfiguration, &out.CorsConfiguration
 		*out = new(Cors)
@@ -278,6 +288,11 @@ func (in *APISpec) DeepCopyInto(out *APISpec) {
 	}
 	if in.DisableSchemaValidation != nil {
 		in, out := &in.DisableSchemaValidation, &out.DisableSchemaValidation
+		*out = new(bool)
+		**out = **in
+	}
+	if in.FailOnWarnings != nil {
+		in, out := &in.FailOnWarnings, &out.FailOnWarnings
 		*out = new(bool)
 		**out = **in
 	}

--- a/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_apis.yaml
+++ b/services/apigatewayv2/config/crd/bases/apigatewayv2.services.k8s.aws_apis.yaml
@@ -38,6 +38,10 @@ spec:
             properties:
               apiKeySelectionExpression:
                 type: string
+              basepath:
+                type: string
+              body:
+                type: string
               corsConfiguration:
                 properties:
                   allowCredentials:
@@ -70,6 +74,8 @@ spec:
                 type: boolean
               disableSchemaValidation:
                 type: boolean
+              failOnWarnings:
+                type: boolean
               name:
                 type: string
               protocolType:
@@ -86,9 +92,6 @@ spec:
                 type: string
               version:
                 type: string
-            required:
-            - name
-            - protocolType
             type: object
           status:
             description: APIStatus defines the observed state of API

--- a/services/apigatewayv2/generator.yaml
+++ b/services/apigatewayv2/generator.yaml
@@ -1,0 +1,24 @@
+resources:
+  Api:
+    fields:
+      Body:
+        from:
+          operation: ImportApi
+          path: Body
+      Basepath:
+        from:
+          operation: ImportApi
+          path: Basepath
+      FailOnWarnings:
+        from:
+          operation: ImportApi
+          path: FailOnWarnings
+      Name:
+        is_required: false
+      ProtocolType:
+        is_required: false
+    update_operation:
+      custom_method_name: customUpdateApi
+operations:
+  CreateApi:
+    custom_implementation: customCreateApi

--- a/services/apigatewayv2/helm/crds/apigatewayv2.services.k8s.aws_apis.yaml
+++ b/services/apigatewayv2/helm/crds/apigatewayv2.services.k8s.aws_apis.yaml
@@ -38,6 +38,10 @@ spec:
             properties:
               apiKeySelectionExpression:
                 type: string
+              basepath:
+                type: string
+              body:
+                type: string
               corsConfiguration:
                 properties:
                   allowCredentials:
@@ -70,6 +74,8 @@ spec:
                 type: boolean
               disableSchemaValidation:
                 type: boolean
+              failOnWarnings:
+                type: boolean
               name:
                 type: string
               protocolType:
@@ -86,9 +92,6 @@ spec:
                 type: string
               version:
                 type: string
-            required:
-            - name
-            - protocolType
             type: object
           status:
             description: APIStatus defines the observed state of API

--- a/services/apigatewayv2/pkg/resource/api/custom_http_api.go
+++ b/services/apigatewayv2/pkg/resource/api/custom_http_api.go
@@ -1,0 +1,413 @@
+package api
+
+import (
+	"context"
+	"errors"
+
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+	"github.com/aws/aws-controllers-k8s/services/apigatewayv2/apis/v1alpha1"
+	"github.com/aws/aws-sdk-go/service/apigatewayv2"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// customCreateApi checks if the Api resource should be imported or created.
+// If the API resource should be imported, this operation performs the import and returns the updated ko.
+// And if the API resource should be created, this operation returns nil, nil and createApi is performed in sdkCreate
+// operation.
+func (rm *resourceManager) customCreateApi(
+	ctx context.Context,
+	r *resource,
+) (*resource, error) {
+	// Based on the fields in desired, find whether we need to reimport or update
+	if rm.importFieldsPresent(r.ko) {
+		if err := rm.validateImportApiInputFields(r.ko); err != nil {
+			return nil, err
+		} else {
+			// import
+			return rm.importApi(ctx, r)
+		}
+	} else {
+		if err := rm.validateCreateApiInputFields(r.ko); err != nil {
+			return nil, err
+		} else {
+			return nil, nil
+		}
+	}
+}
+
+// customUpdateApi is the custom implementation for API resource's update operation
+// If the API resource should be reimported, this operation performs the reimportApi and returns the updated ko.
+// And if the API resource should be updated, this operation performs the updateApi and returns the updated ko.
+func (rm *resourceManager) customUpdateApi(ctx context.Context,
+	desired *resource,
+	latest *resource,
+	diffReporter *ackcompare.Reporter,
+) (*resource, error) {
+	// Based on the fields in desired, find whether we need to reimport or update
+	if rm.importFieldsPresent(desired.ko) {
+		if err := rm.validateReimportApiInputFields(desired.ko); err != nil {
+			return nil, err
+		} else {
+			return rm.reimportApi(ctx, desired)
+		}
+	} else {
+		if err := rm.validateUpdateApiInputFields(desired.ko); err != nil {
+			return nil, err
+		} else {
+			return rm.updateApi(ctx, desired)
+		}
+	}
+}
+
+// importFieldsPresent checks for the presence of 'Body', 'Basepath' & 'FailOnWarning' fields
+// in the API resource. When the mentioned fields are present, ImportApi operation is desired over CreateApi
+func (rm *resourceManager) importFieldsPresent(api *v1alpha1.API) bool {
+	if api.Spec.Body != nil || api.Spec.Basepath != nil || api.Spec.FailOnWarnings != nil {
+		return true
+	}
+	return false
+}
+
+// validateImportApiInputFields validates if all the fields are present for a successful 'ImportApi' call
+func (rm *resourceManager) validateImportApiInputFields(api *v1alpha1.API) error {
+	// For import-api, body is a required field
+	if api.Spec.Body == nil {
+		errorMessage := ""
+		if api.Spec.FailOnWarnings != nil {
+			errorMessage += "'FailOnWarnings'"
+		}
+
+		if api.Spec.Basepath != nil {
+			if errorMessage == "" {
+				errorMessage += "'Basepath'"
+			} else {
+				errorMessage += " and 'Basepath'"
+			}
+		}
+		errorMessage += " field(s) can only be used with 'Body' field for import-api operation"
+
+		return errors.New(errorMessage)
+	} else {
+		// Body field is present.
+		// Check that no other fields except 'Basepath' and 'FailOnWarnings' is present.
+		specCopy := api.Spec.DeepCopy()
+		specCopy.Body = nil
+		specCopy.FailOnWarnings = nil
+		specCopy.Basepath = nil
+		opts := []cmp.Option{cmpopts.EquateEmpty()}
+		if cmp.Equal(*specCopy, v1alpha1.APISpec{}, opts...) {
+			return nil
+		} else {
+			return errors.New("only 'FailOnWarnings' and 'Basepath' fields can be used with 'Body' field")
+		}
+	}
+}
+
+// validateReimportApiInputFields validates if all the fields are present for a successful ReimportApi operation
+// Currently this validation is similar to ImportApi validation.
+func (rm *resourceManager) validateReimportApiInputFields(api *v1alpha1.API) error {
+	return rm.validateImportApiInputFields(api)
+}
+
+// validateCreateApiInputFields validates if all the fields are present for a successful CreateApi operation
+func (rm *resourceManager) validateCreateApiInputFields(api *v1alpha1.API) error {
+	if api.Spec.Name == nil || api.Spec.ProtocolType == nil {
+		return errors.New("'Name' and 'ProtocolType' are required properties if 'Body' field is not present")
+	}
+	return nil
+}
+
+// validateUpdateApiInputFields validates if all the fields are present for a successful UpdateApi operation
+// Currently this validation is similar to CreateApi validation.
+func (rm *resourceManager) validateUpdateApiInputFields(api *v1alpha1.API) error {
+	return rm.validateCreateApiInputFields(api)
+}
+
+// importApi creates the Api resource by performing ImportApi sdk operation
+func (rm *resourceManager) importApi(ctx context.Context, desired *resource) (*resource, error) {
+	input, err := rm.importApiInput(desired)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, respErr := rm.sdkapi.ImportApiWithContext(ctx, input)
+	rm.metrics.RecordAPICall("CREATE", "ImportApi", respErr)
+	if respErr != nil {
+		return nil, respErr
+	}
+
+	// Merge in the information we read from the API call above to the copy of
+	// the original Kubernetes object we passed to the function
+	ko := desired.ko.DeepCopy()
+
+	if resp.ApiEndpoint != nil {
+		ko.Status.APIEndpoint = resp.ApiEndpoint
+	}
+	if resp.ApiGatewayManaged != nil {
+		ko.Status.APIGatewayManaged = resp.ApiGatewayManaged
+	}
+	if resp.ApiId != nil {
+		ko.Status.APIID = resp.ApiId
+	}
+	if resp.CreatedDate != nil {
+		ko.Status.CreatedDate = &metav1.Time{*resp.CreatedDate}
+	}
+	if resp.ImportInfo != nil {
+		f9 := []*string{}
+		for _, f9iter := range resp.ImportInfo {
+			var f9elem string
+			f9elem = *f9iter
+			f9 = append(f9, &f9elem)
+		}
+		ko.Status.ImportInfo = f9
+	}
+	if resp.Warnings != nil {
+		f15 := []*string{}
+		for _, f15iter := range resp.Warnings {
+			var f15elem string
+			f15elem = *f15iter
+			f15 = append(f15, &f15elem)
+		}
+		ko.Status.Warnings = f15
+	}
+
+	rm.setStatusDefaults(ko)
+
+	return &resource{ko}, nil
+}
+
+// reimportApi updates the Api resource's desired state after performing ReimportApi sdk operation
+func (rm *resourceManager) reimportApi(ctx context.Context, desired *resource) (*resource, error) {
+	input, err := rm.reimportApiInput(desired)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, respErr := rm.sdkapi.ReimportApiWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "ReimportApi", respErr)
+	if respErr != nil {
+		return nil, respErr
+	}
+
+	// Merge in the information we read from the API call above to the copy of
+	// the original Kubernetes object we passed to the function
+	ko := desired.ko.DeepCopy()
+
+	if resp.ApiEndpoint != nil {
+		ko.Status.APIEndpoint = resp.ApiEndpoint
+	}
+	if resp.ApiGatewayManaged != nil {
+		ko.Status.APIGatewayManaged = resp.ApiGatewayManaged
+	}
+	if resp.ApiId != nil {
+		ko.Status.APIID = resp.ApiId
+	}
+	if resp.CreatedDate != nil {
+		ko.Status.CreatedDate = &metav1.Time{*resp.CreatedDate}
+	}
+	if resp.ImportInfo != nil {
+		f9 := []*string{}
+		for _, f9iter := range resp.ImportInfo {
+			var f9elem string
+			f9elem = *f9iter
+			f9 = append(f9, &f9elem)
+		}
+		ko.Status.ImportInfo = f9
+	}
+	if resp.Warnings != nil {
+		f15 := []*string{}
+		for _, f15iter := range resp.Warnings {
+			var f15elem string
+			f15elem = *f15iter
+			f15 = append(f15, &f15elem)
+		}
+		ko.Status.Warnings = f15
+	}
+
+	rm.setStatusDefaults(ko)
+
+	return &resource{ko}, nil
+}
+
+// updateApi updates the Api resource's desired state after performing UpdateApi sdk operation
+func (rm *resourceManager) updateApi(ctx context.Context, desired *resource) (*resource, error) {
+	input, err := rm.updateApiInput(desired)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, respErr := rm.sdkapi.UpdateApiWithContext(ctx, input)
+	rm.metrics.RecordAPICall("UPDATE", "UpdateApi", respErr)
+	if respErr != nil {
+		return nil, respErr
+	}
+	// Merge in the information we read from the API call above to the copy of
+	// the original Kubernetes object we passed to the function
+	ko := desired.ko.DeepCopy()
+
+	if resp.ApiEndpoint != nil {
+		ko.Status.APIEndpoint = resp.ApiEndpoint
+	}
+	if resp.ApiGatewayManaged != nil {
+		ko.Status.APIGatewayManaged = resp.ApiGatewayManaged
+	}
+	if resp.ApiId != nil {
+		ko.Status.APIID = resp.ApiId
+	}
+	if resp.CreatedDate != nil {
+		ko.Status.CreatedDate = &metav1.Time{*resp.CreatedDate}
+	}
+	if resp.ImportInfo != nil {
+		f9 := []*string{}
+		for _, f9iter := range resp.ImportInfo {
+			var f9elem string
+			f9elem = *f9iter
+			f9 = append(f9, &f9elem)
+		}
+		ko.Status.ImportInfo = f9
+	}
+	if resp.Warnings != nil {
+		f15 := []*string{}
+		for _, f15iter := range resp.Warnings {
+			var f15elem string
+			f15elem = *f15iter
+			f15 = append(f15, &f15elem)
+		}
+		ko.Status.Warnings = f15
+	}
+
+	rm.setStatusDefaults(ko)
+
+	return &resource{ko}, nil
+}
+
+// importApiInput returns an SDK-specific struct for the HTTP request
+// payload of the  ImportApi call for the resource
+func (rm *resourceManager) importApiInput(r *resource) (*apigatewayv2.ImportApiInput, error) {
+	res := &apigatewayv2.ImportApiInput{}
+	if r.ko.Spec.Body != nil {
+		res.SetBody(*r.ko.Spec.Body)
+	}
+	if r.ko.Spec.Basepath != nil {
+		res.SetBasepath(*r.ko.Spec.Basepath)
+	}
+	if r.ko.Spec.FailOnWarnings != nil {
+		res.SetFailOnWarnings(*r.ko.Spec.FailOnWarnings)
+	}
+	return res, nil
+}
+
+// reimportApiInput returns an SDK-specific struct for the HTTP request
+// payload of the  ReimportApi call for the resource
+func (rm *resourceManager) reimportApiInput(r *resource) (*apigatewayv2.ReimportApiInput, error) {
+	res := &apigatewayv2.ReimportApiInput{}
+
+	if r.ko.Status.APIID != nil {
+		res.SetApiId(*r.ko.Status.APIID)
+	} else {
+		return nil, errors.New("'APIID' is required input parameter for 'ReimportApi' operation")
+	}
+
+	if r.ko.Spec.Body != nil {
+		res.SetBody(*r.ko.Spec.Body)
+	}
+	if r.ko.Spec.Basepath != nil {
+		res.SetBasepath(*r.ko.Spec.Basepath)
+	}
+	if r.ko.Spec.FailOnWarnings != nil {
+		res.SetFailOnWarnings(*r.ko.Spec.FailOnWarnings)
+	}
+	return res, nil
+}
+
+// updateApiInput returns an SDK-specific struct for the HTTP request
+// payload of the UpdateApi call for the resource
+func (rm *resourceManager) updateApiInput(
+	r *resource,
+) (*apigatewayv2.UpdateApiInput, error) {
+	res := &apigatewayv2.UpdateApiInput{}
+
+	if r.ko.Status.APIID != nil {
+		res.SetApiId(*r.ko.Status.APIID)
+	}
+	if r.ko.Spec.APIKeySelectionExpression != nil {
+		res.SetApiKeySelectionExpression(*r.ko.Spec.APIKeySelectionExpression)
+	}
+	if r.ko.Spec.CorsConfiguration != nil {
+		f2 := &apigatewayv2.Cors{}
+		if r.ko.Spec.CorsConfiguration.AllowCredentials != nil {
+			f2.SetAllowCredentials(*r.ko.Spec.CorsConfiguration.AllowCredentials)
+		}
+		if r.ko.Spec.CorsConfiguration.AllowHeaders != nil {
+			f2f1 := []*string{}
+			for _, f2f1iter := range r.ko.Spec.CorsConfiguration.AllowHeaders {
+				var f2f1elem string
+				f2f1elem = *f2f1iter
+				f2f1 = append(f2f1, &f2f1elem)
+			}
+			f2.SetAllowHeaders(f2f1)
+		}
+		if r.ko.Spec.CorsConfiguration.AllowMethods != nil {
+			f2f2 := []*string{}
+			for _, f2f2iter := range r.ko.Spec.CorsConfiguration.AllowMethods {
+				var f2f2elem string
+				f2f2elem = *f2f2iter
+				f2f2 = append(f2f2, &f2f2elem)
+			}
+			f2.SetAllowMethods(f2f2)
+		}
+		if r.ko.Spec.CorsConfiguration.AllowOrigins != nil {
+			f2f3 := []*string{}
+			for _, f2f3iter := range r.ko.Spec.CorsConfiguration.AllowOrigins {
+				var f2f3elem string
+				f2f3elem = *f2f3iter
+				f2f3 = append(f2f3, &f2f3elem)
+			}
+			f2.SetAllowOrigins(f2f3)
+		}
+		if r.ko.Spec.CorsConfiguration.ExposeHeaders != nil {
+			f2f4 := []*string{}
+			for _, f2f4iter := range r.ko.Spec.CorsConfiguration.ExposeHeaders {
+				var f2f4elem string
+				f2f4elem = *f2f4iter
+				f2f4 = append(f2f4, &f2f4elem)
+			}
+			f2.SetExposeHeaders(f2f4)
+		}
+		if r.ko.Spec.CorsConfiguration.MaxAge != nil {
+			f2.SetMaxAge(*r.ko.Spec.CorsConfiguration.MaxAge)
+		}
+		res.SetCorsConfiguration(f2)
+	}
+	if r.ko.Spec.CredentialsARN != nil {
+		res.SetCredentialsArn(*r.ko.Spec.CredentialsARN)
+	}
+	if r.ko.Spec.Description != nil {
+		res.SetDescription(*r.ko.Spec.Description)
+	}
+	if r.ko.Spec.DisableExecuteAPIEndpoint != nil {
+		res.SetDisableExecuteApiEndpoint(*r.ko.Spec.DisableExecuteAPIEndpoint)
+	}
+	if r.ko.Spec.DisableSchemaValidation != nil {
+		res.SetDisableSchemaValidation(*r.ko.Spec.DisableSchemaValidation)
+	}
+	if r.ko.Spec.Name != nil {
+		res.SetName(*r.ko.Spec.Name)
+	}
+	if r.ko.Spec.RouteKey != nil {
+		res.SetRouteKey(*r.ko.Spec.RouteKey)
+	}
+	if r.ko.Spec.RouteSelectionExpression != nil {
+		res.SetRouteSelectionExpression(*r.ko.Spec.RouteSelectionExpression)
+	}
+	if r.ko.Spec.Target != nil {
+		res.SetTarget(*r.ko.Spec.Target)
+	}
+	if r.ko.Spec.Version != nil {
+		res.SetVersion(*r.ko.Spec.Version)
+	}
+
+	return res, nil
+}

--- a/services/apigatewayv2/pkg/resource/api/custom_http_api_test.go
+++ b/services/apigatewayv2/pkg/resource/api/custom_http_api_test.go
@@ -1,0 +1,292 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package api
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-controllers-k8s/pkg/metrics"
+	svcapitypes "github.com/aws/aws-controllers-k8s/services/apigatewayv2/apis/v1alpha1"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/apigatewayv2"
+	"github.com/aws/aws-sdk-go/service/apigatewayv2/apigatewayv2iface"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockApiGatewayV2 struct {
+	apigatewayv2iface.ApiGatewayV2API
+	importApiOutput   *apigatewayv2.ImportApiOutput
+	reimportApiOutput *apigatewayv2.ReimportApiOutput
+	updateApiOutput   *apigatewayv2.UpdateApiOutput
+}
+
+func (i mockApiGatewayV2) ImportApiWithContext(aws.Context, *apigatewayv2.ImportApiInput, ...request.Option) (*apigatewayv2.ImportApiOutput, error) {
+	return i.importApiOutput, nil
+}
+
+func (i mockApiGatewayV2) ReimportApiWithContext(aws.Context, *apigatewayv2.ReimportApiInput, ...request.Option) (*apigatewayv2.ReimportApiOutput, error) {
+	return i.reimportApiOutput, nil
+}
+
+func (i mockApiGatewayV2) UpdateApiWithContext(aws.Context, *apigatewayv2.UpdateApiInput, ...request.Option) (*apigatewayv2.UpdateApiOutput, error) {
+	return i.updateApiOutput, nil
+}
+
+// Helper methods to setup tests
+// provideResourceManager returns pointer to resourceManager
+func provideResourceManager(importApiOutput *apigatewayv2.ImportApiOutput, reimportApiOutput *apigatewayv2.ReimportApiOutput,
+	updateApiOutput *apigatewayv2.UpdateApiOutput) *resourceManager {
+	return &resourceManager{
+		rr:           nil,
+		awsAccountID: "",
+		awsRegion:    "",
+		sess:         nil,
+		sdkapi:       mockApiGatewayV2{importApiOutput: importApiOutput, reimportApiOutput: reimportApiOutput, updateApiOutput: updateApiOutput},
+		metrics:      metrics.NewMetrics("apigatewayv2"),
+	}
+}
+
+// provideResource returns pointer to resource
+func provideResource() *resource {
+	return &resource{
+		ko: &svcapitypes.API{},
+	}
+}
+
+func Test_ImportApi_IncompatibleFieldsPresent(t *testing.T) {
+	assert := assert.New(t)
+	// Setup
+	rm := provideResourceManager(nil, nil, nil)
+
+	desired := provideResource()
+	body := "body"
+	name := "name"
+	desired.ko.Spec = svcapitypes.APISpec{Body: &body, Name: &name}
+
+	var ctx context.Context
+
+	res, err := rm.customCreateApi(ctx, desired)
+	assert.Nil(res)
+	assert.NotNil(err)
+	assert.True(strings.Contains(err.Error(), "only 'FailOnWarnings' and 'Basepath' fields can be used with 'Body' field"))
+}
+
+func Test_ImportApi_BodyFieldMissing(t *testing.T) {
+	assert := assert.New(t)
+	// Setup
+	rm := provideResourceManager(nil, nil, nil)
+
+	desired := provideResource()
+	basepath := "basepath"
+	failOnWarning := false
+	desired.ko.Spec = svcapitypes.APISpec{Basepath: &basepath, FailOnWarnings: &failOnWarning}
+
+	var ctx context.Context
+
+	res, err := rm.customCreateApi(ctx, desired)
+	assert.Nil(res)
+	assert.NotNil(err)
+	assert.True(strings.Contains(err.Error(), "'FailOnWarnings' and 'Basepath' field(s) can only be used with 'Body' field for import-api operation"))
+
+	desired.ko.Spec = svcapitypes.APISpec{Basepath: &basepath}
+	res, err = rm.customCreateApi(ctx, desired)
+	assert.Nil(res)
+	assert.NotNil(err)
+	assert.True(strings.Contains(err.Error(), "'Basepath' field(s) can only be used with 'Body' field for import-api operation"))
+
+	desired.ko.Spec = svcapitypes.APISpec{FailOnWarnings: &failOnWarning}
+	res, err = rm.customCreateApi(ctx, desired)
+	assert.Nil(res)
+	assert.NotNil(err)
+	assert.True(strings.Contains(err.Error(), "'FailOnWarnings' field(s) can only be used with 'Body' field for import-api operation"))
+}
+
+func Test_ImportApi_Successful(t *testing.T) {
+	assert := assert.New(t)
+	// Setup
+	apiId := "apiId"
+	importApiOutput := apigatewayv2.ImportApiOutput{ApiId: &apiId}
+	rm := provideResourceManager(&importApiOutput, nil, nil)
+
+	desired := provideResource()
+	body := "body"
+	desired.ko.Spec = svcapitypes.APISpec{Body: &body}
+
+	var ctx context.Context
+
+	res, err := rm.customCreateApi(ctx, desired)
+	assert.NotNil(res)
+	assert.Nil(err)
+	assert.Equal(apiId, *res.ko.Status.APIID)
+}
+
+func Test_CreateApi_MissingRequiredFields(t *testing.T) {
+	assert := assert.New(t)
+	// Setup
+	rm := provideResourceManager(nil, nil, nil)
+
+	desired := provideResource()
+	desired.ko.Spec = svcapitypes.APISpec{}
+
+	var ctx context.Context
+
+	res, err := rm.customCreateApi(ctx, desired)
+	assert.Nil(res)
+	assert.NotNil(err)
+	assert.True(strings.Contains(err.Error(), "'Name' and 'ProtocolType' are required properties if 'Body' field is not present"))
+}
+
+func Test_CreateApi_HappyCase(t *testing.T) {
+	assert := assert.New(t)
+	// Setup
+	rm := provideResourceManager(nil, nil, nil)
+
+	desired := provideResource()
+	name := "apiname"
+	protocoltype := "protocolType"
+	desired.ko.Spec = svcapitypes.APISpec{Name: &name, ProtocolType: &protocoltype}
+
+	var ctx context.Context
+
+	res, err := rm.customCreateApi(ctx, desired)
+	assert.Nil(res)
+	assert.Nil(err)
+}
+
+func Test_ReImportApi_IncompatibleFieldsPresent(t *testing.T) {
+	assert := assert.New(t)
+	// Setup
+	rm := provideResourceManager(nil, nil, nil)
+
+	desired := provideResource()
+	body := "body"
+	name := "name"
+	desired.ko.Spec = svcapitypes.APISpec{Body: &body, Name: &name}
+
+	var ctx context.Context
+
+	res, err := rm.customUpdateApi(ctx, desired, nil, nil)
+	assert.Nil(res)
+	assert.NotNil(err)
+	assert.True(strings.Contains(err.Error(), "only 'FailOnWarnings' and 'Basepath' fields can be used with 'Body' field"))
+}
+
+func Test_ReImportApi_BodyFieldMissing(t *testing.T) {
+	assert := assert.New(t)
+	// Setup
+	rm := provideResourceManager(nil, nil, nil)
+
+	desired := provideResource()
+	basepath := "basepath"
+	failOnWarning := false
+	desired.ko.Spec = svcapitypes.APISpec{Basepath: &basepath, FailOnWarnings: &failOnWarning}
+
+	var ctx context.Context
+
+	res, err := rm.customUpdateApi(ctx, desired, nil, nil)
+	assert.Nil(res)
+	assert.NotNil(err)
+	assert.True(strings.Contains(err.Error(), "'FailOnWarnings' and 'Basepath' field(s) can only be used with 'Body' field for import-api operation"))
+
+	desired.ko.Spec = svcapitypes.APISpec{Basepath: &basepath}
+	res, err = rm.customUpdateApi(ctx, desired, nil, nil)
+	assert.Nil(res)
+	assert.NotNil(err)
+	assert.True(strings.Contains(err.Error(), "'Basepath' field(s) can only be used with 'Body' field for import-api operation"))
+
+	desired.ko.Spec = svcapitypes.APISpec{FailOnWarnings: &failOnWarning}
+	res, err = rm.customUpdateApi(ctx, desired, nil, nil)
+	assert.Nil(res)
+	assert.NotNil(err)
+	assert.True(strings.Contains(err.Error(), "'FailOnWarnings' field(s) can only be used with 'Body' field for import-api operation"))
+}
+
+func Test_ReImportApi_ApiIdMissing(t *testing.T) {
+	assert := assert.New(t)
+	// Setup
+	apiId := "apiId"
+	reimportApiOutput := apigatewayv2.ReimportApiOutput{ApiId: &apiId}
+	rm := provideResourceManager(nil, &reimportApiOutput, nil)
+
+	desired := provideResource()
+	body := "body"
+	desired.ko.Spec = svcapitypes.APISpec{Body: &body}
+
+	var ctx context.Context
+
+	res, err := rm.customUpdateApi(ctx, desired, nil, nil)
+	assert.Nil(res)
+	assert.NotNil(err)
+	assert.True(strings.Contains(err.Error(), "'APIID' is required input parameter for 'ReimportApi' operation"))
+}
+
+func Test_ReImportApi_Successful(t *testing.T) {
+	assert := assert.New(t)
+	// Setup
+	apiId := "apiId"
+	reimportApiOutput := apigatewayv2.ReimportApiOutput{ApiId: &apiId}
+	rm := provideResourceManager(nil, &reimportApiOutput, nil)
+
+	desired := provideResource()
+	body := "body"
+	desired.ko.Spec = svcapitypes.APISpec{Body: &body}
+	desired.ko.Status = svcapitypes.APIStatus{APIID: &apiId}
+
+	var ctx context.Context
+
+	res, err := rm.customUpdateApi(ctx, desired, nil, nil)
+	assert.NotNil(res)
+	assert.Nil(err)
+	assert.Equal(apiId, *res.ko.Status.APIID)
+}
+
+func Test_UpdateApi_MissingRequiredFields(t *testing.T) {
+	assert := assert.New(t)
+	// Setup
+	rm := provideResourceManager(nil, nil, nil)
+
+	desired := provideResource()
+	desired.ko.Spec = svcapitypes.APISpec{}
+
+	var ctx context.Context
+
+	res, err := rm.customUpdateApi(ctx, desired, nil, nil)
+	assert.Nil(res)
+	assert.NotNil(err)
+	assert.True(strings.Contains(err.Error(), "'Name' and 'ProtocolType' are required properties if 'Body' field is not present"))
+
+}
+
+func Test_UpdateApi_HappyCase(t *testing.T) {
+	assert := assert.New(t)
+	// Setup
+	apiId := "apiId"
+	updateApiOutput := apigatewayv2.UpdateApiOutput{ApiId: &apiId}
+	rm := provideResourceManager(nil, nil, &updateApiOutput)
+
+	desired := provideResource()
+	name := "name"
+	protocolType := "HTTP"
+	desired.ko.Spec = svcapitypes.APISpec{Name: &name, ProtocolType: &protocolType}
+
+	var ctx context.Context
+
+	res, err := rm.customUpdateApi(ctx, desired, nil, nil)
+	assert.NotNil(res)
+	assert.Nil(err)
+	assert.Equal(apiId, *res.ko.Status.APIID)
+}

--- a/test/e2e/apigatewayv2/api/e2e.sh
+++ b/test/e2e/apigatewayv2/api/e2e.sh
@@ -18,6 +18,8 @@ debug_msg "executing test: $service_name/$test_name"
 
 api_name="ack-test-$service_name-api"
 api_resource_name="api/$api_name"
+import_api_name="import-$api_name"
+import_api_resource_name="api/$import_api_name"
 integration_name="ack-test-$service_name-integration"
 integration_resource_name="integration/$integration_name"
 route_name="ack-test-$service_name-route"
@@ -51,6 +53,11 @@ if k8s_resource_exists "$authorizer_resource_name"; then
     exit 1
 fi
 
+if k8s_resource_exists "$import_api_resource_name"; then
+    echo "FATAL: expected $import_api_resource_name to not exist. Did previous test run cleanup?"
+    exit 1
+fi
+
 if k8s_resource_exists "$api_resource_name"; then
     echo "FATAL: expected $api_resource_name to not exist. Did previous test run cleanup?"
     exit 1
@@ -61,6 +68,8 @@ apigwv2_setup_iam_resources_for_authorizer "$authorizer_role_name"
 sleep 5
 apigwv2_create_lambda_authorizer "$authorizer_function_name" "$authorizer_role_name"
 
+apigwv2_import_http_api_and_validate "$import_api_name"
+apigwv2_reimport_http_api_and_validate "$import_api_name"
 apigwv2_create_http_api_and_validate "$api_name"
 apigwv2_update_http_api_and_validate "$api_name"
 apigwv2_create_integration_and_validate "$api_name" "$integration_name"
@@ -78,6 +87,7 @@ apigwv2_delete_route_and_validate "$api_name" "$route_name"
 apigwv2_delete_integration_and_validate "$api_name" "$integration_name"
 apigwv2_delete_authorizer_and_validate "$api_name" "$authorizer_name"
 apigwv2_delete_http_api_and_validate "$api_name"
+apigwv2_delete_http_api_and_validate "$import_api_name"
 
 apigwv2_delete_authorizer_lambda "$authorizer_function_name"
 apigwv2_clean_up_iam_resources_for_authorizer "$authorizer_role_name"

--- a/test/e2e/run-tests.sh
+++ b/test/e2e/run-tests.sh
@@ -2,8 +2,11 @@
 
 set -eo pipefail
 
-THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+E2E_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+ROOT_DIR="$E2E_DIR/../.."
+SCRIPTS_DIR="$ROOT_DIR/scripts"
 
+source "$SCRIPTS_DIR/lib/common.sh"
 USAGE="
 Usage:
   $(basename "$0") <service>
@@ -23,7 +26,7 @@ fi
 
 SERVICE="$1"
 
-service_test_dir="$THIS_DIR/$SERVICE"
+service_test_dir="$E2E_DIR/$SERVICE"
 
 if [ ! -d "$service_test_dir" ]; then
     echo "No tests for service $SERVICE"


### PR DESCRIPTION
Issue #128 , if available:

Description of changes:

Same as PR #600 but squashed into single commit.

Description of changes:
* **Fixing the classic e2e test run. Temporarily commenting docker test run.**
    * Update ack-generate/release to drop ".tpl" from files generated for helm charts.
    * I spent one day trying to fix docker-file and scripts for successfully running docker-test-run but in the end I hit the blocker where daws was unable to run inside docker.
    * Then I fall back to old e2e runs and temporarily commented docker-test-runs from kind-build-test
    * I made some minor fixes in script for successfully running e2e tests. 

* **Adding required override for fields in FieldConfig.**
    * Introduced a new boolean field 'IsRequired' in FieldConfig to override the required behavior present in aws-sdk-go.
    * This was required for ImportApi operation to succeed without taking required-fields from CreateApi operation.

* **Implementing ImportApi & ReimportApi for apigatewayv2.**
    * Created custom methods for Import and Reimport Api operations.
    * Updated e2e tests for apigatewayv2 to include ImportApi and ReimportApi.

Latest e2e test run

```
vijat@186590cff3cf ~ % cd /Users/vijat/Documents/gocode/src/github.com/vijtrip2/aws-controllers-k8s
vijat@186590cff3cf aws-controllers-k8s % ./scripts/kind-build-test.sh apigatewayv2                                   
checking AWS credentials ... ok.
creating kind cluster ack-test-c5f64136-857dc735 ... ok.
[+] Building 123.9s (17/17) FINISHED                                                                                                                                                          
 => [internal] load build definition from Dockerfile                                                                                                                                     0.5s
 => => transferring dockerfile: 39B                                                                                                                                                      0.3s
 => [internal] load .dockerignore                                                                                                                                                        0.2s
 => => transferring context: 2B                                                                                                                                                          0.0s
 => [internal] load metadata for docker.io/library/amazonlinux:2                                                                                                                         2.4s
 => [internal] load metadata for docker.io/library/golang:1.14.1                                                                                                                         2.5s
 => [auth] library/amazonlinux:pull token for registry-1.docker.io                                                                                                                       0.0s
 => [auth] library/golang:pull token for registry-1.docker.io                                                                                                                            0.0s
 => CACHED [stage-1 1/3] FROM docker.io/library/amazonlinux:2@sha256:420a6503505c73ea05e1254acd4d1a5e73305dab8ec3fa70833e112cc6980624                                                    0.0s
 => [internal] load build context                                                                                                                                                       13.6s
 => => transferring context: 19.28MB                                                                                                                                                    13.3s
 => [builder 1/7] FROM docker.io/library/golang:1.14.1@sha256:38a520b05b971181a5a30d72b74d1b70c63688eb267a4fb376c7476a5c6f885b                                                           0.0s
 => => resolve docker.io/library/golang:1.14.1@sha256:38a520b05b971181a5a30d72b74d1b70c63688eb267a4fb376c7476a5c6f885b                                                                   0.0s
 => CACHED [builder 2/7] WORKDIR /github.com/aws/aws-controllers-k8s                                                                                                                     0.0s
 => CACHED [builder 3/7] COPY go.mod go.mod                                                                                                                                              0.0s
 => CACHED [builder 4/7] COPY go.sum go.sum                                                                                                                                              0.0s
 => CACHED [builder 5/7] RUN  go mod download                                                                                                                                            0.0s
 => [builder 6/7] COPY . /github.com/aws/aws-controllers-k8s/                                                                                                                           11.2s
 => [builder 7/7] RUN GIT_VERSION=$(git describe --tags --dirty --always) &&     GIT_COMMIT=$(git rev-parse HEAD) &&     BUILD_DATE=$(date +%Y-%m-%dT%H:%M) &&     go build -ldflags="  93.8s
 => [stage-1 2/3] COPY --from=builder /github.com/aws/aws-controllers-k8s/bin/controller /github.com/aws/aws-controllers-k8s/LICENSE /github.com/aws/aws-controllers-k8s/ATTRIBUTION.md  0.4s
 => exporting to image                                                                                                                                                                   0.4s
 => => exporting layers                                                                                                                                                                  0.4s
 => => writing image sha256:8f6f96d4b469850e6e5738a54bebbe672186f71a25986325e0b17abdeb235d00                                                                                             0.0s
 => => naming to docker.io/library/aws-controllers-k8s:apigatewayv2-v0.0.1-138-g8444d33-dirty                                                                                            0.0s
ok.
loading the images into the cluster ... ok.
loading CRD manifests for apigatewayv2 into the cluster ... ok.
loading RBAC manifests for apigatewayv2 into the cluster ... ok.
loading service controller Deployment for apigatewayv2 into the cluster ...ok.
generating AWS temporary credentials and adding to env vars map ... ok.
======================================================================================================
To poke around your test cluster manually:
export KUBECONFIG=/Users/vijat/Documents/gocode/src/github.com/vijtrip2/aws-controllers-k8s/scripts/lib/../../build/tmp-ack-test-c5f64136-857dc735/kubeconfig
kubectl get pods -A
======================================================================================================
testing Helm release for apigatewayv2 for release version v0.0.1-138-g8444d33-dirty.
Building release artifacts for apigatewayv2-v0.0.1-138-g8444d33-dirty
Generating custom resource definitions for apigatewayv2
Generating RBAC manifests for apigatewayv2
namespace/ack-system-test-helm created
installing the helm chart for ack-apigatewayv2-controller in namespace ack-system-test-helm ... ok.
uninstalling the helm chart for ack-apigatewayv2-controller in namespace ack-system-test-helm ... ok.
e2e took 207 second(s)
🥑 Deleting k8s cluster using "kind"
Deleting cluster "ack-test-c5f64136-857dc735" ...

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
