### PR TITLE
standardize how current directory is determined

### DIFF
--- a/scripts/build-controller-image.sh
+++ b/scripts/build-controller-image.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-DIR=$(cd "$(dirname "$0")"; pwd)
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 SCRIPTS_DIR=$DIR
 DOCKERFILE_PATH=$DIR/../Dockerfile
 BUILD_CONTEXT=$DIR/..

--- a/scripts/build-controller-release.sh
+++ b/scripts/build-controller-release.sh
@@ -5,7 +5,7 @@
 
 set -eo pipefail
 
-SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$SCRIPTS_DIR/.."
 BIN_DIR="$ROOT_DIR/bin"
 TEMPLATES_DIR="$ROOT_DIR/templates"

--- a/scripts/build-controller.sh
+++ b/scripts/build-controller.sh
@@ -4,7 +4,7 @@
 
 set -eo pipefail
 
-SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$SCRIPTS_DIR/.."
 BIN_DIR="$ROOT_DIR/bin"
 TEMPLATES_DIR="$ROOT_DIR/templates"

--- a/scripts/delete-kind-cluster.sh
+++ b/scripts/delete-kind-cluster.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 USAGE="
 Usage:

--- a/scripts/helm-package-controller.sh
+++ b/scripts/helm-package-controller.sh
@@ -5,7 +5,7 @@
 
 set -eo pipefail
 
-SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$SCRIPTS_DIR/.."
 BUILD_DIR="$ROOT_DIR/build"
 

--- a/scripts/helm-publish-charts.sh
+++ b/scripts/helm-publish-charts.sh
@@ -7,7 +7,7 @@
 
 set -eo pipefail
 
-SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$SCRIPTS_DIR/.."
 SERVICES_DIR="$ROOT_DIR/services"
 DEFAULT_HELM_REGISTRY="public.ecr.aws/aws-controllers-k8s"

--- a/scripts/install-controller-gen.sh
+++ b/scripts/install-controller-gen.sh
@@ -17,7 +17,7 @@
 
 set -eo pipefail
 
-SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$SCRIPTS_DIR/.."
 CONTROLLER_TOOLS_VERSION="v0.4.0"
 

--- a/scripts/install-helm.sh
+++ b/scripts/install-helm.sh
@@ -11,7 +11,7 @@
 
 set -eo pipefail
 
-SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$SCRIPTS_DIR/.."
 DEFAULT_HELM_VERSION="3.2.4"
 

--- a/scripts/install-kind.sh
+++ b/scripts/install-kind.sh
@@ -11,7 +11,7 @@
 
 set -eo pipefail
 
-SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$SCRIPTS_DIR/.."
 DEFAULT_KIND_VERSION="0.9.0"
 

--- a/scripts/install-kubectl.sh
+++ b/scripts/install-kubectl.sh
@@ -8,7 +8,7 @@
 
 set -eo pipefail
 
-SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$SCRIPTS_DIR/.."
 
 source "$SCRIPTS_DIR/lib/common.sh"

--- a/scripts/install-kustomize.sh
+++ b/scripts/install-kustomize.sh
@@ -8,7 +8,7 @@
 
 set -eo pipefail
 
-SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$SCRIPTS_DIR/.."
 
 source "$SCRIPTS_DIR/lib/common.sh"

--- a/scripts/install-mockery.sh
+++ b/scripts/install-mockery.sh
@@ -6,7 +6,7 @@
 
 set -eo pipefail
 
-SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$SCRIPTS_DIR/.."
 BIN_DIR="$ROOT_DIR/bin"
 

--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -6,7 +6,7 @@
 
 set -Eeo pipefail
 
-SCRIPTS_DIR=$(cd "$(dirname "$0")" || exit 1; pwd)
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$SCRIPTS_DIR/.."
 TEST_DIR="$ROOT_DIR/test"
 TEST_E2E_DIR="$TEST_DIR/e2e"

--- a/scripts/provision-kind-cluster.sh
+++ b/scripts/provision-kind-cluster.sh
@@ -5,7 +5,7 @@
 
 set -eo pipefail
 
-SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$SCRIPTS_DIR/.."
 
 source "$SCRIPTS_DIR"/lib/common.sh

--- a/scripts/publish-controller-image.sh
+++ b/scripts/publish-controller-image.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-DIR=$(cd "$(dirname "$0")"; pwd)
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 SCRIPTS_DIR=$DIR
 DEFAULT_DOCKER_REPOSITORY="amazon/aws-controllers-k8s"
 DOCKER_REPOSITORY=${DOCKER_REPOSITORY:-$DEFAULT_DOCKER_REPOSITORY}


### PR DESCRIPTION
Issue #504 

Description of changes:
Standardize how the current directory is determined. Between the varied methods used, I have chosen the following:

`THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"`

Reasons:
- It now matches how it's done in other folders like `/test`
- it works even if the scripts are sourced, `dirname $0` will point to the bash binary when sourced instead. E.g.:

```
[nnosenzo@localhost aws-controllers-k8s]$ cat test.sh 
#!/usr/bin/env bash
THIS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
echo $THIS_DIR
SCRIPTS_DIR=$(cd "$(dirname "$0")"; pwd)
echo $SCRIPTS_DIR
```

Then, 
```
[nnosenzo@localhost aws-controllers-k8s]$ ./test.sh 
/home/nnosenzo/go/src/github.com/niconosenzo/aws-controllers-k8s
/home/nnosenzo/go/src/github.com/niconosenzo/aws-controllers-k8s
[nnosenzo@localhost aws-controllers-k8s]$ . ./test.sh 
/home/nnosenzo/go/src/github.com/niconosenzo/aws-controllers-k8s
/bin
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
