### PR TITLE
Update install-controller-gen.sh and dev docs

### DIFF
--- a/docs/contents/dev-docs/testing.md
+++ b/docs/contents/dev-docs/testing.md
@@ -32,6 +32,7 @@ which in turn requires Docker.
 In summary, in order to test ACK you will need to have the following tools
 installed and configured:
 
+1. [Golang 1.14+](https://golang.org/doc/install)
 1. [Docker](https://docs.docker.com/get-docker/)
 1. [kind](https://kind.sigs.k8s.io/docs/user/quick-start/)
 1. [kubernetes-sigs/controller-tools](https://github.com/kubernetes-sigs/controller-tools)
@@ -93,7 +94,7 @@ make build-controller SERVICE=$SERVICE
 !!! bug "Handle `controller-gen: command not found`"
     If you run into the `controller-gen: command not found` message when
     executing `make build-controller` then you want to check if the
-    `controller-gen` binary is available in `$GOPATH/bin`, see also
+    `controller-gen` binary is available in `$GOPATH/bin`, also ensure that `$GOPATH/bin` is part of your `$PATH`, see also
     [`#234`](https://github.com/aws/aws-controllers-k8s/issues/234).
 
 In addition to the ACK service controller code, above generates the

--- a/scripts/install-controller-gen.sh
+++ b/scripts/install-controller-gen.sh
@@ -25,9 +25,9 @@ source "$SCRIPTS_DIR/lib/common.sh"
 source "$SCRIPTS_DIR/lib/k8s.sh"
 
 if ! is_installed controller-gen; then
-    # GOBIN not always set... so default to installing into $GOPATH/bin if
-    # not...
-    __install_dir=${GOBIN:-$GOPATH/bin}
+    # GOBIN and GOPATH are not always set, so default to GOPATH from `go env`
+    __GOPATH=$(go env GOPATH)
+    __install_dir=${GOBIN:-$__GOPATH/bin}
     __install_path="$__install_dir/controller-gen"
     __work_dir=$(mktemp -d /tmp/controller-gen-XXX)
 


### PR DESCRIPTION
Updated install-controller-gen.sh to use GO Binary to determine
GOPATH as not all platforms have $GOPATH configured. Updated dev docs
to supported version of GO based on go.mod file.

Issue #, if available:

Description of changes:
* Update docs for clarity
* Update install-controller-gen.sh to support different platforms by using go binary to find the environment path

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
