### PR TITLE
E2E Tests for Events, Allowed node modifications

### DIFF
--- a/test/e2e/elasticache/cache_parameter_group/e2e.sh
+++ b/test/e2e/elasticache/cache_parameter_group/e2e.sh
@@ -107,6 +107,7 @@ update_cache_parameter_group_fields() {
 update_cache_parameter_group_fields
 ack_set_custom_cache_parameters
 assert_custom_cache_parameters
+assert_cpg_events "$cpg_name"
 
 #########################
 ## Remove parameter

--- a/test/e2e/elasticache/replication_group/creation.sh
+++ b/test/e2e/elasticache/replication_group/creation.sh
@@ -106,6 +106,12 @@ test_create_rg_single_shard_no_replicas() {
 
   # ensure resource successfully created and available
   wait_and_assert_replication_group_synced_and_available "$rg_id"
+
+  # ensure node type modification list exists.
+  assert_replication_list_allowed_node_type_modifications "$rg_id"
+
+  # ensure events exist.
+  assert_replication_group_events "$rg_id"
 }
 
 # create RG with custom node group specification where ID isn't surrounded by quotes: negative test,


### PR DESCRIPTION
Add new asserts for the existing tests to validate events, allowed node modifications.

Asserting on exact  allowed node type modifications and events is difficult so we assert on length.