### PR TITLE
Fix integration test automation

### DIFF
--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -191,6 +191,22 @@ echo "==========================================================================
 export KUBECONFIG
 
 $TEST_RELEASE_DIR/test-helm.sh "$AWS_SERVICE" "$VERSION"
-#$TEST_E2E_DIR/build-run-test-dockerfile.sh $AWS_SERVICE
-# switching to old e2e runs temporarily until docker test runs are successful.
-$TEST_E2E_DIR/run-tests.sh $AWS_SERVICE
+
+# Fork E2E tests based on bash or Python
+service_test_dir="$TEST_E2E_DIR/$AWS_SERVICE"
+
+if [ ! -d "$service_test_dir" ]; then
+    echo "No tests for service $SERVICE"
+    exit 0
+fi
+
+# check to see if the tests use pytest
+[[ -f "$service_test_dir/__init__.py" ]] && enable_python_tests="true" || enable_python_tests="false"
+
+if [[ "$enable_python_tests" == "false" ]]; then
+    # Run tests directly
+    $TEST_E2E_DIR/run-tests.sh $AWS_SERVICE
+else
+    # Run tests inside Dockerfile
+    $TEST_E2E_DIR/build-run-test-dockerfile.sh $AWS_SERVICE
+fi

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -3,6 +3,10 @@ The ACK End-to-End (E2E) testing framework intends to test each of the service
 operators against a set of known custom resource definitions.
 
 ## Overview
+The tests assume that a cluster has already been configured, the CRDs and 
+controller have been installed, and that the current user has access to AWS 
+credentials.
+
 The overall flow for the automated testing any one service is as follows:
 1. Run a bootstrap Python script
     - Invokes the individual service's `service_bootstrap.py` file,

--- a/test/e2e/build-run-test-dockerfile.sh
+++ b/test/e2e/build-run-test-dockerfile.sh
@@ -20,10 +20,13 @@ fi
 
 SERVICE="$1"
 
-KUBECONFIG_LOCATION="${KUBECONFIG:-"$HOME/.kube/config"}"
+  KUBECONFIG_LOCATION="${KUBECONFIG:-"$HOME/.kube/config"}"
 
-# Build the dockerfile first
-TEST_DOCKER_SHA="$(docker build . --quiet)"
+# Ensure we are inside the correct build context
+pushd "${THIS_DIR}" > /dev/null
+  # Build the dockerfile first
+  TEST_DOCKER_SHA="$(docker build . --quiet)"
+popd
 
 # Ensure it can connect to KIND cluster on host device by running on host 
 # network. 

--- a/test/e2e/build-run-test-dockerfile.sh
+++ b/test/e2e/build-run-test-dockerfile.sh
@@ -20,7 +20,7 @@ fi
 
 SERVICE="$1"
 
-  KUBECONFIG_LOCATION="${KUBECONFIG:-"$HOME/.kube/config"}"
+KUBECONFIG_LOCATION="${KUBECONFIG:-"$HOME/.kube/config"}"
 
 # Ensure we are inside the correct build context
 pushd "${THIS_DIR}" > /dev/null

--- a/test/e2e/run-tests.sh
+++ b/test/e2e/run-tests.sh
@@ -3,10 +3,6 @@
 set -eo pipefail
 
 E2E_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-ROOT_DIR="$E2E_DIR/../.."
-SCRIPTS_DIR="$ROOT_DIR/scripts"
-
-source "$SCRIPTS_DIR/lib/common.sh"
 USAGE="
 Usage:
   $(basename "$0") <service>
@@ -40,6 +36,10 @@ fi
 service_test_files=$( find "$service_test_dir" -name helper -prune -false -o -type f ! -name '.*' | sort )
 
 if [[ "$enable_python_tests" == "false" ]]; then
+  ROOT_DIR="$E2E_DIR/../.."
+  SCRIPTS_DIR="$ROOT_DIR/scripts"
+  source "$SCRIPTS_DIR/lib/common.sh"
+
   for service_test_file in $service_test_files; do
       test_name=$( filenoext "$service_test_file" )
       test_start_time=$( date +%s )


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Attempting to fix automation of integration tests, don't want shell script tests to use Dockerfile.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
