### PR TITLE
refresh service release docs

### DIFF
--- a/docs/contents/services.md
+++ b/docs/contents/services.md
@@ -15,29 +15,41 @@ Controller Release Roadmap](https://github.com/aws/aws-controllers-k8s/projects/
 
 | AWS Service | Current Status | Next Milestone
 | ----------- | -------------- | --------------
-| Amazon [API Gateway V2][apigwv2] | `DEVELOPER PREVIEW` | [`BETA`](https://github.com/aws/aws-controllers-k8s/milestone/15)
-| Amazon [CloudFront Distribution][cfd] | `PLANNED` | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/14)
-| Amazon [DynamoDB][dynamodb] | `DEVELOPER PREVIEW` |
-| Amazon [ECR][ecr] | `DEVELOPER PREVIEW` |
-| Amazon [EFS][efs] | `PROPOSED` |
-| Amazon [EKS][eks] | `PLANNED` | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/7)
-| Amazon [ElastiCache][elasticache] | `DEVELOPER PREVIEW` | [`BETA`](https://github.com/aws/aws-controllers-k8s/milestone/9)
-| AWS [IAM][iam] | `PROPOSED` |
-| AWS [Lambda][lambda] | `PLANNED` | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/10)
-| Amazon [MQ][mq] | `PLANNED` | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/12)
-| Amazon [MSK][msk] | `PLANNED` | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/13)
-| Amazon [RDS][rds] | `PLANNED` | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/8)
-| Amazon [Sagemaker][sagemaker] | `BUILD` | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/11)
-| Amazon [SNS][sns] | `DEVELOPER PREVIEW` |
-| Amazon [SQS][sqs] | `BUILD` | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/6)
-| AWS [StepFunctions][sfn] | `DEVELOPER PREVIEW`
-| Amazon [S3][s3] | `DEVELOPER PREVIEW` |
+| Amazon [ACM][Amazon ACM] | `PROPOSED` |
+| Amazon [API Gateway V2][Amazon API Gateway v2] | `DEVELOPER PREVIEW` | [`BETA`](https://github.com/aws/aws-controllers-k8s/milestone/15)
+| Amazon [CloudFront Distribution][Amazon CloudFront Distribution] | `PLANNED` | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/14)
+| Amazon [DynamoDB][Amazon DynamoDB] | `DEVELOPER PREVIEW` |
+| Amazon [ECR][Amazon ECR] | `DEVELOPER PREVIEW` |
+| Amazon [EFS][Amazon EFS] | `PROPOSED` |
+| Amazon [EKS][Amazon EKS] | `PLANNED` | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/7)
+| Amazon [ElastiCache][Amazon ElastiCache] | `DEVELOPER PREVIEW` | [`BETA`](https://github.com/aws/aws-controllers-k8s/milestone/9)
+| Amazon [Elasticsearch][Amazon Elasticsearch] | `PROPOSED` |
+| Amazon [EC2 VPC][Amazon EC2 VPC] | `PROPOSED` |
+| AWS [IAM][AWS IAM] | `PROPOSED` |
+| AWS [Kinesis][AWS Kinesis] | `PROPOSED` |
+| Amazon [KMS][Amazon KMS] | `BUILD` | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/18)
+| AWS [Lambda][AWS Lambda] | `BUILD` | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/10)
+| Amazon [MQ][Amazon MQ] | `BUILD` | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/12)
+| Amazon [MSK][Amazon MSK] | `PLANNED` | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/13)
+| Amazon [RDS][Amazon RDS] | `BUILD` | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/8)
+| Amazon [Route53][Amazon Route53] | `PROPOSED` |
+| Amazon [SageMaker][Amazon SageMaker] | `BUILD` | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/11)
+| Amazon [SNS][Amazon SNS] | `DEVELOPER PREVIEW` |
+| Amazon [SQS][Amazon SQS] | `BUILD` | [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/6)
+| AWS [StepFunctions][AWS StepFunctions] | `DEVELOPER PREVIEW`
+| Amazon [S3][Amazon S3] | `DEVELOPER PREVIEW` |
 
 !!! note "Don't see a service listed?"
     If you don't see a particular AWS service listed, feel free to
     [propose it](https://github.com/aws/aws-controllers-k8s/issues/new?labels=Service+Controller&template=propose_new_controller.md&title=%5Bname%5D+service+controller)!
 
-## Amazon API Gateway v2 [apigwv2]
+## Amazon ACM
+
+* Proposed: https://github.com/aws/aws-controllers-k8s/issues/482
+* Current release status: `PROPOSED`
+* AWS service documentation: https://aws.amazon.com/acm/
+
+## Amazon API Gateway v2
 
 * Proposed: https://github.com/aws/aws-controllers-k8s/issues/207
 * Current release status: `DEVELOPER PREVIEW`
@@ -45,14 +57,14 @@ Controller Release Roadmap](https://github.com/aws/aws-controllers-k8s/projects/
 * AWS service documentation: https://aws.amazon.com/api-gateway/
 * ACK service controller: https://github.com/aws/aws-controllers-k8s/tree/main/services/apigatewayv2
 
-## Amazon CloudFront Distribution [cfd]
+## Amazon CloudFront Distribution
 
 * Proposed: https://github.com/aws/aws-controllers-k8s/issues/249
 * Next milestone: [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/14)
 * Current release status: `PLANNED`
 * AWS service documentation: https://aws.amazon.com/cloudfront/
 
-## Amazon DynamoDB [dynamodb]
+## Amazon DynamoDB
 
 * Proposed: https://github.com/aws/aws-controllers-k8s/issues/206
 * Current release status: `DEVELOPER PREVIEW`
@@ -60,7 +72,7 @@ Controller Release Roadmap](https://github.com/aws/aws-controllers-k8s/projects/
 * AWS service documentation: https://aws.amazon.com/dynamodb/
 * ACK service controller: https://github.com/aws/aws-controllers-k8s/tree/main/services/dynamodb
 
-## Amazon ECR [ecr]
+## Amazon ECR
 
 * Proposed: https://github.com/aws/aws-controllers-k8s/issues/208
 * Current release status: `DEVELOPER PREVIEW`
@@ -68,19 +80,19 @@ Controller Release Roadmap](https://github.com/aws/aws-controllers-k8s/projects/
 * AWS service documentation: https://aws.amazon.com/ecr/
 * ACK service controller: https://github.com/aws/aws-controllers-k8s/tree/main/services/ecr
 
-## Amazon EFS [efs]
+## Amazon EFS
 
 * Proposed: https://github.com/aws/aws-controllers-k8s/issues/328
 * Current release status: `PROPOSED`
 * AWS service documentation: https://aws.amazon.com/efs/
 
-## Amazon EKS [eks]
+## Amazon EKS
 
 * Proposed: https://github.com/aws/aws-controllers-k8s/issues/16
 * Current release status: `PLANNED`
 * AWS service documentation: https://aws.amazon.com/eks/
 
-## Amazon Elasticache [elasticache]
+## Amazon ElastiCache
 
 * Proposed: https://github.com/aws/aws-controllers-k8s/issues/240
 * Current release status: `DEVELOPER PREVIEW`
@@ -88,48 +100,85 @@ Controller Release Roadmap](https://github.com/aws/aws-controllers-k8s/projects/
 * AWS service documentation: https://aws.amazon.com/elasticache/
 * ACK service controller: https://github.com/aws/aws-controllers-k8s/tree/main/services/elasticache
 
-## AWS IAM [iam]
+## Amazon Elasticsearch
+
+* Proposed: https://github.com/aws/aws-controllers-k8s/issues/503
+* Current release status: `PROPOSED`
+* AWS service documentation: https://aws.amazon.com/elasticsearch-service/
+
+## Amazon EC2 VPC
+
+* Proposed: https://github.com/aws/aws-controllers-k8s/issues/489
+* Current release status: `PROPOSED`
+* AWS service documentation: https://docs.aws.amazon.com/vpc/
+
+## AWS IAM
 
 * Proposed: https://github.com/aws/aws-controllers-k8s/issues/222
 * Current release status: `PROPOSED`
 * AWS service documentation: https://aws.amazon.com/iam/
 
-## AWS Lambda [lambda]
+## AWS Lambda
 
 * Proposed: https://github.com/aws/aws-controllers-k8s/issues/238
-* Current release status: `PLANNED`
+* Current release status: `BUILD`
 * Next milestone: [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/10)
 * AWS service documentation: https://aws.amazon.com/lambda/
 
-## Amazon MQ [mq]
+## Amazon EFS
+
+* Proposed: https://github.com/aws/aws-controllers-k8s/issues/328
+* Current release status: `PROPOSED`
+* AWS service documentation: https://aws.amazon.com/efs/
+
+## Amazon Kinesis
+
+* Proposed: https://github.com/aws/aws-controllers-k8s/issues/235
+* Current release status: `PROPOSED`
+* AWS service documentation: https://aws.amazon.com/kinesis/
+
+## AWS KMS
+
+* Proposed: https://github.com/aws/aws-controllers-k8s/issues/491
+* Current release status: `BUILD`
+* Next milestone: [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/18)
+* AWS service documentation: https://aws.amazon.com/kms/
+
+## Amazon MQ
 
 * Proposed: https://github.com/aws/aws-controllers-k8s/issues/390
-* Current release status: `PLANNED`
+* Current release status: `BUILD`
 * Next milestone: [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/12)
 * AWS service documentation: https://aws.amazon.com/amazon-mq/
 
-## Amazon MSK [msk]
+## Amazon MSK
 
 * Proposed: https://github.com/aws/aws-controllers-k8s/issues/348
 * Current release status: `PLANNED`
 * Next milestone: [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/13)
 * AWS service documentation: https://aws.amazon.com/msk/
 
-## Amazon RDS [rds]
+## Amazon RDS
 
 * Proposed: https://github.com/aws/aws-controllers-k8s/issues/237
 * Current release status: `PLANNED`
 * Next milestone: [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/8)
 * AWS service documentation: https://aws.amazon.com/rds/
 
-## Amazon Sagemaker [sagemaker]
+## Amazon Route53
+
+* Proposed: https://github.com/aws/aws-controllers-k8s/issues/480
+* Current release status: `PROPOSED`
+* AWS service documentation: https://docs.aws.amazon.com/Route53/
+
+## Amazon SageMaker
 
 * Proposed: https://github.com/aws/aws-controllers-k8s/issues/385
 * Current release status: `BUILD`
 * Next milestone: [`DEVELOPER PREVIEW`](https://github.com/aws/aws-controllers-k8s/milestone/11)
 * AWS service documentation: https://aws.amazon.com/sagemaker/
 
-## Amazon SNS [sns]
+## Amazon SNS
 
 * Proposed: https://github.com/aws/aws-controllers-k8s/issues/202
 * Current release status: `DEVELOPER PREVIEW`
@@ -137,7 +186,7 @@ Controller Release Roadmap](https://github.com/aws/aws-controllers-k8s/projects/
 * AWS service documentation: https://aws.amazon.com/sns/
 * ACK service controller: https://github.com/aws/aws-controllers-k8s/tree/main/services/sns
 
-## Amazon SQS [sqs]
+## Amazon SQS
 
 * Proposed: https://github.com/aws/aws-controllers-k8s/issues/205
 * Current release status: `BUILD`
@@ -145,14 +194,14 @@ Controller Release Roadmap](https://github.com/aws/aws-controllers-k8s/projects/
 * AWS service documentation: https://aws.amazon.com/sqs/
 * ACK service controller: https://github.com/aws/aws-controllers-k8s/tree/main/services/sqs
 
-## AWS Step Functions [sfn]
+## AWS Step Functions
 
 * Proposed: https://github.com/aws/aws-controllers-k8s/issues/239
 * Current release status: `DEVELOPER PREVIEW`
 * AWS service documentation: https://aws.amazon.com/step-functions/
 * ACK service controller: https://github.com/aws/aws-controllers-k8s/tree/main/services/sfn
 
-## Amazon S3 [s3]
+## Amazon S3
 
 * Proposed: https://github.com/aws/aws-controllers-k8s/issues/204
 * Current release status: `DEVELOPER PREVIEW`


### PR DESCRIPTION
Updates the service release matrix and docs to the latest status and
adds ACM, Kinesis, KSM, EC2 VPC service controllers in Proposed status.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
