### PR TITLE
Add Printer Columns for SageMaker TrainingJob and Remove DebugRuleEvaluation Status Field (for now)

### DIFF
--- a/services/sagemaker/apis/v1alpha1/training_job.go
+++ b/services/sagemaker/apis/v1alpha1/training_job.go
@@ -58,16 +58,17 @@ type TrainingJobStatus struct {
 	// contains a collection of `ackv1alpha1.Condition` objects that describe
 	// the various terminal states of the CR and its backend AWS service API
 	// resource
-	Conditions                  []*ackv1alpha1.Condition     `json:"conditions"`
-	DebugRuleEvaluationStatuses []*DebugRuleEvaluationStatus `json:"debugRuleEvaluationStatuses,omitempty"`
-	FailureReason               *string                      `json:"failureReason,omitempty"`
-	SecondaryStatus             *string                      `json:"secondaryStatus,omitempty"`
-	TrainingJobStatus           *string                      `json:"trainingJobStatus,omitempty"`
+	Conditions        []*ackv1alpha1.Condition `json:"conditions"`
+	FailureReason     *string                  `json:"failureReason,omitempty"`
+	SecondaryStatus   *string                  `json:"secondaryStatus,omitempty"`
+	TrainingJobStatus *string                  `json:"trainingJobStatus,omitempty"`
 }
 
 // TrainingJob is the Schema for the TrainingJobs API
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="SecondaryStatus",type=string,JSONPath=`.status.secondaryStatus`
+// +kubebuilder:printcolumn:name="TrainingJobStatus",type=string,JSONPath=`.status.trainingJobStatus`
 type TrainingJob struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/services/sagemaker/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/services/sagemaker/apis/v1alpha1/zz_generated.deepcopy.go
@@ -2926,17 +2926,6 @@ func (in *TrainingJobStatus) DeepCopyInto(out *TrainingJobStatus) {
 			}
 		}
 	}
-	if in.DebugRuleEvaluationStatuses != nil {
-		in, out := &in.DebugRuleEvaluationStatuses, &out.DebugRuleEvaluationStatuses
-		*out = make([]*DebugRuleEvaluationStatus, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(DebugRuleEvaluationStatus)
-				(*in).DeepCopyInto(*out)
-			}
-		}
-	}
 	if in.FailureReason != nil {
 		in, out := &in.FailureReason, &out.FailureReason
 		*out = new(string)

--- a/services/sagemaker/config/controller/deployment.yaml
+++ b/services/sagemaker/config/controller/deployment.yaml
@@ -36,6 +36,8 @@ spec:
         - "$(ACK_LOG_LEVEL)"
         image: controller:latest
         name: controller
+        ports:
+          - containerPort: 8080
         resources:
           limits:
             cpu: 100m

--- a/services/sagemaker/config/controller/kustomization.yaml
+++ b/services/sagemaker/config/controller/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
 - deployment.yaml
+- service.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:

--- a/services/sagemaker/config/controller/service.yaml
+++ b/services/sagemaker/config/controller/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ack-sagemaker-metrics-service
+  namespace: ack-system
+spec:
+  selector:
+    control-plane: controller
+  ports:
+    - name: metricsport
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+  type: NodePort

--- a/services/sagemaker/config/crd/bases/sagemaker.services.k8s.aws_trainingjobs.yaml
+++ b/services/sagemaker/config/crd/bases/sagemaker.services.k8s.aws_trainingjobs.yaml
@@ -16,7 +16,14 @@ spec:
     singular: trainingjob
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.secondaryStatus
+      name: SecondaryStatus
+      type: string
+    - jsonPath: .status.trainingJobStatus
+      name: TrainingJobStatus
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: TrainingJob is the Schema for the TrainingJobs API
@@ -299,22 +306,6 @@ spec:
                   required:
                   - status
                   - type
-                  type: object
-                type: array
-              debugRuleEvaluationStatuses:
-                items:
-                  properties:
-                    lastModifiedTime:
-                      format: date-time
-                      type: string
-                    ruleConfigurationName:
-                      type: string
-                    ruleEvaluationJobARN:
-                      type: string
-                    ruleEvaluationStatus:
-                      type: string
-                    statusDetails:
-                      type: string
                   type: object
                 type: array
               failureReason:

--- a/services/sagemaker/generator.yaml
+++ b/services/sagemaker/generator.yaml
@@ -18,19 +18,16 @@ resources:
     fields:
       TrainingJobStatus:
           is_read_only: true
+          is_printable: true
           from:
             operation: DescribeTrainingJob
             path: TrainingJobStatus
       SecondaryStatus:
         is_read_only: true
+        is_printable: true
         from:
           operation: DescribeTrainingJob
           path: SecondaryStatus
-      DebugRuleEvaluationStatuses:
-        is_read_only: true
-        from:
-          operation: DescribeTrainingJob
-          path: DebugRuleEvaluationStatuses
       FailureReason:
         is_read_only: true
         from:

--- a/services/sagemaker/pkg/resource/model/sdk.go
+++ b/services/sagemaker/pkg/resource/model/sdk.go
@@ -17,7 +17,6 @@ package model
 
 import (
 	"context"
-	corev1 "k8s.io/api/core/v1"
 	"strings"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
@@ -25,6 +24,7 @@ import (
 	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	svcapitypes "github.com/aws/aws-controllers-k8s/services/sagemaker/apis/v1alpha1"

--- a/services/sagemaker/pkg/resource/training_job/sdk.go
+++ b/services/sagemaker/pkg/resource/training_job/sdk.go
@@ -17,7 +17,6 @@ package training_job
 
 import (
 	"context"
-	corev1 "k8s.io/api/core/v1"
 	"strings"
 
 	ackv1alpha1 "github.com/aws/aws-controllers-k8s/apis/core/v1alpha1"
@@ -25,6 +24,7 @@ import (
 	ackerr "github.com/aws/aws-controllers-k8s/pkg/errors"
 	"github.com/aws/aws-sdk-go/aws"
 	svcsdk "github.com/aws/aws-sdk-go/service/sagemaker"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	svcapitypes "github.com/aws/aws-controllers-k8s/services/sagemaker/apis/v1alpha1"
@@ -184,29 +184,6 @@ func (rm *resourceManager) sdkFind(
 			f6 = append(f6, f6elem)
 		}
 		ko.Spec.DebugRuleConfigurations = f6
-	}
-	if resp.DebugRuleEvaluationStatuses != nil {
-		f7 := []*svcapitypes.DebugRuleEvaluationStatus{}
-		for _, f7iter := range resp.DebugRuleEvaluationStatuses {
-			f7elem := &svcapitypes.DebugRuleEvaluationStatus{}
-			if f7iter.LastModifiedTime != nil {
-				f7elem.LastModifiedTime = &metav1.Time{*f7iter.LastModifiedTime}
-			}
-			if f7iter.RuleConfigurationName != nil {
-				f7elem.RuleConfigurationName = f7iter.RuleConfigurationName
-			}
-			if f7iter.RuleEvaluationJobArn != nil {
-				f7elem.RuleEvaluationJobARN = f7iter.RuleEvaluationJobArn
-			}
-			if f7iter.RuleEvaluationStatus != nil {
-				f7elem.RuleEvaluationStatus = f7iter.RuleEvaluationStatus
-			}
-			if f7iter.StatusDetails != nil {
-				f7elem.StatusDetails = f7iter.StatusDetails
-			}
-			f7 = append(f7, f7elem)
-		}
-		ko.Status.DebugRuleEvaluationStatuses = f7
 	}
 	if resp.EnableInterContainerTrafficEncryption != nil {
 		ko.Spec.EnableInterContainerTrafficEncryption = resp.EnableInterContainerTrafficEncryption


### PR DESCRIPTION
Description of changes:
Two small changes to the SageMaker TrainingJob Controller - 
1. Add Printer Columns for SageMaker TrainingJob and 
2. Remove DebugRuleEvaluation Status Field (for now) since the job completes after trainingjob and the status reflected is not accurate. Needs further testing and changes to the requeue logic before re-adding this field. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
