### PR TITLE
crossplane: referencer and selector fields generation

### DIFF
--- a/pkg/generate/config/field.go
+++ b/pkg/generate/config/field.go
@@ -136,6 +136,10 @@ type FieldConfig struct {
 	// that owns the resource. This is a special field that we direct to
 	// storage in the common `Status.ACKResourceMetadata.OwnerAccountID` field.
 	IsOwnerAccountID bool `json:"is_owner_account_id"`
+	// ReferencedType is the Group Version Kind of another CRD that can be referenced
+	// to get the value of this field. The format is <group>/<version>.<kind>.
+	// For example: "sns/v1alpha1.Topic"
+	ReferencedType *string `json:"referenced_type,omitempty"`
 	// From instructs the code generator that the value of the field should
 	// be retrieved from the specified operation and member path
 	From *SourceFieldConfig `json:"from,omitempty"`

--- a/pkg/generate/crossplane/crossplane.go
+++ b/pkg/generate/crossplane/crossplane.go
@@ -42,7 +42,8 @@ var (
 	}
 	copyPaths = []string{}
 	funcMap   = ttpl.FuncMap{
-		"ToLower": strings.ToLower,
+		"ToLower":  strings.ToLower,
+		"Contains": strings.Contains,
 		"ResourceExceptionCode": func(r *ackmodel.CRD, httpStatusCode int) string {
 			return r.ExceptionCode(httpStatusCode)
 		},

--- a/pkg/model/field.go
+++ b/pkg/model/field.go
@@ -46,6 +46,15 @@ func (f *Field) IsRequired() bool {
 	return util.InStrings(f.Names.ModelOrginal, f.CRD.Ops.Create.InputRef.Shape.Required)
 }
 
+// ReferencedType returns the given type information for the referencer of this
+// field.
+func (f *Field) ReferencedType() *string {
+	if f.FieldConfig == nil {
+		return nil
+	}
+	return f.FieldConfig.ReferencedType
+}
+
 // newField returns a pointer to a new Field object
 func newField(
 	crd *CRD,

--- a/templates/crossplane/apis/crd.go.tpl
+++ b/templates/crossplane/apis/crd.go.tpl
@@ -7,7 +7,7 @@ package {{ .APIVersion }}
 import (
 {{- if .CRD.TypeImports }}
 {{- range $packagePath, $alias := .CRD.TypeImports }}
-    {{ if $alias }}{{ $alias }} {{ end }}"{{ $packagePath }}"
+		{{ if $alias }}{{ $alias }} {{ end }}"{{ $packagePath }}"
 {{ end }}
 
 {{- end }}
@@ -21,14 +21,32 @@ type {{ .CRD.Kind }}Parameters struct {
 	// Region is which region the {{ .CRD.Kind }} will be created.
 	// +kubebuilder:validation:Required
 	Region string `json:"region"`
-	{{- range $fieldName, $field := .CRD.SpecFields }}
-	{{- if $field.ShapeRef }}
+{{- range $fieldName, $field := .CRD.SpecFields }}
+	{{ if $field.ShapeRef }}
 	{{ $field.ShapeRef.Documentation }}
 	{{- end }}
-	{{ if $field.IsRequired }} // +kubebuilder:validation:Required
+	{{- if $field.ReferencedType}}
+	{{ $field.Names.Camel }} {{ $field.GoType }} `json:"{{ $field.Names.CamelLower }},omitempty"`
+
+	// {{ $field.Names.Camel }}Ref is a reference to an {{ $field.ReferencedType }} used
+	// to set the {{ $field.Names.Camel }} field.
+	// +optional
+	{{ $field.Names.Camel }}Ref {{if Contains $field.GoType "[]" -}}[]xpv1.Reference{{- else -}}*xpv1.Reference{{- end -}} `json:"{{ $field.Names.CamelLower }}Ref,omitempty"`
+
+	// {{ $field.Names.Camel }}Selector selects references to {{ $field.ReferencedType }}
+	// used to set the {{ $field.Names.Camel }}.
+	// +optional
+	{{ $field.Names.Camel }}Selector *xpv1.Selector `json:"{{ $field.Names.CamelLower }}Selector,omitempty"`
+	{{- else if $field.IsRequired }}
+	// +kubebuilder:validation:Required
 	{{ $field.Names.Camel }} {{ $field.GoType }} `json:"{{ $field.Names.CamelLower }}"`
-	{{- else }} {{ $field.Names.Camel }} {{ $field.GoType }} `json:"{{ $field.Names.CamelLower }},omitempty"` {{ end }}
+	{{- else }}
+	{{ $field.Names.Camel }} {{ $field.GoType }} `json:"{{ $field.Names.CamelLower }},omitempty"`
+	{{- end }}
 {{- end }}
+
+  // Custom{{ .CRD.Kind }}Parameters includes the additional fields on top of
+  // the generated ones.
 	Custom{{ .CRD.Kind }}Parameters `json:",inline"`
 }
 


### PR DESCRIPTION
Description of changes: Crossplane uses two additional fields for the ones that can be referenced by another CRD - `Reference` and `Selector`. This PR allows users to enter the type of the referenced object so that we automatically generate these fields. The type information is necessary for the resolver but since we're not yet generating it, only the existence of a value in `referenced_type` is used. When we generate the resolver code, we'll need type information as well.

One caveat is that any field on the CR (including the ones in `types.go`) could be a candidate as a reference field but from what I can tell, we are only able to address the top level fields in `Config` object. For now, that will be a limitation we'll live with.

Fixes https://github.com/crossplane/provider-aws/issues/484

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
