### PR TITLE
crossplane: fix read many template

### DIFF
--- a/pkg/generate/code/set_resource.go
+++ b/pkg/generate/code/set_resource.go
@@ -290,6 +290,21 @@ func SetResource(
 	return out
 }
 
+func ListMemberNameInReadManyOutput(
+	r *model.CRD,
+) string {
+	// Find the element in the output shape that contains the list of
+	// resources. This heuristic is simplistic (just look for the field with a
+	// list type) but seems to be followed consistently by the aws-sdk-go for
+	// List operations.
+	for memberName, memberShapeRef := range r.Ops.ReadMany.OutputRef.Shape.MemberRefs {
+		if memberShapeRef.Shape.Type == "list" {
+			return memberName
+		}
+	}
+	panic("List output shape had no field of type 'list'")
+}
+
 // setResourceReadMany sets the supplied target variable from the results of a
 // List operation. This is a special-case handling of those APIs where there is
 // no ReadOne operation and instead the only way to grab information for a

--- a/pkg/generate/crossplane/crossplane.go
+++ b/pkg/generate/crossplane/crossplane.go
@@ -58,6 +58,9 @@ var (
 		"GoCodeSetReadManyOutput": func(r *ackmodel.CRD, sourceVarName string, targetVarName string, indentLevel int, performSpecUpdate bool) string {
 			return code.SetResource(r.Config(), r, ackmodel.OpTypeList, sourceVarName, targetVarName, indentLevel, performSpecUpdate)
 		},
+		"ListMemberNameInReadManyOutput": func(r *ackmodel.CRD) string {
+			return code.ListMemberNameInReadManyOutput(r)
+		},
 		"GoCodeSetReadManyInput": func(r *ackmodel.CRD, sourceVarName string, targetVarName string, indentLevel int) string {
 			return code.SetSDK(r.Config(), r, ackmodel.OpTypeList, sourceVarName, targetVarName, indentLevel)
 		},

--- a/templates/crossplane/pkg/controller.go.tpl
+++ b/templates/crossplane/pkg/controller.go.tpl
@@ -90,7 +90,7 @@ func (e *external) Observe(ctx context.Context, mg cpresource.Managed) (managed.
 		return managed.ExternalObservation{ResourceExists: false}, errors.Wrap(cpresource.Ignore(IsNotFound, err), errDescribe)
 	}
 	resp = e.filterList(cr, resp)
-	if len(resp.Items) == 0 {
+	if len(resp.{{ ListMemberNameInReadManyOutput .CRD }}) == 0 {
 		return managed.ExternalObservation{ResourceExists: false}, nil
 	}
 {{- end }}


### PR DESCRIPTION
Description of changes: `ReadMany` template was using `.Items` subfield for all `ReadMany` outputs but that's not true for all `ReadMany` resources. For example, RDS `DBCluster` has `.DBClusters` in the returned object. ACK already addresses this in set output code but Crossplane does a filtering before that step so we needed to check whether the filtered list still has any items.

Fixes https://github.com/crossplane/provider-aws/issues/492

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
