### PR TITLE
automatically generate desired controller-gen binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ publish-controller-image:  ## docker push a container image for SERVICE
 	./scripts/publish-controller-image.sh $(AWS_SERVICE)
 
 build-controller: build-ack-generate ## Generate controller code for SERVICE
+	@./scripts/install-controller-gen.sh 
 	@./scripts/build-controller.sh $(AWS_SERVICE)
 
 kind-test: export PRESERVE = true

--- a/docs/contents/dev-docs/testing.md
+++ b/docs/contents/dev-docs/testing.md
@@ -35,7 +35,6 @@ installed and configured:
 1. [Golang 1.14+](https://golang.org/doc/install)
 1. [Docker](https://docs.docker.com/get-docker/)
 1. [kind](https://kind.sigs.k8s.io/docs/user/quick-start/)
-1. [kubernetes-sigs/controller-tools](https://github.com/kubernetes-sigs/controller-tools)
 1. [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv1.html) version 1
 1. [jq](https://github.com/stedolan/jq/wiki/Installation)
 1. `make`


### PR DESCRIPTION
Issue #, if available:
#633 
 
Description of changes:
1. Desired version of controller-gen binary will be automatically generated with 'make build-controller SERVICE=$SERVICE' command 
2. Removed kubernetes-sigs/controller-tools from prerequisites as users might try to install controller-gen manually and run into errors mentioned in #633 . The Makefile change will anyways install the correct version automatically or indicate the user to install the correct one in case of mismatch as below -

$make build-controller SERVICE=$SERVICE
building ack-generate ... ok.
FATAL: Existing version of controller-gen Version: v0.4.1, required version is v0.4.0.
FATAL: Please uninstall controller-gen and install the required version with scripts/install-controller-gen.sh.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
