### PR TITLE
Corrected scripts for cluster reuse

### DIFF
--- a/scripts/kind-build-test.sh
+++ b/scripts/kind-build-test.sh
@@ -57,7 +57,8 @@ function clean_up {
         "${SCRIPTS_DIR}"/delete-kind-cluster.sh "$TMP_DIR" || :
         return
     fi
-    echo "To resume test with the same cluster use: \"-c $TMP_DIR\""""
+    echo "To resume test with the same cluster use: \" TMP_DIR=$TMP_DIR
+    AWS_SERVICE_DOCKER_IMG=$AWS_SERVICE_DOCKER_IMG \""""
 }
 
 

--- a/test/release/test-helm.sh
+++ b/test/release/test-helm.sh
@@ -53,7 +53,7 @@ ACK_GENERATE_IMAGE_REPOSITORY="aws-controllers-k8s" \
 
 popd 1>/dev/null
 
-kubectl create namespace "$K8S_NAMESPACE"
+kubectl create namespace "$K8S_NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
 
 pushd $CHART_DIR/helm 1>/dev/null
 


### PR DESCRIPTION
Issue #, if available:

The PRESERVE env var is by default true. So this means that the cluster is not deleted after test execution.
There are a couple of issues observed when this kind cluster is reused for testing - 

1. When "make kind-test SERVICE=$SERVICE" finishes execution for the 1st time for a given service then at the end the following message is generated to reuse the cluster -
      To resume test with the same cluster use: "-c <TMP_DIR path>" 
 However the script does not take -c as an argument. Infact the script uses env vars  TMP_DIR and AWS_SERVICE_DOCKER_IMG for reusing the cluster.

Note: If env var TMP_DIR is not set or passed then the script errors out as it tries to recreate the cluster.
         If AWS_SERVICE_DOCKER_IMG is not set then the script rebuilds the docker image.    

2. Even if the given env vars are set the script errors out while creating the helm charts as the namespace "ack-system-test-helm" already exists from the previous run. 

Description of changes:

Fix for 1. is to simply correct the output message to use these 2 env vars upon reuse
2. is fixed by creating the namespace only if it doesn't already exist. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
