### PR TITLE
SageMaker: Add Custom Callbacks for TrainingJob, Model and ProcessingJob Update Ops

### DIFF
--- a/services/sagemaker/apis/v1alpha1/processing_job.go
+++ b/services/sagemaker/apis/v1alpha1/processing_job.go
@@ -57,8 +57,8 @@ type ProcessingJobStatus struct {
 // ProcessingJob is the Schema for the ProcessingJobs API
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="FailureReason",type=string,JSONPath=`.status.failureReason`
 // +kubebuilder:printcolumn:name="ProcessingJobStatus",type=string,JSONPath=`.status.processingJobStatus`
+// +kubebuilder:printcolumn:name="FailureReason",type=string,JSONPath=`.status.failureReason`
 type ProcessingJob struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/services/sagemaker/apis/v1alpha1/training_job.go
+++ b/services/sagemaker/apis/v1alpha1/training_job.go
@@ -67,8 +67,9 @@ type TrainingJobStatus struct {
 // TrainingJob is the Schema for the TrainingJobs API
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="TrainingJobStatus",type=string,JSONPath=`.status.trainingJobStatus`
+// +kubebuilder:printcolumn:name="FailureReason",type=string,JSONPath=`.status.failureReason`
 // +kubebuilder:printcolumn:name="SecondaryStatus",type=string,JSONPath=`.status.secondaryStatus`
+// +kubebuilder:printcolumn:name="TrainingJobStatus",type=string,JSONPath=`.status.trainingJobStatus`
 type TrainingJob struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/services/sagemaker/config/crd/bases/sagemaker.services.k8s.aws_processingjobs.yaml
+++ b/services/sagemaker/config/crd/bases/sagemaker.services.k8s.aws_processingjobs.yaml
@@ -17,11 +17,11 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.failureReason
-      name: FailureReason
-      type: string
     - jsonPath: .status.processingJobStatus
       name: ProcessingJobStatus
+      type: string
+    - jsonPath: .status.failureReason
+      name: FailureReason
       type: string
     name: v1alpha1
     schema:

--- a/services/sagemaker/config/crd/bases/sagemaker.services.k8s.aws_trainingjobs.yaml
+++ b/services/sagemaker/config/crd/bases/sagemaker.services.k8s.aws_trainingjobs.yaml
@@ -17,11 +17,14 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.trainingJobStatus
-      name: TrainingJobStatus
+    - jsonPath: .status.failureReason
+      name: FailureReason
       type: string
     - jsonPath: .status.secondaryStatus
       name: SecondaryStatus
+      type: string
+    - jsonPath: .status.trainingJobStatus
+      name: TrainingJobStatus
       type: string
     name: v1alpha1
     schema:

--- a/services/sagemaker/generator.yaml
+++ b/services/sagemaker/generator.yaml
@@ -7,12 +7,16 @@ operations:
     resource_name: ProcessingJob
 resources:
   Model:
+    update_operation:
+      custom_method_name: customUpdateModel
     exceptions:
       errors:
         404:
           code: ValidationException
           message_prefix: Could not find model
   TrainingJob:
+    update_operation:
+      custom_method_name: customUpdateTrainingJob
     exceptions:
       errors:
           404:
@@ -33,10 +37,13 @@ resources:
           path: SecondaryStatus
       FailureReason:
         is_read_only: true
+        is_printable: true
         from:
           operation: DescribeTrainingJob
           path: FailureReason 
   ProcessingJob:
+    update_operation:
+      custom_method_name: customUpdateProcessingJob
     exceptions:
       errors:
           404:

--- a/services/sagemaker/pkg/resource/model/custom_update_api.go
+++ b/services/sagemaker/pkg/resource/model/custom_update_api.go
@@ -1,0 +1,29 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package model
+
+import (
+	"context"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+)
+
+// TrainingJob has no update op (as of aws_sdk_go_v1.34.32)
+func (rm *resourceManager) customUpdateModel(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+	diffReporter *ackcompare.Reporter,
+) (*resource, error) {
+	return latest, nil
+}

--- a/services/sagemaker/pkg/resource/model/sdk.go
+++ b/services/sagemaker/pkg/resource/model/sdk.go
@@ -383,8 +383,7 @@ func (rm *resourceManager) sdkUpdate(
 	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
-	// TODO(jaypipes): Figure this out...
-	return nil, ackerr.NotImplemented
+	return rm.customUpdateModel(ctx, desired, latest, diffReporter)
 }
 
 // sdkDelete deletes the supplied resource in the backend AWS service API

--- a/services/sagemaker/pkg/resource/processing_job/custom_update_api.go
+++ b/services/sagemaker/pkg/resource/processing_job/custom_update_api.go
@@ -1,0 +1,29 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package processing_job
+
+import (
+	"context"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+)
+
+// TrainingJob has no update op (as of aws_sdk_go_v1.34.32)
+func (rm *resourceManager) customUpdateProcessingJob(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+	diffReporter *ackcompare.Reporter,
+) (*resource, error) {
+	return latest, nil
+}

--- a/services/sagemaker/pkg/resource/processing_job/sdk.go
+++ b/services/sagemaker/pkg/resource/processing_job/sdk.go
@@ -531,8 +531,7 @@ func (rm *resourceManager) sdkUpdate(
 	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
-	// TODO(jaypipes): Figure this out...
-	return nil, ackerr.NotImplemented
+	return rm.customUpdateProcessingJob(ctx, desired, latest, diffReporter)
 }
 
 // sdkDelete deletes the supplied resource in the backend AWS service API

--- a/services/sagemaker/pkg/resource/training_job/custom_update_api.go
+++ b/services/sagemaker/pkg/resource/training_job/custom_update_api.go
@@ -1,0 +1,29 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package training_job
+
+import (
+	"context"
+	ackcompare "github.com/aws/aws-controllers-k8s/pkg/compare"
+)
+
+// TrainingJob has no update op (as of aws_sdk_go_v1.34.32)
+func (rm *resourceManager) customUpdateTrainingJob(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+	diffReporter *ackcompare.Reporter,
+) (*resource, error) {
+	return latest, nil
+}

--- a/services/sagemaker/pkg/resource/training_job/sdk.go
+++ b/services/sagemaker/pkg/resource/training_job/sdk.go
@@ -764,8 +764,7 @@ func (rm *resourceManager) sdkUpdate(
 	latest *resource,
 	diffReporter *ackcompare.Reporter,
 ) (*resource, error) {
-	// TODO(jaypipes): Figure this out...
-	return nil, ackerr.NotImplemented
+	return rm.customUpdateTrainingJob(ctx, desired, latest, diffReporter)
 }
 
 // sdkDelete deletes the supplied resource in the backend AWS service API


### PR DESCRIPTION
### Description of changes:
1. Add Custom Callbacks for TrainingJob, Model and ProcessingJob Update No-op since these resources do not support updates as of aws_sdk_go 1.34.32. This change fixes the issue where we saw a `not implemented` in controller log for update actions. 
Note: However the latest version of gosdk v1 does support updateTrainingJob but this needs to be a part of a separate PR.

2. Adds back the failureReason as a printer column for TrainingJob (I am not sure why the order of these fields keeps changing across different controller-gen versions)

### Testing:
Ran the integ tests and checked the logs to ensure no errors 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
