### PR TITLE
fix release copy file generation

### DIFF
--- a/pkg/generate/ack/release.go
+++ b/pkg/generate/ack/release.go
@@ -60,9 +60,9 @@ func Release(
 ) (*templateset.TemplateSet, error) {
 	ts := templateset.New(
 		templateBasePath,
-		apisIncludePaths,
-		apisCopyPaths,
-		apisFuncMap,
+		releaseIncludePaths,
+		releaseCopyPaths,
+		releaseFuncMap,
 	)
 
 	metaVars := g.MetaVars()

--- a/pkg/generate/templateset/templateset.go
+++ b/pkg/generate/templateset/templateset.go
@@ -95,7 +95,8 @@ func (ts *TemplateSet) Execute() error {
 		ts.executed[path] = &b
 	}
 	for _, path := range ts.copyPaths {
-		b, err := byteBufferFromFile(path)
+		copyPath := filepath.Join(ts.basePath, path)
+		b, err := byteBufferFromFile(copyPath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The pkg/generate/ack/release.go file was calling templateset.New() with
the wrong set of copyPaths (it was passing the api copy paths not the
release copy paths). The templateset.Execute() call was also not
properly constructing a full path for copying by prepending the template
base path to the copied file path.

Related to bugs found in #661 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
